### PR TITLE
Improve usage of unsafe blocks

### DIFF
--- a/src/abstraction/transient.rs
+++ b/src/abstraction/transient.rs
@@ -157,7 +157,8 @@ impl TransientObjectContext {
             self.context.flush_context(key_handle)?;
             Err(e)
         })?;
-        let key = match PublicIdUnion::from_public(&key_pub_id) {
+        let key = match unsafe { PublicIdUnion::from_public(&key_pub_id) } {
+            // call should be safe given our trust in the TSS library
             PublicIdUnion::Rsa(pub_key) => {
                 let mut key = pub_key.buffer.to_vec();
                 key.truncate(pub_key.size.try_into().unwrap()); // should not fail on supported targets


### PR DESCRIPTION
This commit improves our handling of `unsafe` blocks. It moves the
`unsafe` label to methods that could lead to undefined behaviour
instead of hiding the lack of safety inside the method.

All remaining `unsafe` blocks should be safe to a sane level - we control the inputs to the function calls within and can guarantee, based on trust (usually in the TSS stack below) that the calls are safe. 
Thread safety is offered by all `Context` struct methods requiring mutable references to `self`. 

Fixes #2 