### PR TITLE
Added rust types for handles.

### DIFF
--- a/src/constants/tss.rs
+++ b/src/constants/tss.rs
@@ -491,6 +491,7 @@ pub const TPM2_HT_SAVED_SESSION: TPM2_HT = 0x03; /* Saved Authorization Session 
 pub const TPM2_HT_PERMANENT: TPM2_HT = 0x40; /* Permanent Values  assigned by this specification in */
 pub const TPM2_HT_TRANSIENT: TPM2_HT = 0x80; /* Transient Objects  assigned by the TPM when an object is loaded into transient object memory or when a persistent object is converted to a transient object */
 pub const TPM2_HT_PERSISTENT: TPM2_HT = 0x81; /* Persistent Objects  assigned by the TPM when a loaded transient object is made persistent */
+pub const TPM2_HT_AC: TPM2_HT = 0x90; /* Attached Component – handle for an Attached Component. */
 
 pub const TPM2_RH_FIRST: TPM2_RH = 0x40000000; /* R */
 pub const TPM2_RH_SRK: TPM2_RH = 0x40000000; /* R */

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::algorithm::structures::SensitiveData;
 use crate::constants::algorithm::HashingAlgorithm;
-use crate::nv::storage::{NvAuthorization, NvIndexHandle, NvPublic};
+use crate::handles::esys::NvIndexHandle;
+use crate::nv::storage::{NvAuthorization, NvPublic};
 use crate::structures::{
     Auth, Data, Digest, DigestList, HashcheckTicket, MaxBuffer, MaxNvBuffer, Name, Nonce,
     PcrSelectionList, PublicKeyRSA,

--- a/src/handles/esys.rs
+++ b/src/handles/esys.rs
@@ -1,0 +1,62 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::tss2_esys::ESYS_TR;
+use std::convert::From;
+
+/// Representation of the most general handle
+/// that is used to access esys resources.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ObjectHandle {
+    value: u32,
+}
+
+impl From<ESYS_TR> for ObjectHandle {
+    fn from(esys_object_handle: ESYS_TR) -> ObjectHandle {
+        ObjectHandle {
+            value: esys_object_handle,
+        }
+    }
+}
+
+impl From<ObjectHandle> for ESYS_TR {
+    fn from(object_handle: ObjectHandle) -> ESYS_TR {
+        object_handle.value
+    }
+}
+
+/// Represents a specific esys object handle
+/// used for referencing a nv index.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct NvIndexHandle {
+    value: u32,
+}
+
+impl From<ObjectHandle> for NvIndexHandle {
+    fn from(object_handle: ObjectHandle) -> NvIndexHandle {
+        NvIndexHandle {
+            value: object_handle.value,
+        }
+    }
+}
+
+impl From<NvIndexHandle> for ObjectHandle {
+    fn from(nv_index_handle: NvIndexHandle) -> ObjectHandle {
+        ObjectHandle {
+            value: nv_index_handle.value,
+        }
+    }
+}
+
+impl From<ESYS_TR> for NvIndexHandle {
+    fn from(esys_resource_handle: ESYS_TR) -> NvIndexHandle {
+        NvIndexHandle {
+            value: esys_resource_handle,
+        }
+    }
+}
+
+impl From<NvIndexHandle> for ESYS_TR {
+    fn from(nv_index_handle: NvIndexHandle) -> ESYS_TR {
+        nv_index_handle.value
+    }
+}

--- a/src/handles/mod.rs
+++ b/src/handles/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module that contains the different types of handles
+/// that the ESAPI and the TPM uses in order to provide
+/// access to objects that was or has been created.
+pub mod esys;
+pub mod tpm;

--- a/src/handles/tpm.rs
+++ b/src/handles/tpm.rs
@@ -1,0 +1,181 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    constants::tss::{
+        TPM2_HT_AC, TPM2_HT_HMAC_SESSION, TPM2_HT_LOADED_SESSION, TPM2_HT_NV_INDEX, TPM2_HT_PCR,
+        TPM2_HT_PERMANENT, TPM2_HT_PERSISTENT, TPM2_HT_POLICY_SESSION, TPM2_HT_SAVED_SESSION,
+        TPM2_HT_TRANSIENT,
+    },
+    tss2_esys::TPM2_HANDLE,
+    Error, Result, WrapperErrorKind,
+};
+use log::error;
+use std::convert::{From, TryFrom};
+use std::stringify;
+
+/// Enum representing the different types of tpm handles
+/// of a TPM handle.
+///
+/// * Details
+/// The TPM handles are used
+/// to reference shielded locations of various
+/// types within the TPM.
+///
+/// * OBS
+/// Do not confuse the TpmHandles with the
+/// ESYS [ObjectHandle](crate::handles::esys::ObjectHandle).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum TpmHandle {
+    Pcr(PcrTpmHandle),
+    NvIndex(NvIndexTpmHandle),
+    HmacSession(HmacSessionTpmHandle),
+    LoadedSession(LoadedSessionTpmHandle),
+    PolicySession(PolicySessionTpmHandle),
+    SavedSession(SavedSessionTpmHandle),
+    Permanent(PermanentTpmHandle),
+    Transient(TransientTpmHandle),
+    Persistent(PersistentTpmHandle),
+    Ac(AcTpmHandle),
+}
+
+impl From<TpmHandle> for TPM2_HANDLE {
+    fn from(tpm_handle: TpmHandle) -> TPM2_HANDLE {
+        match tpm_handle {
+            TpmHandle::Pcr(handle) => handle.value,
+            TpmHandle::NvIndex(handle) => handle.value,
+            TpmHandle::HmacSession(handle) => handle.value,
+            TpmHandle::LoadedSession(handle) => handle.value,
+            TpmHandle::PolicySession(handle) => handle.value,
+            TpmHandle::SavedSession(handle) => handle.value,
+            TpmHandle::Permanent(handle) => handle.value,
+            TpmHandle::Transient(handle) => handle.value,
+            TpmHandle::Persistent(handle) => handle.value,
+            TpmHandle::Ac(handle) => handle.value,
+        }
+    }
+}
+
+impl TryFrom<TPM2_HANDLE> for TpmHandle {
+    type Error = Error;
+    fn try_from(tss_tpm_handle: TPM2_HANDLE) -> Result<TpmHandle> {
+        let most_significant_byte = tss_tpm_handle.to_be_bytes()[0];
+        match most_significant_byte {
+            TPM2_HT_PCR => Ok(TpmHandle::Pcr(PcrTpmHandle::new(tss_tpm_handle)?)),
+            TPM2_HT_NV_INDEX => Ok(TpmHandle::NvIndex(NvIndexTpmHandle::new(tss_tpm_handle)?)),
+            TPM2_HT_HMAC_SESSION => Ok(TpmHandle::HmacSession(HmacSessionTpmHandle::new(
+                tss_tpm_handle,
+            )?)),
+            // HMAC and LOADED has the same type id
+            TPM2_HT_POLICY_SESSION => Ok(TpmHandle::PolicySession(PolicySessionTpmHandle::new(
+                tss_tpm_handle,
+            )?)),
+            // POLICY and SAVED has the same type id.
+            TPM2_HT_PERMANENT => Ok(TpmHandle::Permanent(PermanentTpmHandle::new(
+                tss_tpm_handle,
+            )?)),
+            TPM2_HT_TRANSIENT => Ok(TpmHandle::Transient(TransientTpmHandle::new(
+                tss_tpm_handle,
+            )?)),
+            TPM2_HT_PERSISTENT => Ok(TpmHandle::Persistent(PersistentTpmHandle::new(
+                tss_tpm_handle,
+            )?)),
+            TPM2_HT_AC => Ok(TpmHandle::Ac(AcTpmHandle::new(tss_tpm_handle)?)),
+            _ => {
+                error!("Error: Invalid TPM handle type {}", most_significant_byte);
+                Err(Error::local_error(WrapperErrorKind::InvalidParam))
+            }
+        }
+    }
+}
+
+/// Macro for creating the specific TPM handle types
+macro_rules! create_tpm_handle_type {
+    ($handle_type_name:ident, $tpm_handle_kind:path, $tpm_handle_type_id:tt) => {
+        #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+        pub struct $handle_type_name {
+            value: u32,
+        }
+
+        impl $handle_type_name {
+            pub fn new(value: u32) -> Result<$handle_type_name> {
+                if value.to_be_bytes()[0] != $tpm_handle_type_id {
+                    error!(
+                        "Errro: TPM Handle ID of the input value did not match the {} (!={})",
+                        stringify!($handle_type_name),
+                        $tpm_handle_type_id
+                    );
+                    return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+                }
+                Ok($handle_type_name { value })
+            }
+        }
+
+        impl From<$handle_type_name> for TpmHandle {
+            fn from(specific_tpm_handle: $handle_type_name) -> TpmHandle {
+                $tpm_handle_kind(specific_tpm_handle)
+            }
+        }
+
+        impl TryFrom<TpmHandle> for $handle_type_name {
+            type Error = Error;
+            fn try_from(general_tpm_handle: TpmHandle) -> Result<$handle_type_name> {
+                match general_tpm_handle {
+                    $tpm_handle_kind(val) => Ok(val),
+                    _ => {
+                        error!(
+                            "Error: Incorrect tpm handle kind(=={}) when converting to {}",
+                            stringify!($tpm_handle_kind),
+                            stringify!($handle_type_name)
+                        );
+                        return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+                    }
+                }
+            }
+        }
+
+        impl From<$handle_type_name> for TPM2_HANDLE {
+            fn from(specific_tpm_handle: $handle_type_name) -> TPM2_HANDLE {
+                specific_tpm_handle.value
+            }
+        }
+
+        impl TryFrom<TPM2_HANDLE> for $handle_type_name {
+            type Error = Error;
+            fn try_from(tss_tpm_handle: TPM2_HANDLE) -> Result<$handle_type_name> {
+                $handle_type_name::new(tss_tpm_handle)
+            }
+        }
+    };
+}
+
+// Creates the specific handle types
+create_tpm_handle_type!(PcrTpmHandle, TpmHandle::Pcr, TPM2_HT_PCR);
+create_tpm_handle_type!(NvIndexTpmHandle, TpmHandle::NvIndex, TPM2_HT_NV_INDEX);
+create_tpm_handle_type!(
+    HmacSessionTpmHandle,
+    TpmHandle::HmacSession,
+    TPM2_HT_HMAC_SESSION
+);
+create_tpm_handle_type!(
+    LoadedSessionTpmHandle,
+    TpmHandle::LoadedSession,
+    TPM2_HT_LOADED_SESSION
+);
+create_tpm_handle_type!(
+    PolicySessionTpmHandle,
+    TpmHandle::PolicySession,
+    TPM2_HT_POLICY_SESSION
+);
+create_tpm_handle_type!(
+    SavedSessionTpmHandle,
+    TpmHandle::SavedSession,
+    TPM2_HT_SAVED_SESSION
+);
+create_tpm_handle_type!(PermanentTpmHandle, TpmHandle::Permanent, TPM2_HT_PERMANENT);
+create_tpm_handle_type!(TransientTpmHandle, TpmHandle::Transient, TPM2_HT_TRANSIENT);
+create_tpm_handle_type!(
+    PersistentTpmHandle,
+    TpmHandle::Persistent,
+    TPM2_HT_PERSISTENT
+);
+create_tpm_handle_type!(AcTpmHandle, TpmHandle::Ac, TPM2_HT_AC);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub mod algorithm;
 pub mod constants;
 mod context;
 mod error;
+pub mod handles;
 pub mod nv;
 pub mod structures;
 mod tcti;

--- a/src/nv/storage/mod.rs
+++ b/src/nv/storage/mod.rs
@@ -5,7 +5,7 @@
 /// in the TPM.
 ///
 pub use authorization::NvAuthorization;
-pub use index::{NvIndex, NvIndexAttributes, NvIndexHandle, NvIndexType};
+pub use index::{NvIndexAttributes, NvIndexType};
 pub use public::{NvPublic, NvPublicBuilder};
 
 mod authorization;

--- a/src/nv/storage/public.rs
+++ b/src/nv/storage/public.rs
@@ -3,7 +3,8 @@
 
 use crate::{
     constants::algorithm::HashingAlgorithm,
-    nv::storage::{NvIndex, NvIndexAttributes},
+    handles::tpm::NvIndexTpmHandle,
+    nv::storage::NvIndexAttributes,
     structures::Digest,
     tss2_esys::{TPM2B_NV_PUBLIC, TPMS_NV_PUBLIC},
     Error, Result, WrapperErrorKind,
@@ -13,7 +14,7 @@ use std::convert::{TryFrom, TryInto};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NvPublic {
-    nv_index: NvIndex,
+    nv_index: NvIndexTpmHandle,
     name_algorithm: HashingAlgorithm,
     attributes: NvIndexAttributes,
     authorization_policy: Digest,
@@ -23,7 +24,7 @@ pub struct NvPublic {
 impl NvPublic {
     const MAX_SIZE: usize = std::mem::size_of::<TPMS_NV_PUBLIC>();
 
-    pub fn nv_index(&self) -> NvIndex {
+    pub fn nv_index(&self) -> NvIndexTpmHandle {
         self.nv_index
     }
 
@@ -86,7 +87,7 @@ impl TryFrom<NvPublic> for TPM2B_NV_PUBLIC {
 ///
 #[derive(Debug, Default)]
 pub struct NvPublicBuilder {
-    nv_index: Option<NvIndex>,
+    nv_index: Option<NvIndexTpmHandle>,
     name_algorithm: Option<HashingAlgorithm>,
     attributes: Option<NvIndexAttributes>,
     authorization_policy: Option<Digest>,
@@ -104,7 +105,7 @@ impl NvPublicBuilder {
         }
     }
 
-    pub fn with_nv_index(mut self, nv_index: NvIndex) -> Self {
+    pub fn with_nv_index(mut self, nv_index: NvIndexTpmHandle) -> Self {
         self.nv_index = Some(nv_index);
         self
     }

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -40,7 +40,8 @@ use tss_esapi::{
         algorithm::{Cipher, HashingAlgorithm},
         tss::*,
     },
-    nv::storage::{NvAuthorization, NvIndex, NvIndexAttributes, NvPublicBuilder},
+    handles::tpm::NvIndexTpmHandle,
+    nv::storage::{NvAuthorization, NvIndexAttributes, NvPublicBuilder},
     structures::{
         Auth, Data, Digest, DigestList, MaxBuffer, MaxNvBuffer, Nonce, PcrSelectionListBuilder,
         PcrSlot, PublicKeyRSA, Ticket,
@@ -1912,7 +1913,7 @@ mod test_nv_define_space {
     fn test_nv_define_space_failures() {
         let mut context = create_ctx_with_session();
 
-        let nv_index = NvIndex::create_from_value(0x01500015).unwrap();
+        let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
 
         // Create owner nv public.
         let mut owner_nv_index_attributes = NvIndexAttributes(0);
@@ -1955,7 +1956,7 @@ mod test_nv_define_space {
     fn test_nv_define_space() {
         let mut context = create_ctx_with_session();
 
-        let nv_index = NvIndex::create_from_value(0x01500015).unwrap();
+        let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
 
         // Create owner nv public.
         let mut owner_nv_index_attributes = NvIndexAttributes(0);
@@ -2009,7 +2010,7 @@ mod test_nv_undefine_space {
     fn test_nv_undefine_space() {
         let mut context = create_ctx_with_session();
 
-        let nv_index = NvIndex::create_from_value(0x01500015).unwrap();
+        let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
 
         // Create owner nv public.
         let mut owner_nv_index_attributes = NvIndexAttributes(0);
@@ -2042,7 +2043,7 @@ mod test_nv_write {
     fn test_nv_write() {
         let mut context = create_ctx_with_session();
 
-        let nv_index = NvIndex::create_from_value(0x01500015).unwrap();
+        let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
 
         // Create owner nv public.
         let mut owner_nv_index_attributes = NvIndexAttributes(0);
@@ -2085,7 +2086,7 @@ mod test_nv_read_public {
     fn test_nv_read_public() {
         let mut context = create_ctx_with_session();
 
-        let nv_index = NvIndex::create_from_value(0x01500015).unwrap();
+        let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
 
         let mut nv_index_attributes = NvIndexAttributes(0);
         nv_index_attributes.set_owner_write(true);
@@ -2127,7 +2128,7 @@ mod test_nv_read {
     fn test_nv_read() {
         let mut context = create_ctx_with_session();
 
-        let nv_index = NvIndex::create_from_value(0x01500015).unwrap();
+        let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
 
         // Create owner nv public.
         let mut owner_nv_index_attributes = NvIndexAttributes(0);

--- a/tests/handles_tpm_tests.rs
+++ b/tests/handles_tpm_tests.rs
@@ -1,0 +1,266 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use std::convert::{Into, TryFrom};
+use tss_esapi::{
+    constants::tss::{
+        TPM2_HT_AC, TPM2_HT_HMAC_SESSION, TPM2_HT_LOADED_SESSION, TPM2_HT_NV_INDEX, TPM2_HT_PCR,
+        TPM2_HT_PERMANENT, TPM2_HT_PERSISTENT, TPM2_HT_POLICY_SESSION, TPM2_HT_SAVED_SESSION,
+        TPM2_HT_TRANSIENT,
+    },
+    handles::tpm::{
+        AcTpmHandle, HmacSessionTpmHandle, LoadedSessionTpmHandle, NvIndexTpmHandle, PcrTpmHandle,
+        PermanentTpmHandle, PersistentTpmHandle, PolicySessionTpmHandle, SavedSessionTpmHandle,
+        TpmHandle, TransientTpmHandle,
+    },
+    tss2_esys::TPM2_HANDLE,
+};
+
+mod test_tpm_handles {
+    use super::*;
+
+    #[test]
+    fn test_pcr_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = PcrTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_PCR;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = PcrTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_nv_index_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = NvIndexTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_NV_INDEX;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = NvIndexTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_hmac_session_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = HmacSessionTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_HMAC_SESSION;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = HmacSessionTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_loaded_session_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = LoadedSessionTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_LOADED_SESSION;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = LoadedSessionTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_policy_session_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = PolicySessionTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_POLICY_SESSION;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = PolicySessionTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_saved_session_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = SavedSessionTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_SAVED_SESSION;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = SavedSessionTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_permanent_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = PermanentTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_PERMANENT;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = PermanentTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_transient_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = TransientTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_TRANSIENT;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = TransientTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_persistent_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = PersistentTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_PERSISTENT;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = PersistentTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_ac_tpm_handle() {
+        let invalid_value: u32 = 0xFFFFFFFF;
+        let _ = AcTpmHandle::new(invalid_value).unwrap_err();
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_AC;
+        let valid_value: u32 = u32::from_be_bytes(be_bytes);
+        let _ = AcTpmHandle::new(valid_value).unwrap();
+    }
+
+    #[test]
+    fn test_general_tpm_handle_from_tss_tpm_handle_conversion() {
+        let invalid_value: TPM2_HANDLE = 0xFFFFFFFF;
+        let _ = TpmHandle::try_from(invalid_value).unwrap_err();
+
+        let mut be_bytes = invalid_value.to_be_bytes();
+        be_bytes[0] = TPM2_HT_PCR;
+
+        assert_eq!(
+            TpmHandle::try_from(u32::from_be_bytes(be_bytes)).unwrap(),
+            TpmHandle::Pcr(PcrTpmHandle::new(u32::from_be_bytes(be_bytes)).unwrap())
+        );
+
+        be_bytes[0] = TPM2_HT_NV_INDEX;
+
+        assert_eq!(
+            TpmHandle::try_from(u32::from_be_bytes(be_bytes)).unwrap(),
+            TpmHandle::NvIndex(NvIndexTpmHandle::new(u32::from_be_bytes(be_bytes)).unwrap())
+        );
+
+        be_bytes[0] = TPM2_HT_HMAC_SESSION;
+
+        assert_eq!(
+            TpmHandle::try_from(u32::from_be_bytes(be_bytes)).unwrap(),
+            TpmHandle::HmacSession(
+                HmacSessionTpmHandle::new(u32::from_be_bytes(be_bytes)).unwrap()
+            )
+        );
+
+        // TPM2_HT_LOADED_SESSION is the same as TPM2_HT_HMAC_SESSION
+
+        be_bytes[0] = TPM2_HT_POLICY_SESSION;
+
+        assert_eq!(
+            TpmHandle::try_from(u32::from_be_bytes(be_bytes)).unwrap(),
+            TpmHandle::PolicySession(
+                PolicySessionTpmHandle::new(u32::from_be_bytes(be_bytes)).unwrap()
+            )
+        );
+
+        // TPM2_HT_SAVED_SESSION is the same as TPM2_HT_POLICY_SESSION
+
+        be_bytes[0] = TPM2_HT_PERMANENT;
+
+        assert_eq!(
+            TpmHandle::try_from(u32::from_be_bytes(be_bytes)).unwrap(),
+            TpmHandle::Permanent(PermanentTpmHandle::new(u32::from_be_bytes(be_bytes)).unwrap())
+        );
+
+        be_bytes[0] = TPM2_HT_TRANSIENT;
+
+        assert_eq!(
+            TpmHandle::try_from(u32::from_be_bytes(be_bytes)).unwrap(),
+            TpmHandle::Transient(TransientTpmHandle::new(u32::from_be_bytes(be_bytes)).unwrap())
+        );
+
+        be_bytes[0] = TPM2_HT_PERSISTENT;
+
+        assert_eq!(
+            TpmHandle::try_from(u32::from_be_bytes(be_bytes)).unwrap(),
+            TpmHandle::Persistent(PersistentTpmHandle::new(u32::from_be_bytes(be_bytes)).unwrap())
+        );
+
+        be_bytes[0] = TPM2_HT_AC;
+
+        assert_eq!(
+            TpmHandle::try_from(u32::from_be_bytes(be_bytes)).unwrap(),
+            TpmHandle::Ac(AcTpmHandle::new(u32::from_be_bytes(be_bytes)).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_general_tpm_handle_to_tss_tpm_handle_conversion() {
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_PCR, 0x00, 0x00, 0x01]);
+            let tpm_handle = TpmHandle::Pcr(PcrTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_NV_INDEX, 0x00, 0x00, 0x01]);
+            let tpm_handle = TpmHandle::NvIndex(NvIndexTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_HMAC_SESSION, 0x00, 0x00, 0x01]);
+            let tpm_handle = TpmHandle::HmacSession(HmacSessionTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_LOADED_SESSION, 0x00, 0x00, 0x01]);
+            let tpm_handle =
+                TpmHandle::LoadedSession(LoadedSessionTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_POLICY_SESSION, 0x00, 0x00, 0x01]);
+            let tpm_handle =
+                TpmHandle::PolicySession(PolicySessionTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_SAVED_SESSION, 0x00, 0x00, 0x01]);
+            let tpm_handle = TpmHandle::SavedSession(SavedSessionTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_PERMANENT, 0x00, 0x00, 0x01]);
+            let tpm_handle = TpmHandle::Permanent(PermanentTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_TRANSIENT, 0x00, 0x00, 0x01]);
+            let tpm_handle = TpmHandle::Transient(TransientTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_PERSISTENT, 0x00, 0x00, 0x01]);
+            let tpm_handle = TpmHandle::Persistent(PersistentTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+
+        {
+            let expected = u32::from_be_bytes([TPM2_HT_AC, 0x00, 0x00, 0x01]);
+            let tpm_handle = TpmHandle::Ac(AcTpmHandle::new(expected).unwrap());
+            let actual: TPM2_HANDLE = tpm_handle.into();
+            assert_eq!(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
This is an initial work that adds the basic
handle rust types for ESYS ESAPI(ESYS_TR) handles and
TPM handles(TPM2_HANDLE). Some API will require more specific
handle types which can be implemented later.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>