### PR TITLE
Added more TPM Resource API:s

### DIFF
--- a/src/abstraction/transient.rs
+++ b/src/abstraction/transient.rs
@@ -18,7 +18,7 @@ use crate::response_code::{Error, Result, WrapperErrorKind as ErrorKind};
 use crate::tss2_esys::*;
 use crate::utils::algorithm_specifiers::Cipher;
 use crate::utils::{
-    self, get_rsa_public, Hierarchy, PublicIdUnion, TpmaSession, TpmsContext, TpmtTkVerified,
+    self, get_rsa_public, Hierarchy, PublicIdUnion, TpmaSessionBuilder, TpmsContext, TpmtTkVerified,
 };
 use crate::{Context, Tcti};
 use log::error;
@@ -256,9 +256,10 @@ impl TransientKeyContext {
     /// * if `Context::set_session_attr` returns an error, that error is propagated through
     fn set_session_attrs(&mut self) -> Result<()> {
         let (session, _, _) = self.context.sessions();
-        let session_attr = utils::TpmaSession::new()
+        let session_attr = utils::TpmaSessionBuilder::new()
             .with_flag(TPMA_SESSION_DECRYPT)
-            .with_flag(TPMA_SESSION_ENCRYPT);
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
         self.context.tr_sess_set_attributes(session, session_attr)?;
         Ok(())
     }
@@ -380,9 +381,10 @@ impl TransientKeyContextBuilder {
             self.session_encr_cipher.into(),
             self.session_hash_alg,
         )?;
-        let session_attr = TpmaSession::new()
+        let session_attr = TpmaSessionBuilder::new()
             .with_flag(TPMA_SESSION_DECRYPT)
-            .with_flag(TPMA_SESSION_ENCRYPT);
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
         context.tr_sess_set_attributes(session, session_attr)?;
 
         context.set_sessions((session, ESYS_TR_NONE, ESYS_TR_NONE));

--- a/src/abstraction/transient.rs
+++ b/src/abstraction/transient.rs
@@ -188,7 +188,7 @@ impl TransientKeyContext {
         self.set_session_attrs()?;
         let key_handle = self.context.context_load(key_context)?;
         self.context
-            .set_handle_auth(key_handle, key_auth)
+            .tr_set_auth(key_handle, key_auth)
             .or_else(|e| {
                 self.context.flush_context(key_handle)?;
                 Err(e)
@@ -259,7 +259,7 @@ impl TransientKeyContext {
         let session_attr = utils::TpmaSession::new()
             .with_flag(TPMA_SESSION_DECRYPT)
             .with_flag(TPMA_SESSION_ENCRYPT);
-        self.context.set_session_attr(session, session_attr)?;
+        self.context.tr_sess_set_attributes(session, session_attr)?;
         Ok(())
     }
 }
@@ -383,7 +383,7 @@ impl TransientKeyContextBuilder {
         let session_attr = TpmaSession::new()
             .with_flag(TPMA_SESSION_DECRYPT)
             .with_flag(TPMA_SESSION_ENCRYPT);
-        context.set_session_attr(session, session_attr)?;
+        context.tr_sess_set_attributes(session, session_attr)?;
 
         context.set_sessions((session, ESYS_TR_NONE, ESYS_TR_NONE));
         let root_key_auth: Vec<u8> = if self.root_key_auth_size > 0 {
@@ -392,7 +392,7 @@ impl TransientKeyContextBuilder {
             vec![]
         };
         if !self.hierarchy_auth.is_empty() {
-            context.set_handle_auth(self.hierarchy.esys_rh(), &self.hierarchy_auth)?;
+            context.tr_set_auth(self.hierarchy.esys_rh(), &self.hierarchy_auth)?;
         }
 
         let root_key_handle = context.create_primary_key(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -852,7 +852,13 @@ impl Context {
     /// TPM Resource Section
     ///////////////////////////////////////////////////////////////////////////
 
-    /// Set the authorization value of an ESYS_TR
+    /// Set the authentication value for a given object handle in the ESYS context.
+    ///
+    /// # Constraints
+    /// * `auth_value` must be at most 64 elements long
+    ///
+    /// # Errors
+    /// * if `auth_value` is larger than the limit, a `WrongParamSize` wrapper error is returned
     pub fn tr_set_auth(&mut self, handle: ESYS_TR, auth_value: &[u8]) -> Result<()> {
         let auth = wrap_buffer!(auth_value, TPM2B_AUTH, 64);
         let ret = unsafe { Esys_TR_SetAuth(self.mut_context(), handle, &auth) };
@@ -878,14 +884,20 @@ impl Context {
         }
     }
 
-    // Set session attributes
+    /// Set the given attributes on a given session.
     pub fn tr_sess_set_attributes(
         &mut self,
         handle: ESYS_TR,
-        flags: TPMA_SESSION,
-        mask: TPMA_SESSION,
+        attributes: TpmaSession,
     ) -> Result<()> {
-        let ret = unsafe { Esys_TRSess_SetAttributes(self.mut_context(), handle, flags, mask) };
+        let ret = unsafe {
+            Esys_TRSess_SetAttributes(
+                self.mut_context(),
+                handle,
+                attributes.flags(),
+                attributes.mask(),
+            )
+        };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
             Ok(())
@@ -895,31 +907,15 @@ impl Context {
     }
 
     /// Get session attribute flags.
-    pub fn tr_sess_get_attributes(&mut self, handle: ESYS_TR) -> Result<TPMA_SESSION> {
+    pub fn tr_sess_get_attributes(&mut self, handle: ESYS_TR) -> Result<TpmaSession> {
         let mut flags: TPMA_SESSION = 0;
         let ret = unsafe { Esys_TRSess_GetAttributes(self.mut_context(), handle, &mut flags) };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            Ok(flags)
+            Ok(TpmaSession::new().with_flag(flags))
         } else {
             Err(ret)
         }
-    }
-
-    /// Set the authentication value for a given object handle in the ESYS context.
-    ///
-    /// # Constraints
-    /// * `auth_value` must be at most 64 elements long
-    ///
-    /// # Errors
-    /// * if `auth_value` is larger than the limit, a `WrongParamSize` wrapper error is returned
-    pub fn set_handle_auth(&mut self, handle: ESYS_TR, auth_value: &[u8]) -> Result<()> {
-        self.tr_set_auth(handle, auth_value)
-    }
-
-    /// Set the given attributes on a given session.
-    pub fn set_session_attr(&mut self, handle: ESYS_TR, attrs: TpmaSession) -> Result<()> {
-        self.tr_sess_set_attributes(handle, attrs.flags(), attrs.mask())
     }
 
     /// Returns a mutable reference to the native ESYS context handle.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ use std::convert::{TryFrom, TryInto};
 use std::ffi::CString;
 use std::ptr::{null, null_mut};
 use tss2_esys::*;
-use utils::{PublicParmsUnion, Signature, TpmaSession, TpmsContext};
+use utils::{PublicParmsUnion, Signature, TpmaSession, TpmaSessionBuilder, TpmsContext};
 
 #[macro_use]
 macro_rules! wrap_buffer {
@@ -912,7 +912,7 @@ impl Context {
         let ret = unsafe { Esys_TRSess_GetAttributes(self.mut_context(), handle, &mut flags) };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            Ok(TpmaSession::new().with_flag(flags))
+            Ok(TpmaSessionBuilder::new().with_flag(flags).build())
         } else {
             Err(ret)
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -647,44 +647,72 @@ impl TryFrom<Signature> for TPMT_SIGNATURE {
 }
 
 /// Rust native wrapper for session attributes objects.
-///
-/// If no mask has been specified then it will be
-/// defaulted to be have the same value as the flags.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct TpmaSession {
+    flags: TPMA_SESSION,
+    mask: TPMA_SESSION,
+}
+
+impl TpmaSession {
+    // Clones the TpmaSession but adds a new mask.
+    pub fn clone_with_new_mask(self, new_mask: TPMA_SESSION) -> TpmaSession {
+        TpmaSession {
+            flags: self.flags,
+            mask: new_mask,
+        }
+    }
+
+    /// Function to retrieve the masks
+    /// that have been set.
+    pub fn mask(self) -> TPMA_SESSION {
+        self.mask
+    }
+
+    /// Function to retrive the flags that
+    /// gave been set.
+    pub fn flags(self) -> TPMA_SESSION {
+        self.flags
+    }
+}
+
+/// A builder for TpmaSession.
+///
+/// If no mask have been added then the mask
+/// will be set till all flags.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct TpmaSessionBuilder {
     flags: TPMA_SESSION,
     mask: Option<TPMA_SESSION>,
 }
 
-impl TpmaSession {
-    /// Create a new session attributes object.
-    pub fn new() -> TpmaSession {
-        TpmaSession {
+impl TpmaSessionBuilder {
+    pub fn new() -> TpmaSessionBuilder {
+        TpmaSessionBuilder {
             flags: 0,
             mask: None,
         }
     }
 
-    /// Set flag.
+    /// Function used to add flags.
     pub fn with_flag(mut self, flag: TPMA_SESSION) -> Self {
         self.flags |= flag;
         self
     }
 
-    /// Set a mask
+    /// Function used to add masks.
     pub fn with_mask(mut self, mask: TPMA_SESSION) -> Self {
         self.mask = Some(self.mask.unwrap_or(0) | mask);
         self
     }
 
-    /// Get mask.
-    pub fn mask(self) -> TPMA_SESSION {
-        self.mask.unwrap_or(self.flags)
-    }
-
-    /// Get all set flags.
-    pub fn flags(self) -> TPMA_SESSION {
-        self.flags
+    /// Function used to build a TpmaSession
+    /// from the parameters that have been
+    /// added.
+    pub fn build(self) -> TpmaSession {
+        TpmaSession {
+            flags: self.flags,
+            mask: self.mask.unwrap_or(self.flags),
+        }
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -647,29 +647,44 @@ impl TryFrom<Signature> for TPMT_SIGNATURE {
 }
 
 /// Rust native wrapper for session attributes objects.
+///
+/// If no mask has been specified then it will be
+/// defaulted to be have the same value as the flags.
 #[derive(Copy, Clone, Debug, Default)]
-pub struct TpmaSession(TPMA_SESSION);
+pub struct TpmaSession {
+    flags: TPMA_SESSION,
+    mask: Option<TPMA_SESSION>,
+}
 
 impl TpmaSession {
     /// Create a new session attributes object.
     pub fn new() -> TpmaSession {
-        TpmaSession(0)
+        TpmaSession {
+            flags: 0,
+            mask: None,
+        }
     }
 
     /// Set flag.
     pub fn with_flag(mut self, flag: TPMA_SESSION) -> Self {
-        self.0 |= flag;
+        self.flags |= flag;
         self
     }
 
-    /// Get mask for all set flags.
+    /// Set a mask
+    pub fn with_mask(mut self, mask: TPMA_SESSION) -> Self {
+        self.mask = Some(self.mask.unwrap_or(0) | mask);
+        self
+    }
+
+    /// Get mask.
     pub fn mask(self) -> TPMA_SESSION {
-        self.0
+        self.mask.unwrap_or(self.flags)
     }
 
     /// Get all set flags.
     pub fn flags(self) -> TPMA_SESSION {
-        self.0
+        self.flags
     }
 }
 

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -57,7 +57,7 @@ fn create_ctx_with_session() -> Context {
     let session_attr = TpmaSession::new()
         .with_flag(TPMA_SESSION_DECRYPT)
         .with_flag(TPMA_SESSION_ENCRYPT);
-    ctx.set_session_attr(session, session_attr).unwrap();
+    ctx.tr_sess_set_attributes(session, session_attr).unwrap();
     ctx.set_sessions((session, ESYS_TR_NONE, ESYS_TR_NONE));
 
     ctx
@@ -98,7 +98,9 @@ fn comprehensive_test() {
     let session_attr = TpmaSession::new()
         .with_flag(TPMA_SESSION_DECRYPT)
         .with_flag(TPMA_SESSION_ENCRYPT);
-    context.set_session_attr(new_session, session_attr).unwrap();
+    context
+        .tr_sess_set_attributes(new_session, session_attr)
+        .unwrap();
     context.set_sessions((new_session, ESYS_TR_NONE, ESYS_TR_NONE));
 
     let (key_priv, key_pub) = context
@@ -115,7 +117,7 @@ fn comprehensive_test() {
 
     let key_context = context.context_save(key_handle).unwrap();
     let key_handle = context.context_load(key_context).unwrap();
-    context.set_handle_auth(key_handle, &key_auth).unwrap();
+    context.tr_set_auth(key_handle, &key_auth).unwrap();
     let scheme = TPMT_SIG_SCHEME {
         scheme: TPM2_ALG_NULL,
         details: Default::default(),
@@ -237,7 +239,7 @@ mod test_start_sess {
             .with_flag(TPMA_SESSION_ENCRYPT)
             .with_flag(TPMA_SESSION_AUDIT);
         context
-            .set_session_attr(encrypted_sess, session_attr)
+            .tr_sess_set_attributes(encrypted_sess, session_attr)
             .unwrap();
 
         let _ = context
@@ -321,7 +323,7 @@ mod test_get_random {
             .with_flag(TPMA_SESSION_ENCRYPT)
             .with_flag(TPMA_SESSION_AUDIT);
         context
-            .set_session_attr(encrypted_sess, session_attr)
+            .tr_sess_set_attributes(encrypted_sess, session_attr)
             .unwrap();
 
         context.set_sessions((encrypted_sess, ESYS_TR_NONE, ESYS_TR_NONE));
@@ -1081,7 +1083,7 @@ mod test_handle_auth {
             digest: Default::default(),
         };
 
-        context.set_handle_auth(new_key_handle, &key_auth).unwrap();
+        context.tr_set_auth(new_key_handle, &key_auth).unwrap();
         let _ = context
             .sign(new_key_handle, &HASH[..32], scheme, &validation)
             .unwrap();
@@ -1104,7 +1106,7 @@ mod test_handle_auth {
             .unwrap();
 
         context
-            .set_handle_auth(prim_key_handle, &[0xff; 100])
+            .tr_set_auth(prim_key_handle, &[0xff; 100])
             .unwrap_err();
     }
 
@@ -1115,9 +1117,7 @@ mod test_handle_auth {
     #[test]
     fn test_invalid_handle() {
         let mut context = create_ctx_with_session();
-        context
-            .set_handle_auth(ESYS_TR_NONE, &[0x11; 10])
-            .unwrap_err();
+        context.tr_set_auth(ESYS_TR_NONE, &[0x11; 10]).unwrap_err();
     }
 }
 
@@ -1142,7 +1142,9 @@ mod test_session_attr {
             .with_flag(TPMA_SESSION_DECRYPT)
             .with_flag(TPMA_SESSION_ENCRYPT)
             .with_flag(TPMA_SESSION_AUDIT);
-        context.set_session_attr(sess_handle, sess_attr).unwrap();
+        context
+            .tr_sess_set_attributes(sess_handle, sess_attr)
+            .unwrap();
         context.set_sessions((sess_handle, ESYS_TR_NONE, ESYS_TR_NONE));
 
         let _ = context.get_random(10).unwrap();

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -37,7 +37,7 @@ use tss_esapi::constants::*;
 use tss_esapi::tss2_esys::*;
 use tss_esapi::utils::{
     self, algorithm_specifiers::Cipher, AsymSchemeUnion, ObjectAttributes, PublicIdUnion,
-    PublicParmsUnion, Signature, Tpm2BPublicBuilder, TpmaSession, TpmsRsaParmsBuilder,
+    PublicParmsUnion, Signature, Tpm2BPublicBuilder, TpmaSessionBuilder, TpmsRsaParmsBuilder,
     TpmtSymDefBuilder,
 };
 use tss_esapi::*;
@@ -54,9 +54,10 @@ fn create_ctx_with_session() -> Context {
             TPM2_ALG_SHA256,
         )
         .unwrap();
-    let session_attr = TpmaSession::new()
+    let session_attr = TpmaSessionBuilder::new()
         .with_flag(TPMA_SESSION_DECRYPT)
-        .with_flag(TPMA_SESSION_ENCRYPT);
+        .with_flag(TPMA_SESSION_ENCRYPT)
+        .build();
     ctx.tr_sess_set_attributes(session, session_attr).unwrap();
     ctx.set_sessions((session, ESYS_TR_NONE, ESYS_TR_NONE));
 
@@ -95,9 +96,10 @@ fn comprehensive_test() {
             TPM2_ALG_SHA256,
         )
         .unwrap();
-    let session_attr = TpmaSession::new()
+    let session_attr = TpmaSessionBuilder::new()
         .with_flag(TPMA_SESSION_DECRYPT)
-        .with_flag(TPMA_SESSION_ENCRYPT);
+        .with_flag(TPMA_SESSION_ENCRYPT)
+        .build();
     context
         .tr_sess_set_attributes(new_session, session_attr)
         .unwrap();
@@ -234,10 +236,11 @@ mod test_start_sess {
                 TPM2_ALG_SHA256,
             )
             .unwrap();
-        let session_attr = utils::TpmaSession::new()
+        let session_attr = utils::TpmaSessionBuilder::new()
             .with_flag(TPMA_SESSION_DECRYPT)
             .with_flag(TPMA_SESSION_ENCRYPT)
-            .with_flag(TPMA_SESSION_AUDIT);
+            .with_flag(TPMA_SESSION_AUDIT)
+            .build();
         context
             .tr_sess_set_attributes(encrypted_sess, session_attr)
             .unwrap();
@@ -318,10 +321,11 @@ mod test_get_random {
                 TPM2_ALG_SHA256,
             )
             .unwrap();
-        let session_attr = utils::TpmaSession::new()
+        let session_attr = utils::TpmaSessionBuilder::new()
             .with_flag(TPMA_SESSION_DECRYPT)
             .with_flag(TPMA_SESSION_ENCRYPT)
-            .with_flag(TPMA_SESSION_AUDIT);
+            .with_flag(TPMA_SESSION_AUDIT)
+            .build();
         context
             .tr_sess_set_attributes(encrypted_sess, session_attr)
             .unwrap();
@@ -1138,10 +1142,11 @@ mod test_session_attr {
             )
             .unwrap();
 
-        let sess_attr = TpmaSession::new()
+        let sess_attr = TpmaSessionBuilder::new()
             .with_flag(TPMA_SESSION_DECRYPT)
             .with_flag(TPMA_SESSION_ENCRYPT)
-            .with_flag(TPMA_SESSION_AUDIT);
+            .with_flag(TPMA_SESSION_AUDIT)
+            .build();
         context
             .tr_sess_set_attributes(sess_handle, sess_attr)
             .unwrap();


### PR DESCRIPTION
Added more of the ESYS TPM Resource API:s. Some of the API:s already existed with
some extended functionality or a different name. I changed this to call new functions
that are only thin wrappers around the original C API:s. The reason for the changes is
to keep the naming consistent. So that the TPM Resource functions are prefixed with 'tr'.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>