### PR TITLE
Fix session handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"

--- a/src/response_code.rs
+++ b/src/response_code.rs
@@ -98,7 +98,7 @@ impl Tss2ResponseCode {
         }
     }
 
-    fn kind(self) -> Option<Tss2ResponseCodeKind> {
+    pub fn kind(self) -> Option<Tss2ResponseCodeKind> {
         match self {
             Tss2ResponseCode::Success => Some(Tss2ResponseCodeKind::Success),
             Tss2ResponseCode::FormatZero(rc) => {
@@ -218,7 +218,8 @@ impl Tss2ResponseCode {
     }
 }
 
-enum Tss2ResponseCodeKind {
+#[derive(PartialEq)]
+pub enum Tss2ResponseCodeKind {
     // FormatZero errors
     Success,
     TpmVendorSpecific,


### PR DESCRIPTION
This commit improves our handling of sessions by setting the encrypt
and decrypt attributes before every command that should be protected.

A few other small fixes are also included.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>