### PR TITLE
Hash method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "4.0.1-alpha.1"
+version = "4.0.2-alpha.1"
 authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -340,6 +340,7 @@ pub const TPM2_ST_ATTEST_QUOTE: TPM2_ST = 0x8018; /* tag for an attestation stru
 pub const TPM2_ST_ATTEST_TIME: TPM2_ST = 0x8019; /* tag for an attestation structure */
 pub const TPM2_ST_ATTEST_CREATION: TPM2_ST = 0x801A; /* tag for an attestation structure */
 pub const TPM2_ST_RESERVED3: TPM2_ST = 0x801B; /* do not use . NOTE This was previously assigned to TPM2_ST_ATTEST_NV. The tag is changed because the structure has changed */
+pub const TPM2_ST_ATTEST_NV_DIGEST: TPM2_ST = 0x801c; /* tag for an attestation structure */
 pub const TPM2_ST_CREATION: TPM2_ST = 0x8021; /* tag for a ticket type */
 pub const TPM2_ST_VERIFIED: TPM2_ST = 0x8022; /* tag for a ticket type */
 pub const TPM2_ST_AUTH_SECRET: TPM2_ST = 0x8023; /* tag for a ticket type */

--- a/src/utils/tags.rs
+++ b/src/utils/tags.rs
@@ -1,0 +1,93 @@
+use crate::constants::{
+    TPM2_ST_ATTEST_CERTIFY, TPM2_ST_ATTEST_COMMAND_AUDIT, TPM2_ST_ATTEST_CREATION,
+    TPM2_ST_ATTEST_NV, TPM2_ST_ATTEST_NV_DIGEST, TPM2_ST_ATTEST_QUOTE,
+    TPM2_ST_ATTEST_SESSION_AUDIT, TPM2_ST_ATTEST_TIME, TPM2_ST_AUTH_SECRET, TPM2_ST_AUTH_SIGNED,
+    TPM2_ST_CREATION, TPM2_ST_FU_MANIFEST, TPM2_ST_HASHCHECK, TPM2_ST_NO_SESSIONS, TPM2_ST_NULL,
+    TPM2_ST_RESERVED1, TPM2_ST_RESERVED2, TPM2_ST_RESERVED3, TPM2_ST_RSP_COMMAND, TPM2_ST_SESSIONS,
+    TPM2_ST_VERIFIED,
+};
+use crate::response_code::{Error, Result, WrapperErrorKind};
+use crate::tss2_esys::TPM2_ST;
+use std::convert::{From, TryFrom};
+
+/// This enum represents the TPM_ST (Structure Tags)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StructureTag {
+    RspCommand,
+    Null,
+    NoSessions,
+    Sessions,
+    Reserved1,
+    Reserved2,
+    AttestNv,
+    AttestCommandAudit,
+    AttestSessionAudit,
+    AttestCertify,
+    AttestQuote,
+    AttestTime,
+    AttestCreation,
+    AttestNvDigest,
+    Creation,
+    Verified,
+    AuthSecret,
+    Hashcheck,
+    AuthSigned,
+    FuManifest,
+}
+
+impl From<StructureTag> for TPM2_ST {
+    fn from(structure_tag: StructureTag) -> Self {
+        match structure_tag {
+            StructureTag::RspCommand => TPM2_ST_RSP_COMMAND,
+            StructureTag::Null => TPM2_ST_NULL,
+            StructureTag::NoSessions => TPM2_ST_NO_SESSIONS,
+            StructureTag::Sessions => TPM2_ST_SESSIONS,
+            StructureTag::Reserved1 => TPM2_ST_RESERVED1,
+            StructureTag::Reserved2 => TPM2_ST_RESERVED2,
+            StructureTag::AttestNv => TPM2_ST_ATTEST_NV,
+            StructureTag::AttestCommandAudit => TPM2_ST_ATTEST_COMMAND_AUDIT,
+            StructureTag::AttestSessionAudit => TPM2_ST_ATTEST_SESSION_AUDIT,
+            StructureTag::AttestCertify => TPM2_ST_ATTEST_CERTIFY,
+            StructureTag::AttestQuote => TPM2_ST_ATTEST_QUOTE,
+            StructureTag::AttestTime => TPM2_ST_ATTEST_TIME,
+            StructureTag::AttestCreation => TPM2_ST_ATTEST_CREATION,
+            StructureTag::AttestNvDigest => TPM2_ST_ATTEST_NV_DIGEST,
+            StructureTag::Creation => TPM2_ST_CREATION,
+            StructureTag::Verified => TPM2_ST_VERIFIED,
+            StructureTag::AuthSecret => TPM2_ST_AUTH_SECRET,
+            StructureTag::Hashcheck => TPM2_ST_HASHCHECK,
+            StructureTag::AuthSigned => TPM2_ST_AUTH_SIGNED,
+            StructureTag::FuManifest => TPM2_ST_FU_MANIFEST,
+        }
+    }
+}
+
+impl TryFrom<TPM2_ST> for StructureTag {
+    type Error = Error;
+    fn try_from(tpm2_structure_tag: TPM2_ST) -> Result<Self> {
+        match tpm2_structure_tag {
+            TPM2_ST_RSP_COMMAND => Ok(StructureTag::RspCommand),
+            TPM2_ST_NULL => Ok(StructureTag::Null),
+            TPM2_ST_NO_SESSIONS => Ok(StructureTag::NoSessions),
+            TPM2_ST_SESSIONS => Ok(StructureTag::Sessions),
+            TPM2_ST_RESERVED1 => Ok(StructureTag::Reserved1),
+            TPM2_ST_RESERVED2 => Ok(StructureTag::Reserved2),
+            TPM2_ST_ATTEST_NV => Ok(StructureTag::AttestNv),
+            TPM2_ST_ATTEST_COMMAND_AUDIT => Ok(StructureTag::AttestCommandAudit),
+            TPM2_ST_ATTEST_SESSION_AUDIT => Ok(StructureTag::AttestSessionAudit),
+            TPM2_ST_ATTEST_CERTIFY => Ok(StructureTag::AttestCertify),
+            TPM2_ST_ATTEST_QUOTE => Ok(StructureTag::AttestQuote),
+            TPM2_ST_ATTEST_TIME => Ok(StructureTag::AttestTime),
+            TPM2_ST_ATTEST_CREATION => Ok(StructureTag::AttestCreation),
+            TPM2_ST_RESERVED3 => Err(Error::local_error(WrapperErrorKind::InvalidParam)), /* Spec: "DO NOT USE. This was previously assigned to TPM_ST_ATTEST_NV. The tag is changed because the structure has changed" */
+            TPM2_ST_ATTEST_NV_DIGEST => Ok(StructureTag::AttestNvDigest),
+            TPM2_ST_CREATION => Ok(StructureTag::Creation),
+            TPM2_ST_VERIFIED => Ok(StructureTag::Verified),
+            TPM2_ST_AUTH_SECRET => Ok(StructureTag::AuthSecret),
+            TPM2_ST_HASHCHECK => Ok(StructureTag::Hashcheck),
+            TPM2_ST_AUTH_SIGNED => Ok(StructureTag::AuthSigned),
+            TPM2_ST_FU_MANIFEST => Ok(StructureTag::FuManifest),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}

--- a/src/utils/tickets.rs
+++ b/src/utils/tickets.rs
@@ -1,0 +1,110 @@
+use crate::response_code::{Error, Result, WrapperErrorKind};
+use crate::tss2_esys::{TPM2B_DIGEST, TPMT_TK_HASHCHECK, TPMT_TK_VERIFIED};
+use crate::utils::tags::StructureTag;
+use crate::utils::Hierarchy;
+use log::error;
+use std::convert::{TryFrom, TryInto};
+
+/// Macro used for implementing try_from
+/// TssTicketType -> TicketType
+/// TicketType -> TssTicketType
+macro_rules! impl_ticket_try_froms {
+    ($ticket_type:ident, $tss_ticket_type:ident) => {
+        impl TryFrom<$ticket_type> for $tss_ticket_type {
+            type Error = Error;
+            fn try_from(ticket: $ticket_type) -> Result<Self> {
+                let digest = ticket.digest;
+                if digest.len() > 64 {
+                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+                }
+                let mut buffer = [0; 64];
+                buffer[..digest.len()].clone_from_slice(&digest[..digest.len()]);
+                Ok($tss_ticket_type {
+                    tag: <$ticket_type>::TAG.into(),
+                    hierarchy: ticket.hierarchy.rh(),
+                    digest: TPM2B_DIGEST {
+                        size: digest.len().try_into().unwrap(), // should not fail based on the checks done above
+                        buffer,
+                    },
+                })
+            }
+        }
+
+        impl TryFrom<$tss_ticket_type> for $ticket_type {
+            type Error = Error;
+
+            fn try_from(tss_ticket: $tss_ticket_type) -> Result<Self> {
+                match StructureTag::try_from(tss_ticket.tag) {
+                    Ok(val) => {
+                        if val != <$ticket_type>::TAG {
+                            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+                        }
+                    }
+                    Err(why) => {
+                        error!("Failed to parsed tag: {}", why);
+                        return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+                    }
+                };
+
+                let len = tss_ticket.digest.size.into();
+                let mut digest = tss_ticket.digest.buffer.to_vec();
+                digest.truncate(len);
+
+                let hierarchy = tss_ticket.hierarchy.try_into()?;
+
+                Ok($ticket_type { hierarchy, digest })
+            }
+        }
+    };
+}
+
+pub trait Ticket {
+    const TAG: StructureTag;
+    fn hierarchy(&self) -> Hierarchy;
+    fn digest(&self) -> &[u8];
+}
+
+#[derive(Debug, Clone)]
+pub struct HashcheckTicket {
+    hierarchy: Hierarchy,
+    digest: Vec<u8>,
+}
+
+impl Ticket for HashcheckTicket {
+    /// The tag of the verified ticket.
+    const TAG: StructureTag = StructureTag::Hashcheck;
+    /// Get the hierarchy associated with the verification ticket.
+    fn hierarchy(&self) -> Hierarchy {
+        self.hierarchy
+    }
+
+    /// Get the digest associated with the verification ticket.
+    fn digest(&self) -> &[u8] {
+        &self.digest
+    }
+}
+
+impl_ticket_try_froms!(HashcheckTicket, TPMT_TK_HASHCHECK);
+
+/// Rust native wrapper for `TPMT_TK_VERIFIED` objects.
+#[derive(Debug)]
+pub struct VerifiedTicket {
+    hierarchy: Hierarchy,
+    digest: Vec<u8>,
+}
+
+impl Ticket for VerifiedTicket {
+    // type TssTicketType = TPMT_TK_VERIFIED;
+    /// The tag of the verified ticket.
+    const TAG: StructureTag = StructureTag::Verified;
+    /// Get the hierarchy associated with the verification ticket.
+    fn hierarchy(&self) -> Hierarchy {
+        self.hierarchy
+    }
+    /// Get the digest associated with the verification ticket.
+    fn digest(&self) -> &[u8] {
+        &self.digest
+    }
+}
+
+impl_ticket_try_froms!(VerifiedTicket, TPMT_TK_VERIFIED);


### PR DESCRIPTION
I added context method for the Esys_Hash method. The return value from that method is a digest and a TPMT_TK_HASHCHECK ticket. So in order to create HashcheckTicket type I had to create an enum representing StructureTag(TPM_ST).