### PR TITLE
Remove 'unimplemented' use and fix lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"

--- a/src/abstraction/transient.rs
+++ b/src/abstraction/transient.rs
@@ -40,6 +40,7 @@ use std::convert::{TryFrom, TryInto};
 ///
 /// Currently, only functionality necessary for RSA key creation and usage (for signing and
 /// verifying signatures) is implemented.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub struct TransientObjectContext {
     context: Context,
@@ -187,7 +188,7 @@ impl TransientObjectContext {
         if public_key.len() != 128 && public_key.len() != 256 {
             return Err(Error::local_error(ErrorKind::WrongParamSize));
         }
-        let mut pk_buffer = [0u8; 512];
+        let mut pk_buffer = [0_u8; 512];
         pk_buffer[..public_key.len()].clone_from_slice(&public_key[..public_key.len()]);
 
         let pk = TPMU_PUBLIC_ID {
@@ -201,7 +202,7 @@ impl TransientObjectContext {
             false,
             false,
             true,
-            u16::try_from(public_key.len()).unwrap() * 8u16, // should not fail on valid targets, given the checks above
+            u16::try_from(public_key.len()).unwrap() * 8_u16, // should not fail on valid targets, given the checks above
         );
         public.publicArea.unique = pk;
 
@@ -235,14 +236,14 @@ impl TransientObjectContext {
             self.context.flush_context(key_handle)?;
             Err(e)
         })?;
-        let key = match unsafe { PublicIdUnion::from_public(&key_pub_id) } {
+        let key = match unsafe { PublicIdUnion::from_public(&key_pub_id)? } {
             // call should be safe given our trust in the TSS library
             PublicIdUnion::Rsa(pub_key) => {
                 let mut key = pub_key.buffer.to_vec();
                 key.truncate(pub_key.size.try_into().unwrap()); // should not fail on supported targets
                 key
             }
-            _ => unimplemented!(),
+            _ => return Err(Error::local_error(ErrorKind::UnsupportedParam)),
         };
         self.context.flush_context(key_handle)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@
     dead_code
 )]
 #[allow(clippy::all)]
+#[allow(clippy::unseparated_literal_suffix)]
 // There is an issue where long double become u128 in extern blocks. Check this issue:
 // https://github.com/rust-lang/rust-bindgen/issues/1549
 #[allow(improper_ctypes, missing_debug_implementations, trivial_casts)]
@@ -146,7 +147,7 @@ macro_rules! wrap_buffer {
         if $buf.len() > $buf_size {
             return Err(Error::local_error(ErrorKind::WrongParamSize));
         }
-        let mut buffer = [0u8; $buf_size];
+        let mut buffer = [0_u8; $buf_size];
         buffer[..$buf.len()].clone_from_slice(&$buf[..$buf.len()]);
         let mut buf_struct: $buf_type = Default::default();
         buf_struct.size = $buf.len().try_into().unwrap(); // should not fail since the length is checked above

--- a/src/response_code.rs
+++ b/src/response_code.rs
@@ -51,6 +51,7 @@ bitfield! {
 }
 
 /// Rust native representation of the TSS2 response codes as defined in the spec.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Tss2ResponseCode {
     Success,
@@ -497,6 +498,8 @@ pub enum WrapperErrorKind {
     ParamsMissing,
     /// Returned when two or more parameters have inconsistent values or variants.
     InconsistentParams,
+    /// Returned when the value of a parameter is not yet supported.
+    UnsupportedParam,
 }
 
 impl std::fmt::Display for WrapperErrorKind {
@@ -511,6 +514,10 @@ impl std::fmt::Display for WrapperErrorKind {
             WrapperErrorKind::InconsistentParams => write!(
                 f,
                 "the provided parameters have inconsistent values or variants"
+            ),
+            WrapperErrorKind::UnsupportedParam => write!(
+                f,
+                "the provided parameter is not yet supported by the library"
             ),
         }
     }


### PR DESCRIPTION
This commit removes all uses of the `unimplemented` macro and makes some
code improvements hinted by the linter.