### PR TITLE
Allow the Context values to be unwrapped

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@
 
 Contributions to the `tss-esapi` crate need to follow the process below.
 
-* Contributions are done through GitHub pull-requests.
+* Contributions are done through GitHub pull-requests using a [fork-based workflow](https://github.com/firstcontributions/first-contributions).
 * Contributors need to apply `rustfmt` and `clippy` to their Rust code.
 * New code needs to be tested with unit tests and/or integration tests when applicable and the global test script needs to pass.
 * The code is accepted under the [Developer Certificate of Origin](DCO.txt), so you must add following fields to your commit description:

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,6 +26,7 @@ use crate::constants::*;
 use crate::response_code::{Error, Result, WrapperErrorKind};
 use crate::tss2_esys::*;
 use bitfield::bitfield;
+use mbox::MBox;
 use primitives::Cipher;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
@@ -885,4 +886,13 @@ impl TryFrom<TpmtTkVerified> for TPMT_TK_VERIFIED {
             },
         })
     }
+}
+
+/// Close the ESYS and TCTI contexts.
+pub fn close_contexts(esys_context: MBox<ESYS_CONTEXT>, tcti_context: MBox<TSS2_TCTI_CONTEXT>) {
+    // Close the TCTI context.
+    unsafe { Tss2_TctiLdr_Finalize(&mut tcti_context.into_raw()) };
+
+    // Close the context.
+    unsafe { Esys_Finalize(&mut esys_context.into_raw()) };
 }


### PR DESCRIPTION
This commit allows the Context objects to be unwrapped into a
ESYS_CONTEXT and one TSS2_TCTI_CONTEXT object. This would allow
developers to use said contexts with any of the methods found in the FFI
layer.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>