### PR TITLE
Update Docker image for TSS

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,22 +1,22 @@
-FROM tpm2software/tpm2-tss
+FROM tpm2software/tpm2-tss:ubuntu-18.04
 
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
 # Download and install TSS 2.0
 RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.3
 RUN cd tpm2-tss \
-		&& ./bootstrap \
-		&& ./configure \
-		&& make -j$(nproc) \
-		&& make install \
-		&& ldconfig
+	&& ./bootstrap \
+	&& ./configure \
+	&& make -j$(nproc) \
+	&& make install \
+	&& ldconfig
 
 # Download and install TPM2 tools
 RUN git clone https://github.com/tpm2-software/tpm2-tools.git --branch 4.1
 RUN cd tpm2-tools \
-		&& ./bootstrap \
-		&& ./configure --enable-unit \
-		&& make install
+	&& ./bootstrap \
+	&& ./configure --enable-unit \
+	&& make install
 
 # Install Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y


### PR DESCRIPTION
This commit updates the Docker image we use, as there has been a change
upstream as to how the images are tagged and organised.
We will be using the Ubuntu-flavoured version of the image.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>