### PR TITLE
Fix clippy errors

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1036,7 +1036,7 @@ impl Context {
                 self.sessions.2,
                 num_bytes
                     .try_into()
-                    .or_else(|_| Err(Error::local_error(ErrorKind::WrongParamSize)))?,
+                    .map_err(|_| Error::local_error(ErrorKind::WrongParamSize))?,
                 &mut buffer,
             )
         };

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -610,7 +610,6 @@ mod test_policies {
             )
             .unwrap()
             .0;
-        let ahash = Digest::try_from(ahash).unwrap();
 
         let scheme = TPMT_SIG_SCHEME {
             scheme: TPM2_ALG_NULL,


### PR DESCRIPTION
This fixes the Clippy errors that map_err is more succint than or_else
Err

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>