### PR TITLE
Add a CI job for tests with TPM simulation server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,15 @@ jobs:
     - uses: actions/checkout@v1
     - name: Check formatting
       run: cargo fmt --all -- --check
+
+  # All in one job as I think it is a big overhead to build and run the Docker
+  # container?
+  all:
+    name: Use Docker to execute the test script
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the container
+      run: docker build -t tss2.0 tests/
+    - name: Run the container
+      run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi tss2.0 /tmp/rust-tss-esapi/tests/all.sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,7 +876,7 @@ mod tests {
     fn simple_test() {
         env_logger::init();
 
-        let mut context = Context::new(Tcti::Tabrmd).unwrap();
+        let mut context = Context::new(Tcti::Mssim).unwrap();
         let key_auth: Vec<u8> = context.get_random(NO_SESSIONS, 16).unwrap();
 
         let prim_key_handle = context

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,23 @@
+FROM tpm2software/tpm2-tss
+
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+# Download and install TSS 2.0
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.1
+RUN cd tpm2-tss \
+		&& ./bootstrap \
+		&& ./configure \
+		&& make -j$(nproc) \
+		&& make install \
+		&& ldconfig
+
+# Download and install TPM2 tools
+RUN git clone https://github.com/tpm2-software/tpm2-tools.git --branch 4.1
+RUN cd tpm2-tools \
+		&& ./bootstrap \
+		&& ./configure --enable-unit \
+		&& make install
+
+# Install Rust toolchain
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019, Arm Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# This script executes static checks and tests for the tss-esapi crate.
+# It can be run inside the container which Dockerfile is in the same folder.
+#
+# Usage: ./tests/all.sh
+
+set -e
+
+#################################
+# Run the TPM simulation server #
+#################################
+tpm_server &
+tpm2_startup -c -T mssim || exit 1
+
+##################
+# Execute clippy #
+##################
+cargo clippy || exit 1
+
+###################
+# Build the crate #
+###################
+cargo build || exit 1
+
+#################
+# Static checks #
+#################
+RUST_LOG=info cargo test || exit 1


### PR DESCRIPTION
Adds a Docker container that contains the stack and tools needed to run
the TPM simulation server and build our crate.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>