### PR TITLE
Fix various issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 *.swp
 *DS_Store
 *.patch
+*NVChip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"

--- a/src/abstraction/mod.rs
+++ b/src/abstraction/mod.rs
@@ -13,4 +13,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod transitory;
+pub mod transient;


### PR DESCRIPTION
This commit fixes the following issues:
* `type X = Y` is typically considered an anti-pattern in Rust -
removing our usage of it
* remove authenatication values from reading public parts of keys
in transient context
* store all 3 sessions required by most commands straight on the
context for brevity

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>