### PR TITLE
Add functions for more Policy commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -934,6 +934,192 @@ impl Context {
         }
     }
 
+    /// Cause conditional gating of a policy based on locality.
+    ///
+    /// The TPM will ensure that the current policy can only complete in the specified
+    /// locality (extended) or any of the specified localities (non-extended).
+    pub fn policy_locality(
+        &mut self,
+        policy_session: ESYS_TR,
+        locality: TPMA_LOCALITY,
+    ) -> Result<()> {
+        let ret = unsafe {
+            Esys_PolicyLocality(
+                self.mut_context(),
+                policy_session,
+                self.sessions.0,
+                self.sessions.1,
+                self.sessions.2,
+                locality,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+        if ret.is_success() {
+            Ok(())
+        } else {
+            Err(ret)
+        }
+    }
+
+    /// Cause conditional gating of a policy based on command code of authorized command.
+    ///
+    /// The TPM will ensure that the current policy can only be used to complete the command
+    /// indicated by code.
+    pub fn policy_command_code(&mut self, policy_session: ESYS_TR, code: TPM2_CC) -> Result<()> {
+        let ret = unsafe {
+            Esys_PolicyCommandCode(
+                self.mut_context(),
+                policy_session,
+                self.sessions.0,
+                self.sessions.1,
+                self.sessions.2,
+                code,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+        if ret.is_success() {
+            Ok(())
+        } else {
+            Err(ret)
+        }
+    }
+
+    /// Cause conditional gating of a policy based on physical presence.
+    ///
+    /// The TPM will ensure that the current policy can only complete when physical
+    /// presence is asserted. The way this is done is implementation-specific.
+    pub fn policy_physical_presence(&mut self, policy_session: ESYS_TR) -> Result<()> {
+        let ret = unsafe {
+            Esys_PolicyPhysicalPresence(
+                self.mut_context(),
+                policy_session,
+                self.sessions.0,
+                self.sessions.1,
+                self.sessions.2,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+        if ret.is_success() {
+            Ok(())
+        } else {
+            Err(ret)
+        }
+    }
+
+    /// Cause conditional gating of a policy based on command parameters.
+    ///
+    /// The TPM will ensure that the current policy can only be used to authorize
+    /// a command where the parameters are hashed into cp_hash_a.
+    pub fn policy_cp_hash(&mut self, policy_session: ESYS_TR, cp_hash_a: Digest) -> Result<()> {
+        let cp_hash_a = TPM2B_DIGEST::try_from(cp_hash_a)?;
+        let ret = unsafe {
+            Esys_PolicyCpHash(
+                self.mut_context(),
+                policy_session,
+                self.sessions.0,
+                self.sessions.1,
+                self.sessions.2,
+                &cp_hash_a,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+        if ret.is_success() {
+            Ok(())
+        } else {
+            Err(ret)
+        }
+    }
+
+    /// Cause conditional gating of a policy based on name hash.
+    ///
+    /// The TPM will ensure that the current policy can only be used to authorize
+    /// a command acting on an object whose name hashes to name_hash.
+    pub fn policy_name_hash(&mut self, policy_session: ESYS_TR, name_hash: Digest) -> Result<()> {
+        let name_hash = TPM2B_DIGEST::try_from(name_hash)?;
+        let ret = unsafe {
+            Esys_PolicyNameHash(
+                self.mut_context(),
+                policy_session,
+                self.sessions.0,
+                self.sessions.1,
+                self.sessions.2,
+                &name_hash,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+        if ret.is_success() {
+            Ok(())
+        } else {
+            Err(ret)
+        }
+    }
+
+    /// Cause conditional gating of a policy based on authValue.
+    ///
+    /// The TPM will ensure that the current policy requires the user to know the authValue
+    /// used when creating the object.
+    pub fn policy_auth_value(&mut self, policy_session: ESYS_TR) -> Result<()> {
+        let ret = unsafe {
+            Esys_PolicyAuthValue(
+                self.mut_context(),
+                policy_session,
+                self.sessions.0,
+                self.sessions.1,
+                self.sessions.2,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+        if ret.is_success() {
+            Ok(())
+        } else {
+            Err(ret)
+        }
+    }
+
+    /// Cause conditional gating of a policy based on password.
+    ///
+    /// The TPM will ensure that the current policy requires the user to know the password
+    /// used when creating the object.
+    pub fn policy_password(&mut self, policy_session: ESYS_TR) -> Result<()> {
+        let ret = unsafe {
+            Esys_PolicyPassword(
+                self.mut_context(),
+                policy_session,
+                self.sessions.0,
+                self.sessions.1,
+                self.sessions.2,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+        if ret.is_success() {
+            Ok(())
+        } else {
+            Err(ret)
+        }
+    }
+
+    /// Cause conditional gating of a policy based on NV written state.
+    ///
+    /// The TPM will ensure that the NV index that is used has a specific written state.
+    pub fn policy_nv_written(&mut self, policy_session: ESYS_TR, written_set: bool) -> Result<()> {
+        let ret = unsafe {
+            Esys_PolicyNvWritten(
+                self.mut_context(),
+                policy_session,
+                self.sessions.0,
+                self.sessions.1,
+                self.sessions.2,
+                if written_set { 1 } else { 0 },
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+        if ret.is_success() {
+            Ok(())
+        } else {
+            Err(ret)
+        }
+    }
+
     /// Cause conditional gating of a policy based on an authorized policy
     ///
     /// The TPM will ensure that the current policy digest is correctly signed

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -551,7 +551,7 @@ fn get_pcr_policy_digest(context: &mut Context, mangle: bool, do_trial: bool) ->
     (digest, pcr_ses)
 }
 
-mod test_policy_authorize {
+mod test_policies {
     use super::*;
 
     #[test]
@@ -603,10 +603,6 @@ mod test_policy_authorize {
             .policy_authorize(policy_ses, policy_digest, policy_ref, key_name, tkt)
             .unwrap();
     }
-}
-
-mod test_policy_or {
-    use super::*;
 
     #[test]
     fn test_policy_or() {
@@ -639,6 +635,216 @@ mod test_policy_or {
 
         // There should be no errors setting an Or for a TRIAL session
         context.policy_or(trial_session, digest_list).unwrap();
+    }
+
+    #[test]
+    fn test_policy_locality() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                ESYS_TR_NONE,
+                ESYS_TR_NONE,
+                &[],
+                TPM2_SE_TRIAL,
+                utils::TpmtSymDefBuilder::aes_256_cfb(),
+                TPM2_ALG_SHA256,
+            )
+            .unwrap();
+        let trial_session_attr = TpmaSessionBuilder::new()
+            .with_flag(TPMA_SESSION_DECRYPT)
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        context
+            .tr_sess_set_attributes(trial_session, trial_session_attr)
+            .unwrap();
+
+        // There should be no errors setting an Or for a TRIAL session
+        context.policy_locality(trial_session, 3).unwrap();
+    }
+
+    #[test]
+    fn test_policy_command_code() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                ESYS_TR_NONE,
+                ESYS_TR_NONE,
+                &[],
+                TPM2_SE_TRIAL,
+                utils::TpmtSymDefBuilder::aes_256_cfb(),
+                TPM2_ALG_SHA256,
+            )
+            .unwrap();
+        let trial_session_attr = TpmaSessionBuilder::new()
+            .with_flag(TPMA_SESSION_DECRYPT)
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        context
+            .tr_sess_set_attributes(trial_session, trial_session_attr)
+            .unwrap();
+
+        // There should be no errors setting an Or for a TRIAL session
+        context
+            .policy_command_code(trial_session, TPM2_CC_Unseal)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_policy_physical_presence() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                ESYS_TR_NONE,
+                ESYS_TR_NONE,
+                &[],
+                TPM2_SE_TRIAL,
+                utils::TpmtSymDefBuilder::aes_256_cfb(),
+                TPM2_ALG_SHA256,
+            )
+            .unwrap();
+        let trial_session_attr = TpmaSessionBuilder::new()
+            .with_flag(TPMA_SESSION_DECRYPT)
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        context
+            .tr_sess_set_attributes(trial_session, trial_session_attr)
+            .unwrap();
+
+        // There should be no errors setting an Or for a TRIAL session
+        context.policy_physical_presence(trial_session).unwrap();
+    }
+
+    #[test]
+    fn test_policy_cp_hash() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                ESYS_TR_NONE,
+                ESYS_TR_NONE,
+                &[],
+                TPM2_SE_TRIAL,
+                utils::TpmtSymDefBuilder::aes_256_cfb(),
+                TPM2_ALG_SHA256,
+            )
+            .unwrap();
+        let trial_session_attr = TpmaSessionBuilder::new()
+            .with_flag(TPMA_SESSION_DECRYPT)
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        context
+            .tr_sess_set_attributes(trial_session, trial_session_attr)
+            .unwrap();
+
+        let test_dig = Digest::try_from(vec![
+            252, 200, 17, 232, 137, 217, 130, 51, 54, 22, 184, 131, 2, 134, 99, 130, 175, 216, 159,
+            174, 203, 165, 35, 19, 187, 56, 167, 208, 3, 128, 11, 12,
+        ])
+        .unwrap();
+
+        // There should be no errors setting an Or for a TRIAL session
+        context.policy_cp_hash(trial_session, test_dig).unwrap();
+    }
+    #[test]
+    fn test_policy_name_hash() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                ESYS_TR_NONE,
+                ESYS_TR_NONE,
+                &[],
+                TPM2_SE_TRIAL,
+                utils::TpmtSymDefBuilder::aes_256_cfb(),
+                TPM2_ALG_SHA256,
+            )
+            .unwrap();
+        let trial_session_attr = TpmaSessionBuilder::new()
+            .with_flag(TPMA_SESSION_DECRYPT)
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        context
+            .tr_sess_set_attributes(trial_session, trial_session_attr)
+            .unwrap();
+
+        let test_dig = Digest::try_from(vec![
+            252, 200, 17, 232, 137, 217, 130, 51, 54, 22, 184, 131, 2, 134, 99, 130, 175, 216, 159,
+            174, 203, 165, 35, 19, 187, 56, 167, 208, 3, 128, 11, 12,
+        ])
+        .unwrap();
+
+        // There should be no errors setting an Or for a TRIAL session
+        context.policy_name_hash(trial_session, test_dig).unwrap();
+    }
+    #[test]
+    fn test_policy_auth_value() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                ESYS_TR_NONE,
+                ESYS_TR_NONE,
+                &[],
+                TPM2_SE_TRIAL,
+                utils::TpmtSymDefBuilder::aes_256_cfb(),
+                TPM2_ALG_SHA256,
+            )
+            .unwrap();
+        let trial_session_attr = TpmaSessionBuilder::new()
+            .with_flag(TPMA_SESSION_DECRYPT)
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        context
+            .tr_sess_set_attributes(trial_session, trial_session_attr)
+            .unwrap();
+
+        // There should be no errors setting an Or for a TRIAL session
+        context.policy_auth_value(trial_session).unwrap();
+    }
+    #[test]
+    fn test_policy_password() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                ESYS_TR_NONE,
+                ESYS_TR_NONE,
+                &[],
+                TPM2_SE_TRIAL,
+                utils::TpmtSymDefBuilder::aes_256_cfb(),
+                TPM2_ALG_SHA256,
+            )
+            .unwrap();
+        let trial_session_attr = TpmaSessionBuilder::new()
+            .with_flag(TPMA_SESSION_DECRYPT)
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        context
+            .tr_sess_set_attributes(trial_session, trial_session_attr)
+            .unwrap();
+
+        // There should be no errors setting an Or for a TRIAL session
+        context.policy_password(trial_session).unwrap();
+    }
+    #[test]
+    fn test_policy_nv_written() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                ESYS_TR_NONE,
+                ESYS_TR_NONE,
+                &[],
+                TPM2_SE_TRIAL,
+                utils::TpmtSymDefBuilder::aes_256_cfb(),
+                TPM2_ALG_SHA256,
+            )
+            .unwrap();
+        let trial_session_attr = TpmaSessionBuilder::new()
+            .with_flag(TPMA_SESSION_DECRYPT)
+            .with_flag(TPMA_SESSION_ENCRYPT)
+            .build();
+        context
+            .tr_sess_set_attributes(trial_session, trial_session_attr)
+            .unwrap();
+
+        // There should be no errors setting an Or for a TRIAL session
+        context.policy_nv_written(trial_session, true).unwrap();
     }
 }
 


### PR DESCRIPTION
This implements abstractions for almost all TPM2_Policy* commands.

The ones not implemented are:
- PolicyNV
- PolicyCounterTime
- PolicyDuplicationSelect
- PolicyTemplate
- PolicyAuthorizeNV

These weren't implemented because some of them require complicated structures
and others are not implemented in any of the TPMs I have available for testing.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>