### PR TITLE
Refactor `Cipher`; Add `quote` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "3.0.2"
+version = "4.0.0-alpha.1"
 authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -13,12 +13,18 @@
 
 The `tss-esapi` Rust crate provides an idiomatic interface to the TCG TSS 2.0 Enhanced System API. We expose both direct FFI bindings and abstracted versions, aimed at improved convenience of using the API.
 
+Our end-goal is to achieve a fully Rust-native interface that offers strong safety and security guarantees. Check out our [documentation](https://docs.rs/tss-esapi/*/tss_esapi/#notes-on-code-safety) for an overview of our code safety approach.
+
+## Versioning
+
+The crate is still under development and thus the interface is not stable (despite the version number). As a rule of thumb, all versions marked `alpha` are expected to be short-lived and superseded by a better, more complete interface that relies on breaking changes.
+
 ## Requirements
 
 This crate has currently only been tested with the TSS 2.0
 [open-source implementation](https://github.com/tpm2-software/tpm2-tss).
 It uses `pkg-config` to find the include and library files for the `tss2-esys` and `tss2-tctildr`
-libraries. `pkg-config` tool is needed to build this crate.
+libraries. A minimum version of `2.3.3` is required for both. `pkg-config` tool is needed to build this crate.
 
 Having installed the open-source implementation libraries at `/usr/local/lib` (by default), it
 might happen that `pkg-config` can not find them. Run the following command if that is the

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,6 +4,7 @@ use crate::tss2_esys::*;
 
 pub const TPM2_ALG_ERROR: TPM2_ALG_ID = 0x0000;
 pub const TPM2_ALG_RSA: TPM2_ALG_ID = 0x0001;
+pub const TPM2_ALG_TDES: TPM2_ALG_ID = 0x0003;
 pub const TPM2_ALG_SHA: TPM2_ALG_ID = 0x0004;
 pub const TPM2_ALG_SHA1: TPM2_ALG_ID = 0x0004;
 pub const TPM2_ALG_HMAC: TPM2_ALG_ID = 0x0005;

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -340,6 +340,34 @@ mod test_pcr_read {
     }
 }
 
+mod test_quote {
+    use super::*;
+
+    #[test]
+    fn pcr_quote() {
+        let mut context = create_ctx_with_session();
+        // Quote PCR 0
+        let pcr_selections = PcrSelectionsBuilder::new()
+            .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0])
+            .build();
+        let scheme = TPMT_SIG_SCHEME {
+            scheme: TPM2_ALG_NULL,
+            details: Default::default(),
+        };
+        // No qualifying data
+        let qualifying_data = vec![0xff; 16];
+
+        let key_handle = context
+            .create_primary_key(ESYS_TR_RH_OWNER, &signing_key_pub(), &[], &[], &[], &[])
+            .unwrap();
+
+        let res = context
+            .quote(key_handle, &qualifying_data, scheme, pcr_selections)
+            .expect("Failed to get a quote");
+        assert!(res.0.size != 0);
+    }
+}
+
 mod test_get_random {
     use super::*;
 


### PR DESCRIPTION
This commit adds a few improvements:
* It refactors the old `Cipher` enum to a struct based on the algorithm
enums introduced previously
* Adding a method on `Context` to perform quotes on PCRs as was
requested in #52
* Change our version number to something that points to the crate's
instability and mention it in the README

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>