### PR TITLE
First step to support NV operations.

### DIFF
--- a/src/constants/tss.rs
+++ b/src/constants/tss.rs
@@ -368,6 +368,13 @@ pub const TPM2_CAP_ECC_CURVES: TPM2_CAP = 0x00000008; /* TPM2_ECC_CURVE1 */
 pub const TPM2_CAP_LAST: TPM2_CAP = 0x00000008;
 pub const TPM2_CAP_VENDOR_PROPERTY: TPM2_CAP = 0x00000100; /* manufacturer specific */
 
+pub const TPM2_NT_ORDINARY: TPM2_NT = 0x0; /* Ordinary – contains data that is opaque to the TPM that can only be modified using TPM2_NV_Write(). */
+pub const TPM2_NT_COUNTER: TPM2_NT = 0x1; /* Counter – contains an 8-octet value that is to be used as a counter and can only be modified with TPM2_NV_Increment() */
+pub const TPM2_NT_BITS: TPM2_NT = 0x2; /* Bit Field – contains an 8-octet value to be used as a bit field and can only be modified with TPM2_NV_SetBits(). */
+pub const TPM2_NT_EXTEND: TPM2_NT = 0x4; /* Extend – contains a digest-sized value used like a PCR. The Index can only be modified using TPM2_NV_Extend(). The extend will use the nameAlg of the Index. */
+pub const TPM2_NT_PIN_FAIL: TPM2_NT = 0x8; /* PIN Fail - contains pinCount that increments on a PIN authorization failure and a pinLimit. */
+pub const TPM2_NT_PIN_PASS: TPM2_NT = 0x9; /* PIN Pass - contains pinCount that increments on a PIN authorization success and a pinLimit. */
+
 pub const TPM2_PT_NONE: TPM2_PT = 0x00000000; /* indicates no property type */
 pub const TPM2_PT_GROUP: TPM2_PT = 0x00000100; /* The number of properties in each group. NOTE The first group with any properties is group 1 TPM2_PT_GROUP * 1. Group 0 is reserved. */
 pub const TPM2_PT_FIXED: TPM2_PT = TPM2_PT_GROUP * 1; /* the group of fixed properties returned as TPMS_TAGGED_PROPERTY. The values in this group are only changed due to a firmware change in the TPM. */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub mod algorithm;
 pub mod constants;
 mod context;
 mod error;
+pub mod nv;
 pub mod structures;
 mod tcti;
 pub mod utils;

--- a/src/nv/mod.rs
+++ b/src/nv/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module contains code that deals with the non volatile
+/// parts of the tpm.
+
+/// Non volatile storage module.
+pub mod storage;

--- a/src/nv/storage/authorization.rs
+++ b/src/nv/storage/authorization.rs
@@ -1,0 +1,64 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    tss2_esys::{ESYS_TR, ESYS_TR_RH_OWNER, ESYS_TR_RH_PLATFORM},
+    utils::Hierarchy,
+    Error, Result, WrapperErrorKind,
+};
+use log::error;
+use std::convert::{From, TryFrom};
+/// Enum representing the only type of authorizations
+/// allowed.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum NvAuthorization {
+    Owner,
+    Platform,
+}
+
+impl From<NvAuthorization> for Hierarchy {
+    fn from(nv_auhtorization: NvAuthorization) -> Hierarchy {
+        match nv_auhtorization {
+            NvAuthorization::Owner => Hierarchy::Owner,
+            NvAuthorization::Platform => Hierarchy::Platform,
+        }
+    }
+}
+
+impl TryFrom<Hierarchy> for NvAuthorization {
+    type Error = Error;
+
+    fn try_from(hierarchy: Hierarchy) -> Result<NvAuthorization> {
+        match hierarchy {
+            Hierarchy::Owner => Ok(NvAuthorization::Owner),
+            Hierarchy::Platform => Ok(NvAuthorization::Platform),
+            _ => {
+                error!("Error: Found invalid value when trying to convert Hierarchy to NV Authroization.");
+                Err(Error::local_error(WrapperErrorKind::InvalidParam))
+            }
+        }
+    }
+}
+
+impl From<NvAuthorization> for ESYS_TR {
+    fn from(nv_auhtorization: NvAuthorization) -> ESYS_TR {
+        match nv_auhtorization {
+            NvAuthorization::Owner => ESYS_TR_RH_OWNER,
+            NvAuthorization::Platform => ESYS_TR_RH_PLATFORM,
+        }
+    }
+}
+
+impl TryFrom<ESYS_TR> for NvAuthorization {
+    type Error = Error;
+
+    fn try_from(esys_tr: ESYS_TR) -> Result<NvAuthorization> {
+        match esys_tr {
+            ESYS_TR_RH_OWNER => Ok(NvAuthorization::Owner),
+            ESYS_TR_RH_PLATFORM => Ok(NvAuthorization::Platform),
+            _ => {
+                error!("Error: Found invalid value when trying parse NV Authroization");
+                Err(Error::local_error(WrapperErrorKind::InvalidParam))
+            }
+        }
+    }
+}

--- a/src/nv/storage/index.rs
+++ b/src/nv/storage/index.rs
@@ -1,0 +1,194 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    constants::tss::{
+        TPM2_HT_NV_INDEX, TPM2_NT_BITS, TPM2_NT_COUNTER, TPM2_NT_EXTEND, TPM2_NT_ORDINARY,
+        TPM2_NT_PIN_FAIL, TPM2_NT_PIN_PASS,
+    },
+    tss2_esys::{ESYS_TR, TPM2_NT, TPMA_NV, TPMI_RH_NV_INDEX},
+    Error, Result, WrapperErrorKind,
+};
+
+use bitfield::bitfield;
+use log::error;
+use std::convert::{From, TryFrom};
+
+///
+/// Struct representing the NvIndex.
+///
+/// The NvIndex is a TPM handle and it must
+/// have a most significant octet that is
+/// equal to TPM_HT_NV_INDEX.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct NvIndex {
+    value: u32,
+}
+
+impl NvIndex {
+    /// Creates index using the specified value.
+    ///
+    /// # Errors
+    /// * If `value` does not have a most significant octet
+    ///   that is equal to TPM_HT_NV_INDEX an `InvalidParam`
+    ///   error is returned.
+    pub fn create_from_value(value: u32) -> Result<Self> {
+        let most_significant_octet = value.to_be_bytes()[0];
+        if most_significant_octet != TPM2_HT_NV_INDEX {
+            error!(
+                "Error: Value has invalid most significant octet(={})",
+                most_significant_octet
+            );
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(NvIndex { value })
+    }
+
+    /// Creates an index from an offset of the
+    /// TPM_HT_NV_INDEX.
+    ///
+    /// # Errors
+    /// * If the offset is greater 16 777 215 (i.e. most
+    ///   significant octet is not 0) an `InvalidParam`
+    ///   error is returned.
+    pub fn create_from_offset(offset: u32) -> Result<Self> {
+        let mut nv_index_be_bytes = offset.to_be_bytes();
+        // Check that ha value is not to big.
+        let most_significant_octet = nv_index_be_bytes[0];
+        if most_significant_octet != 0 {
+            error!("Error: Offset is to big (> 16777215)");
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        // Add the correct most significant octet for Nv Index.
+        nv_index_be_bytes[0] = TPM2_HT_NV_INDEX;
+        Ok(NvIndex {
+            value: u32::from_be_bytes(nv_index_be_bytes),
+        })
+    }
+}
+
+impl TryFrom<TPMI_RH_NV_INDEX> for NvIndex {
+    type Error = Error;
+    fn try_from(tss_nv_index: TPMI_RH_NV_INDEX) -> Result<NvIndex> {
+        NvIndex::create_from_value(tss_nv_index)
+    }
+}
+
+impl From<NvIndex> for TPMI_RH_NV_INDEX {
+    fn from(nv_index: NvIndex) -> TPMI_RH_NV_INDEX {
+        nv_index.value
+    }
+}
+
+/// Represents the esys handled used for referencing
+/// the nv index.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct NvIndexHandle {
+    value: u32,
+}
+
+impl From<ESYS_TR> for NvIndexHandle {
+    fn from(esys_resource_handle: ESYS_TR) -> NvIndexHandle {
+        NvIndexHandle {
+            value: esys_resource_handle,
+        }
+    }
+}
+
+impl From<NvIndexHandle> for ESYS_TR {
+    fn from(nv_index_handle: NvIndexHandle) -> ESYS_TR {
+        nv_index_handle.value
+    }
+}
+
+/// Enum with values representing the NV index type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum NvIndexType {
+    Ordinary,
+    Counter,
+    Bits,
+    Extend,
+    PinFail,
+    PinPass,
+}
+
+impl From<NvIndexType> for TPM2_NT {
+    fn from(nv_index_type: NvIndexType) -> TPM2_NT {
+        match nv_index_type {
+            NvIndexType::Ordinary => TPM2_NT_ORDINARY,
+            NvIndexType::Counter => TPM2_NT_COUNTER,
+            NvIndexType::Bits => TPM2_NT_BITS,
+            NvIndexType::Extend => TPM2_NT_EXTEND,
+            NvIndexType::PinFail => TPM2_NT_PIN_FAIL,
+            NvIndexType::PinPass => TPM2_NT_PIN_PASS,
+        }
+    }
+}
+
+impl TryFrom<TPM2_NT> for NvIndexType {
+    type Error = Error;
+    fn try_from(tss_nv_index_type: TPM2_NT) -> Result<NvIndexType> {
+        match tss_nv_index_type {
+            TPM2_NT_ORDINARY => Ok(NvIndexType::Ordinary),
+            TPM2_NT_COUNTER => Ok(NvIndexType::Counter),
+            TPM2_NT_BITS => Ok(NvIndexType::Bits),
+            TPM2_NT_EXTEND => Ok(NvIndexType::Extend),
+            TPM2_NT_PIN_FAIL => Ok(NvIndexType::PinFail),
+            TPM2_NT_PIN_PASS => Ok(NvIndexType::PinPass),
+            _ => {
+                error!("Error: Found invalid value when trying to parse Nv Index Type.");
+                Err(Error::local_error(WrapperErrorKind::InvalidParam))
+            }
+        }
+    }
+}
+
+bitfield! {
+    /// Bitfield representing the nv index attributes.
+    #[derive(Copy, Clone, Eq, PartialEq)]
+    pub struct NvIndexAttributes(TPMA_NV);
+    impl Debug;
+    // NV Index Attributes
+    pub pp_write, set_pp_write: 0;
+    pub owner_write, set_owner_write: 1;
+    pub auth_write, set_auth_write: 2;
+    pub policy_write, set_policy_write: 3;
+    TPM2_NT, tss_index_type, _: 7, 4; // private getter
+    pub TPM2_NT, from into NvIndexType, _, set_index_type: 7, 4;
+    // Reserved 9,8
+    pub policy_delete, set_policy_delete: 10;
+    pub write_locked, set_write_locked: 11;
+    pub write_all, set_write_all: 12;
+    pub write_define, set_write_define: 13;
+    pub write_stclear, set_write_stclear: 14;
+    pub global_lock, set_global_lock: 15;
+    pub pp_read, set_pp_read: 16;
+    pub owner_read, set_owner_read: 17;
+    pub auth_read, set_auth_read: 18;
+    pub policy_read, set_policy_read: 19;
+    // Reserved 24, 20
+    pub no_da, set_no_da: 25;
+    pub orderly, set_orderly: 26;
+    pub clear_stclear, set_clear_stclear: 27;
+    pub read_locked, set_read_locked: 28;
+    pub written, set_written: 29;
+    pub platform_create, set_platform_create: 30;
+    pub read_stclear, set_read_stclear: 31;
+}
+
+impl NvIndexAttributes {
+    pub fn index_type(&self) -> Result<NvIndexType> {
+        NvIndexType::try_from(self.tss_index_type())
+    }
+}
+
+impl From<TPMA_NV> for NvIndexAttributes {
+    fn from(tss_nv_index_atttributes: TPMA_NV) -> NvIndexAttributes {
+        NvIndexAttributes(tss_nv_index_atttributes)
+    }
+}
+
+impl From<NvIndexAttributes> for TPMA_NV {
+    fn from(nv_index_atttributes: NvIndexAttributes) -> TPMA_NV {
+        nv_index_atttributes.0
+    }
+}

--- a/src/nv/storage/mod.rs
+++ b/src/nv/storage/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module conatins code that deaals with non volatile storage
+/// in the TPM.
+///
+pub use authorization::NvAuthorization;
+pub use index::{NvIndex, NvIndexAttributes, NvIndexHandle, NvIndexType};
+pub use public::{NvPublic, NvPublicBuilder};
+
+mod authorization;
+mod index;
+mod public;

--- a/src/nv/storage/public.rs
+++ b/src/nv/storage/public.rs
@@ -1,0 +1,172 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    constants::algorithm::HashingAlgorithm,
+    nv::storage::{NvIndex, NvIndexAttributes},
+    structures::Digest,
+    tss2_esys::{TPM2B_NV_PUBLIC, TPMS_NV_PUBLIC},
+    Error, Result, WrapperErrorKind,
+};
+use log::error;
+use std::convert::{TryFrom, TryInto};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NvPublic {
+    nv_index: NvIndex,
+    name_algorithm: HashingAlgorithm,
+    attributes: NvIndexAttributes,
+    authorization_policy: Digest,
+    data_size: usize,
+}
+
+impl NvPublic {
+    const MAX_SIZE: usize = std::mem::size_of::<TPMS_NV_PUBLIC>();
+
+    pub fn nv_index(&self) -> NvIndex {
+        self.nv_index
+    }
+
+    pub fn name_algorithm(&self) -> HashingAlgorithm {
+        self.name_algorithm
+    }
+
+    pub fn attributes(&self) -> NvIndexAttributes {
+        self.attributes
+    }
+
+    pub fn authorization_policy(&self) -> &Digest {
+        &self.authorization_policy
+    }
+
+    pub fn data_size(&self) -> usize {
+        self.data_size
+    }
+}
+
+impl TryFrom<TPM2B_NV_PUBLIC> for NvPublic {
+    type Error = Error;
+    fn try_from(tss_nv_public: TPM2B_NV_PUBLIC) -> Result<NvPublic> {
+        if tss_nv_public.size as usize > NvPublic::MAX_SIZE {
+            error!("Error: Encounted an invalid size of the TPMS_NV_PUBLIC.");
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        // Parse actual data
+        Ok(NvPublic {
+            nv_index: tss_nv_public.nvPublic.nvIndex.try_into()?,
+            name_algorithm: tss_nv_public.nvPublic.nameAlg.try_into()?,
+            attributes: tss_nv_public.nvPublic.attributes.into(),
+            authorization_policy: tss_nv_public.nvPublic.authPolicy.try_into()?,
+            data_size: tss_nv_public.nvPublic.dataSize as usize,
+        })
+    }
+}
+
+impl TryFrom<NvPublic> for TPM2B_NV_PUBLIC {
+    type Error = Error;
+    fn try_from(nv_public: NvPublic) -> Result<TPM2B_NV_PUBLIC> {
+        Ok(TPM2B_NV_PUBLIC {
+            // Will be ignored due to being a complex TPM2B type
+            // The marshalling functionality in TSS will calculate
+            // the correct value.
+            size: 0,
+            nvPublic: TPMS_NV_PUBLIC {
+                nvIndex: nv_public.nv_index.into(),
+                nameAlg: nv_public.name_algorithm.into(),
+                attributes: nv_public.attributes.into(),
+                authPolicy: nv_public.authorization_policy.try_into()?,
+                dataSize: nv_public.data_size as u16,
+            },
+        })
+    }
+}
+
+/// Builder for NvPublic.
+///
+///
+#[derive(Debug, Default)]
+pub struct NvPublicBuilder {
+    nv_index: Option<NvIndex>,
+    name_algorithm: Option<HashingAlgorithm>,
+    attributes: Option<NvIndexAttributes>,
+    authorization_policy: Option<Digest>,
+    data_size: Option<usize>,
+}
+
+impl NvPublicBuilder {
+    pub fn new() -> Self {
+        NvPublicBuilder {
+            nv_index: None,
+            name_algorithm: None,
+            attributes: None,
+            authorization_policy: None,
+            data_size: None,
+        }
+    }
+
+    pub fn with_nv_index(mut self, nv_index: NvIndex) -> Self {
+        self.nv_index = Some(nv_index);
+        self
+    }
+
+    pub fn with_index_name_algorithm(mut self, nv_index_name_algorithm: HashingAlgorithm) -> Self {
+        self.name_algorithm = Some(nv_index_name_algorithm);
+        self
+    }
+
+    pub fn with_index_attributes(mut self, nv_index_attributes: NvIndexAttributes) -> Self {
+        self.attributes = Some(nv_index_attributes);
+        self
+    }
+
+    pub fn with_index_auth_policy(mut self, nv_index_auth_policy: &Digest) -> Self {
+        self.authorization_policy = Some(nv_index_auth_policy.clone());
+        self
+    }
+
+    pub fn with_data_area_size(mut self, nv_index_data_area_size: usize) -> Self {
+        self.data_size = Some(nv_index_data_area_size);
+        self
+    }
+
+    pub fn build(self) -> Result<NvPublic> {
+        // TODO: Do some clever checking of the values in
+        // order to determine some defaults values when
+        // some params have not been specified.
+        //
+
+        Ok(NvPublic {
+            // Nv Index
+            nv_index: self.nv_index.ok_or_else(|| {
+                error!("Error: No NV index was specified.");
+                Error::local_error(WrapperErrorKind::ParamsMissing)
+            })?,
+            // Hashing algorithm for the name of index
+            name_algorithm: self.name_algorithm.ok_or_else(|| {
+                error!("Error: No name algorithm was specified.");
+                Error::local_error(WrapperErrorKind::ParamsMissing)
+            })?,
+            // Index attributes
+            attributes: self.attributes.ok_or_else(|| {
+                error!("Error: No attributes were specified.");
+                Error::local_error(WrapperErrorKind::ParamsMissing)
+            })?,
+            // Index Auth policy
+            authorization_policy: self.authorization_policy.unwrap_or_default(),
+            // Size of the data area of the index
+            data_size: self
+                .data_size
+                .ok_or_else(|| {
+                    error!("Error: No attributes were specified.");
+                    Error::local_error(WrapperErrorKind::ParamsMissing)
+                })
+                .and_then(|v| {
+                    if v > std::u16::MAX.into() {
+                        error!("Error: data area size is to large(>{})", std::u16::MAX);
+                        return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+                    }
+                    Ok(v)
+                })?,
+        })
+    }
+}

--- a/src/structures/buffers/max_nv.rs
+++ b/src/structures/buffers/max_nv.rs
@@ -1,0 +1,73 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::tss2_esys::{TPM2B_MAX_NV_BUFFER, TPM2_MAX_NV_BUFFER_SIZE};
+use crate::{Error, Result, WrapperErrorKind};
+use log::error;
+use std::convert::TryFrom;
+/// Struct holding a max buffer value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaxNvBuffer {
+    value: Vec<u8>,
+}
+
+impl MaxNvBuffer {
+    const MAX_SIZE: usize = TPM2_MAX_NV_BUFFER_SIZE as usize;
+    pub fn value(&self) -> &[u8] {
+        &self.value
+    }
+}
+
+impl Default for MaxNvBuffer {
+    fn default() -> Self {
+        MaxNvBuffer {
+            value: Vec::<u8>::new(),
+        }
+    }
+}
+
+impl TryFrom<Vec<u8>> for MaxNvBuffer {
+    type Error = Error;
+    fn try_from(bytes: Vec<u8>) -> Result<Self> {
+        if bytes.len() > MaxNvBuffer::MAX_SIZE {
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        Ok(MaxNvBuffer { value: bytes })
+    }
+}
+
+impl TryFrom<TPM2B_MAX_NV_BUFFER> for MaxNvBuffer {
+    type Error = Error;
+    fn try_from(tss_max_nv_buffer: TPM2B_MAX_NV_BUFFER) -> Result<Self> {
+        let size = tss_max_nv_buffer.size as usize;
+        if size > MaxNvBuffer::MAX_SIZE {
+            error!(
+                "Error: Invalid TPM2B_MAX_NV_BUFFER size(> {})",
+                MaxNvBuffer::MAX_SIZE
+            );
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        Ok(MaxNvBuffer {
+            value: tss_max_nv_buffer.buffer[..size].to_vec(),
+        })
+    }
+}
+
+impl TryFrom<MaxNvBuffer> for TPM2B_MAX_NV_BUFFER {
+    type Error = Error;
+    fn try_from(max_nv_buffer: MaxNvBuffer) -> Result<Self> {
+        if max_nv_buffer.value.len() > MaxNvBuffer::MAX_SIZE {
+            error!(
+                "Error: Invalid MaxNvBuffer size(> {})",
+                MaxNvBuffer::MAX_SIZE
+            );
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        let mut tss_max_nv_buffer: TPM2B_MAX_NV_BUFFER = Default::default();
+        if !max_nv_buffer.value.is_empty() {
+            tss_max_nv_buffer.size = max_nv_buffer.value().len() as u16;
+            tss_max_nv_buffer.buffer[..max_nv_buffer.value().len()]
+                .copy_from_slice(&max_nv_buffer.value());
+        }
+        Ok(tss_max_nv_buffer)
+    }
+}

--- a/src/structures/buffers/mod.rs
+++ b/src/structures/buffers/mod.rs
@@ -4,5 +4,6 @@ pub mod auth;
 pub mod data;
 pub mod digest;
 pub mod max;
+pub mod max_nv;
 pub mod nonce;
 pub mod publickeyrsa;

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -38,6 +38,11 @@ pub mod max_buffer {
     pub use super::buffers::max::*;
 }
 
+pub use self::max_nv_buffer::MaxNvBuffer;
+pub mod max_nv_buffer {
+    pub use super::buffers::max_nv::*;
+}
+
 pub use self::data_buffer::Data;
 pub mod data_buffer {
     pub use super::buffers::data::*;

--- a/tests/nv_storage_nv_index_attributes_tests.rs
+++ b/tests/nv_storage_nv_index_attributes_tests.rs
@@ -1,0 +1,137 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use tss_esapi::nv::storage::{NvIndexAttributes, NvIndexType};
+
+mod test_nv_storage_nv_index_attributes {
+    use super::*;
+
+    #[test]
+    fn test_invalid_index_type_value() {
+        // 15(1111) - invalid
+        let invalid_15 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_1111_0000u32);
+        let _ = invalid_15.index_type().unwrap_err();
+
+        // 14(1110) - invalid
+        let invalid_14 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_1110_0000u32);
+        let _ = invalid_14.index_type().unwrap_err();
+
+        // 13(1101) - invalid
+        let invalid_13 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_1101_0000u32);
+        let _ = invalid_13.index_type().unwrap_err();
+
+        // 12(1100) - invalid
+        let invalid_12 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_1100_0000u32);
+        let _ = invalid_12.index_type().unwrap_err();
+
+        // 11(1011) - invalid
+        let invalid_11 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_1011_0000u32);
+        let _ = invalid_11.index_type().unwrap_err();
+
+        // 10(1010) - invalid
+        let invalid_10 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_1011_0000u32);
+        let _ = invalid_10.index_type().unwrap_err();
+
+        // 9(1001) - Valid
+
+        // 8(1000) - Valid
+
+        // 7(0111) - invalid
+        let invalid_7 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_0111_0000u32);
+        let _ = invalid_7.index_type().unwrap_err();
+
+        // 6(0110) - invalid
+        let invalid_6 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_0110_0000u32);
+        let _ = invalid_6.index_type().unwrap_err();
+
+        // 5(0101) - invalid
+        let invalid_5 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_0101_0000u32);
+        let _ = invalid_5.index_type().unwrap_err();
+
+        // 4(0100) - valid
+
+        // 3(0011) - invalid
+        let invalid_3 = NvIndexAttributes(0b0000_0000_0000_0000_0000_0000_0011_0000u32);
+        let _ = invalid_3.index_type().unwrap_err();
+
+        // 2(0010) - valid
+
+        // 1(0001) - valid
+
+        // 0(0000) - valid
+    }
+
+    #[test]
+    fn test_attributes() {
+        let mut attributes = NvIndexAttributes(0x0);
+
+        attributes.set_pp_write(true);
+        assert_eq!(0b0000_0000_0000_0000_0000_0000_0000_0001u32, attributes.0);
+
+        attributes.set_owner_write(true);
+        assert_eq!(0b0000_0000_0000_0000_0000_0000_0000_0011u32, attributes.0);
+
+        attributes.set_auth_write(true);
+        assert_eq!(0b0000_0000_0000_0000_0000_0000_0000_0111u32, attributes.0);
+
+        attributes.set_policy_write(true);
+        assert_eq!(0b0000_0000_0000_0000_0000_0000_0000_1111u32, attributes.0);
+
+        // PinPass = 1001 (7,4)
+        attributes.set_index_type(NvIndexType::PinPass);
+        assert_eq!(0b0000_0000_0000_0000_0000_0000_1001_1111u32, attributes.0);
+        assert_eq!(NvIndexType::PinPass, attributes.index_type().unwrap());
+
+        // (8,9 Reserved)
+        attributes.set_policy_delete(true);
+        assert_eq!(0b0000_0000_0000_0000_0000_0100_1001_1111u32, attributes.0);
+
+        attributes.set_write_locked(true);
+        assert_eq!(0b0000_0000_0000_0000_0000_1100_1001_1111u32, attributes.0);
+
+        attributes.set_write_all(true);
+        assert_eq!(0b0000_0000_0000_0000_0001_1100_1001_1111u32, attributes.0);
+
+        attributes.set_write_define(true);
+        assert_eq!(0b0000_0000_0000_0000_0011_1100_1001_1111u32, attributes.0);
+
+        attributes.set_write_stclear(true);
+        assert_eq!(0b0000_0000_0000_0000_0111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_global_lock(true);
+        assert_eq!(0b0000_0000_0000_0000_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_pp_read(true);
+        assert_eq!(0b0000_0000_0000_0001_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_owner_read(true);
+        assert_eq!(0b0000_0000_0000_0011_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_auth_read(true);
+        assert_eq!(0b0000_0000_0000_0111_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_policy_read(true);
+        assert_eq!(0b0000_0000_0000_1111_1111_1100_1001_1111u32, attributes.0);
+
+        // Reserved (24, 20)
+        attributes.set_no_da(true);
+        assert_eq!(0b0000_0010_0000_1111_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_orderly(true);
+        assert_eq!(0b0000_0110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_clear_stclear(true);
+        assert_eq!(0b0000_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_read_locked(true);
+        assert_eq!(0b0001_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_written(true);
+        assert_eq!(0b0011_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_platform_create(true);
+        assert_eq!(0b0111_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+
+        attributes.set_read_stclear(true);
+        assert_eq!(0b1111_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+    }
+}

--- a/tests/nv_storage_nv_index_type_tests.rs
+++ b/tests/nv_storage_nv_index_type_tests.rs
@@ -1,0 +1,57 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use tss_esapi::{
+    constants::tss::{
+        TPM2_NT_BITS, TPM2_NT_COUNTER, TPM2_NT_EXTEND, TPM2_NT_ORDINARY, TPM2_NT_PIN_FAIL,
+        TPM2_NT_PIN_PASS,
+    },
+    nv::storage::NvIndexType,
+    tss2_esys::TPM2_NT,
+};
+
+use std::convert::{From, TryFrom};
+
+mod test_nv_storage_nv_index_type {
+    use super::*;
+
+    #[test]
+    fn test_conversion_to_tss_type() {
+        assert_eq!(TPM2_NT_ORDINARY, TPM2_NT::from(NvIndexType::Ordinary));
+        assert_eq!(TPM2_NT_COUNTER, TPM2_NT::from(NvIndexType::Counter));
+        assert_eq!(TPM2_NT_BITS, TPM2_NT::from(NvIndexType::Bits));
+        assert_eq!(TPM2_NT_EXTEND, TPM2_NT::from(NvIndexType::Extend));
+        assert_eq!(TPM2_NT_PIN_FAIL, TPM2_NT::from(NvIndexType::PinFail));
+        assert_eq!(TPM2_NT_PIN_PASS, TPM2_NT::from(NvIndexType::PinPass));
+    }
+
+    #[test]
+    fn test_conversion_from_tss_type() {
+        assert_eq!(
+            NvIndexType::Ordinary,
+            NvIndexType::try_from(TPM2_NT_ORDINARY).unwrap()
+        );
+        assert_eq!(
+            NvIndexType::Counter,
+            NvIndexType::try_from(TPM2_NT_COUNTER).unwrap()
+        );
+        assert_eq!(
+            NvIndexType::Bits,
+            NvIndexType::try_from(TPM2_NT_BITS).unwrap()
+        );
+        assert_eq!(
+            NvIndexType::Extend,
+            NvIndexType::try_from(TPM2_NT_EXTEND).unwrap()
+        );
+        assert_eq!(
+            NvIndexType::PinFail,
+            NvIndexType::try_from(TPM2_NT_PIN_FAIL).unwrap()
+        );
+        assert_eq!(
+            NvIndexType::PinPass,
+            NvIndexType::try_from(TPM2_NT_PIN_PASS).unwrap()
+        );
+
+        const INVALID_VALUE: TPM2_NT = 15;
+        let _ = NvIndexType::try_from(INVALID_VALUE).unwrap_err();
+    }
+}


### PR DESCRIPTION
This is a first step in order to add support for non volatile storage in the TPM(#102).

- Added folder src/nv (Non volatile).
- Added folder src/nv/storage (Non volatile storage).
- Added file index.rs to src/nv/storage:
  This file contains NvIndex, NvIndexType, NvIndexHandle, and NvIndexAttributes types.
- Added file public.rs to src/nv/storage:
  This file contains the NvPublic, NvPublicBuilder types.
- Added file authorization.rs to src/nv/storage:
  This file contains the NvAuthroization type.
- Added file max_nv.rs to src/structures/buffers:
  This file contains the MaxNvBuffer type.
- Added Context APIs:
    -- nv_define_space
    -- nv_undefine_space
    -- nv_read_public
    -- nv_read
    -- nv_write

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>