### PR TITLE
Make several improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ num-derive = "0.3.0"
 num-traits = "0.2.11"
 hostname-validator = "1.0.0"
 regex = "1.3.9"
+zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ This project uses the following third party crates:
 * num-traits (MIT and Apache-2.0)
 * hostname-validator (MIT)
 * regex (MIT and Apache-2.0)
+* zeroize (MIT and Apache-2.0)

--- a/src/abstraction/transient.rs
+++ b/src/abstraction/transient.rs
@@ -219,7 +219,8 @@ impl TransientKeyContext {
 
     /// Encrypt a message with an existing key.
     ///
-    /// Takes the key as a parameter, encrypts the message and returns the ciphertext
+    /// Takes the key as a parameter, encrypts the message and returns the ciphertext. A label (i.e.
+    /// nonce) can also be provided.
     ///
     /// # Errors
     /// * errors are returned if any method calls return an error: `Context::context_load`,
@@ -231,6 +232,7 @@ impl TransientKeyContext {
         key_auth: Option<Auth>,
         message: PublicKeyRSA,
         scheme: AsymSchemeUnion,
+        label: Option<Data>,
     ) -> Result<PublicKeyRSA> {
         self.set_session_attrs()?;
         let key_handle = self.context.context_load(key_context)?;
@@ -247,7 +249,7 @@ impl TransientKeyContext {
 
         let ciphertext = self
             .context
-            .rsa_encrypt(key_handle, message, &scheme, Data::default())
+            .rsa_encrypt(key_handle, message, &scheme, label.unwrap_or_default())
             .or_else(|e| {
                 self.context.flush_context(key_handle)?;
                 Err(e)
@@ -260,7 +262,8 @@ impl TransientKeyContext {
 
     /// Decrypt ciphertext with an existing key.
     ///
-    /// Takes the key as a parameter, decrypts the ciphertext and returns the plaintext
+    /// Takes the key as a parameter, decrypts the ciphertext and returns the plaintext. A label (i.e.
+    /// nonce) can also be provided.
     ///
     /// # Errors
     /// * errors are returned if any method calls return an error: `Context::context_load`,
@@ -272,6 +275,7 @@ impl TransientKeyContext {
         key_auth: Option<Auth>,
         ciphertext: PublicKeyRSA,
         scheme: AsymSchemeUnion,
+        label: Option<Data>,
     ) -> Result<PublicKeyRSA> {
         self.set_session_attrs()?;
         let key_handle = self.context.context_load(key_context)?;
@@ -288,7 +292,7 @@ impl TransientKeyContext {
 
         let plaintext = self
             .context
-            .rsa_decrypt(key_handle, ciphertext, &scheme, Data::default())
+            .rsa_decrypt(key_handle, ciphertext, &scheme, label.unwrap_or_default())
             .or_else(|e| {
                 self.context.flush_context(key_handle)?;
                 Err(e)

--- a/src/structures/buffers.rs
+++ b/src/structures/buffers.rs
@@ -8,9 +8,17 @@ macro_rules! buffer_type {
         use log::error;
         use std::convert::TryFrom;
         use std::ops::Deref;
+        use zeroize::Zeroizing;
 
-        #[derive(Debug, Clone, PartialEq, Eq, Default)]
-        pub struct $native_type(Vec<u8>);
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        pub struct $native_type(Zeroizing<Vec<u8>>);
+
+        impl Default for $native_type {
+            fn default() -> Self {
+                $native_type(Vec::new().into())
+            }
+        }
+
         impl $native_type {
             pub const MAX_SIZE: usize = $MAX;
 
@@ -34,7 +42,7 @@ macro_rules! buffer_type {
                     error!("Error: Invalid Vec<u8> size(> {})", Self::MAX_SIZE);
                     return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
                 }
-                Ok($native_type(bytes))
+                Ok($native_type(bytes.into()))
             }
         }
 
@@ -46,7 +54,7 @@ macro_rules! buffer_type {
                     error!("Error: Invalid Vec<u8> size(> {})", Self::MAX_SIZE);
                     return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
                 }
-                Ok($native_type(bytes.to_vec()))
+                Ok($native_type(bytes.to_vec().into()))
             }
         }
 
@@ -59,7 +67,7 @@ macro_rules! buffer_type {
                     error!("Error: Invalid buffer size(> {})", Self::MAX_SIZE);
                     return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
                 }
-                Ok($native_type(tss.buffer[..size].to_vec()))
+                Ok($native_type(tss.buffer[..size].to_vec().into()))
             }
         }
 

--- a/tests/transient_key_context.rs
+++ b/tests/transient_key_context.rs
@@ -204,6 +204,7 @@ fn encrypt_decrypt() {
             None,
             PublicKeyRSA::try_from(message.clone()).unwrap(),
             AsymSchemeUnion::RSAOAEP(HashingAlgorithm::Sha256),
+            None,
         )
         .unwrap();
     assert_ne!(message, ciphertext.value());
@@ -214,6 +215,7 @@ fn encrypt_decrypt() {
             auth,
             ciphertext,
             AsymSchemeUnion::RSAOAEP(HashingAlgorithm::Sha256),
+            None,
         )
         .unwrap();
     assert_eq!(message, plaintext.value());


### PR DESCRIPTION
This commit makes several improvements to the crate:
* a new param is added to the asym encrypt and decrypt methods of the
`TransientKeyContext`, allowing a label/nonce to be passed
* the `zeroize` crate is added and all buffers now wrap around a
zeroizing vector of bytes
* zeroize-on-drop was also implemented on `TpmsContext` and
`SignatureData`

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>