### PR TITLE
Add TestParms method

### DIFF
--- a/src/utils/primitives.rs
+++ b/src/utils/primitives.rs
@@ -160,3 +160,9 @@ impl From<Cipher> for TPMT_SYM_DEF_OBJECT {
             .unwrap() // all params are strictly controlled, should not fail
     }
 }
+
+impl From<Cipher> for TPMS_SYMCIPHER_PARMS {
+    fn from(cipher: Cipher) -> Self {
+        TPMS_SYMCIPHER_PARMS { sym: cipher.into() }
+    }
+}

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -48,8 +48,8 @@ use std::convert::TryInto;
 use tss_esapi::constants::*;
 use tss_esapi::tss2_esys::*;
 use tss_esapi::utils::{
-    self, AsymSchemeUnion, ObjectAttributes, PublicIdUnion, PublicParmsUnion, Signature,
-    Tpm2BPublicBuilder, TpmaSession, TpmsRsaParmsBuilder, TpmtSymDefBuilder,
+    self, primitives::Cipher, AsymSchemeUnion, ObjectAttributes, PublicIdUnion, PublicParmsUnion,
+    Signature, Tpm2BPublicBuilder, TpmaSession, TpmsRsaParmsBuilder, TpmtSymDefBuilder,
 };
 use tss_esapi::*;
 
@@ -1137,5 +1137,18 @@ mod test_session_attr {
         context.set_sessions((sess_handle, ESYS_TR_NONE, ESYS_TR_NONE));
 
         let _ = context.get_random(10).unwrap();
+    }
+}
+
+mod test_test_parms {
+    use super::*;
+
+    #[test]
+    fn test_sym_parms() {
+        let mut context = create_ctx_without_session();
+        let cipher = Cipher::aes_256_cfb();
+        context
+            .test_parms(PublicParmsUnion::SymDetail(cipher))
+            .unwrap();
     }
 }


### PR DESCRIPTION
This commit adds the TestParms method to the ones supported by Context.
Users can now verify if their public parameters are supported by the
TPM before commiting to using them.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>

Closes #38 