### PR TITLE
Remove explicit handles in StartSessionAuth

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ use std::env;
 use std::path::PathBuf;
 
 // Minimum version of the TSS 2.0 libraries that this crate can use.
-const MINIMUM_VERSION: &str = "2.3.0";
+const MINIMUM_VERSION: &str = "2.3.3";
 
 fn main() {
     if cfg!(not(feature = "docs")) {

--- a/src/abstraction/transient.rs
+++ b/src/abstraction/transient.rs
@@ -32,7 +32,7 @@ use crate::utils::primitives::Cipher;
 use crate::utils::{
     self, get_rsa_public, Hierarchy, PublicIdUnion, TpmaSession, TpmsContext, TpmtTkVerified,
 };
-use crate::{Context, Tcti, NO_SESSIONS};
+use crate::{Context, Tcti};
 use log::error;
 use std::convert::{TryFrom, TryInto};
 
@@ -385,7 +385,6 @@ impl TransientKeyContextBuilder {
         let mut context = Context::new(self.tcti)?;
 
         let session = context.start_auth_session(
-            NO_SESSIONS,
             ESYS_TR_NONE,
             ESYS_TR_NONE,
             &[],
@@ -418,7 +417,6 @@ impl TransientKeyContextBuilder {
         )?;
 
         let new_session = context.start_auth_session(
-            NO_SESSIONS,
             root_key_handle,
             ESYS_TR_NONE,
             &[],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,9 +153,6 @@ macro_rules! wrap_buffer {
     }};
 }
 
-/// Placeholder for passing empty session handles for a call to the TPM
-pub const NO_SESSIONS: (ESYS_TR, ESYS_TR, ESYS_TR) = (ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE);
-
 // Possible TCTI to use with the ESYS API.
 // TODO: add to each variant a structure for its configuration. Currently using the default
 // configuration.
@@ -251,7 +248,7 @@ impl Context {
             let esys_context = Some(MBox::from_raw(esys_context));
             let context = Context {
                 esys_context,
-                sessions: NO_SESSIONS,
+                sessions: (ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE),
                 tcti_context,
                 open_handles: HashSet::new(),
             };
@@ -276,7 +273,6 @@ impl Context {
     #[allow(clippy::too_many_arguments)]
     pub fn start_auth_session(
         &mut self,
-        non_auth_sessions: (ESYS_TR, ESYS_TR, ESYS_TR),
         tpm_key: ESYS_TR,
         bind: ESYS_TR,
         nonce: &[u8],
@@ -292,9 +288,9 @@ impl Context {
                 self.mut_context(),
                 tpm_key,
                 bind,
-                non_auth_sessions.0,
-                non_auth_sessions.1,
-                non_auth_sessions.2,
+                self.sessions.0,
+                self.sessions.1,
+                self.sessions.2,
                 if nonce.is_empty() {
                     null()
                 } else {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -685,6 +685,7 @@ impl TryFrom<TPMS_CONTEXT> for TpmsContext {
     }
 }
 
+#[allow(clippy::needless_update)]
 impl TryFrom<TpmsContext> for TPMS_CONTEXT {
     type Error = Error;
 
@@ -705,6 +706,7 @@ impl TryFrom<TpmsContext> for TPMS_CONTEXT {
                 size: buffer_size.try_into().unwrap(), // should not panic given the check above
                 buffer,
             },
+            ..Default::default()
         })
     }
 }

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -3,7 +3,7 @@ FROM tpm2software/tpm2-tss
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
 # Download and install TSS 2.0
-RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.1
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.3
 RUN cd tpm2-tss \
 		&& ./bootstrap \
 		&& ./configure \

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -57,7 +57,6 @@ fn create_ctx_with_session() -> Context {
     let mut ctx = unsafe { Context::new(Tcti::Mssim).unwrap() };
     let session = ctx
         .start_auth_session(
-            NO_SESSIONS,
             ESYS_TR_NONE,
             ESYS_TR_NONE,
             &[],
@@ -73,6 +72,10 @@ fn create_ctx_with_session() -> Context {
     ctx.set_sessions((session, ESYS_TR_NONE, ESYS_TR_NONE));
 
     ctx
+}
+
+fn create_ctx_without_session() -> Context {
+    unsafe { Context::new(Tcti::Mssim).unwrap() }
 }
 
 #[test]
@@ -95,7 +98,6 @@ fn comprehensive_test() {
 
     let new_session = context
         .start_auth_session(
-            NO_SESSIONS,
             ESYS_TR_NONE,
             prim_key_handle,
             &[],
@@ -147,10 +149,9 @@ mod test_start_sess {
 
     #[test]
     fn test_simple_sess() {
-        let mut context = create_ctx_with_session();
+        let mut context = create_ctx_without_session();
         context
             .start_auth_session(
-                NO_SESSIONS,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[],
@@ -163,10 +164,9 @@ mod test_start_sess {
 
     #[test]
     fn test_nonce_sess() {
-        let mut context = create_ctx_with_session();
+        let mut context = create_ctx_without_session();
         context
             .start_auth_session(
-                NO_SESSIONS,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[
@@ -181,10 +181,9 @@ mod test_start_sess {
 
     #[test]
     fn test_long_nonce_sess() {
-        let mut context = create_ctx_with_session();
+        let mut context = create_ctx_without_session();
         context
             .start_auth_session(
-                NO_SESSIONS,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[
@@ -221,7 +220,6 @@ mod test_start_sess {
 
         context
             .start_auth_session(
-                NO_SESSIONS,
                 prim_key_handle,
                 prim_key_handle,
                 &[],
@@ -232,16 +230,11 @@ mod test_start_sess {
             .unwrap();
     }
 
-    // Ignored since currently the TSS library fails when encryption for a `StartAuthSession`
-    // command is used.
-    // See: https://github.com/tpm2-software/tpm2-tss/issues/1590
-    #[ignore]
     #[test]
     fn test_encrypted_start_sess() {
-        let mut context = create_ctx_with_session();
+        let mut context = create_ctx_without_session();
         let encrypted_sess = context
             .start_auth_session(
-                NO_SESSIONS,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[],
@@ -260,7 +253,6 @@ mod test_start_sess {
 
         let _ = context
             .start_auth_session(
-                (encrypted_sess, ESYS_TR_NONE, ESYS_TR_NONE),
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[],
@@ -273,10 +265,9 @@ mod test_start_sess {
 
     #[test]
     fn test_authenticated_start_sess() {
-        let mut context = create_ctx_with_session();
+        let mut context = create_ctx_without_session();
         let auth_sess = context
             .start_auth_session(
-                NO_SESSIONS,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[],
@@ -285,10 +276,10 @@ mod test_start_sess {
                 TPM2_ALG_SHA256,
             )
             .unwrap();
+        context.set_sessions((auth_sess, ESYS_TR_NONE, ESYS_TR_NONE));
 
         context
             .start_auth_session(
-                (auth_sess, ESYS_TR_NONE, ESYS_TR_NONE),
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[],
@@ -308,7 +299,6 @@ mod test_get_random {
         let mut context = create_ctx_with_session();
         let encrypted_sess = context
             .start_auth_session(
-                NO_SESSIONS,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[],
@@ -334,7 +324,6 @@ mod test_get_random {
         let mut context = create_ctx_with_session();
         let auth_sess = context
             .start_auth_session(
-                NO_SESSIONS,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[],
@@ -1131,7 +1120,6 @@ mod test_session_attr {
         let mut context = create_ctx_with_session();
         let sess_handle = context
             .start_auth_session(
-                NO_SESSIONS,
                 ESYS_TR_NONE,
                 ESYS_TR_NONE,
                 &[],


### PR DESCRIPTION
This commit adds a few fixes. The main improvement is due to a bugfix
being published upstream in a release. This bugfix allows auth sessions
to be started with the help of encryption sessions (so that parameters
are encrypted within the command). Thus, StartAuthSession no longer
needs to receive separate sessions handles and can now simply use the
ones stored on the Context. This does, however, mean that the most
recent version of the TSS libraries is needed.
Another fix is for memory allignment for 32bit machines for
TPMS_CONTEXT. When generating the bindings on 32 bit architectures, a
padding field that did not exist on 64 bit machines is added. Any
attempt to use the One True Constructor for said structure then fails if
the new field is not considered.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>