### PR TITLE
bugfix: hierarchy use esys_rh not tpm2_rh in esys calls

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -604,7 +604,7 @@ impl Context {
                 self.sessions.2,
                 private,
                 public,
-                hierarchy.rh(),
+                hierarchy.esys_rh(),
                 &mut key_handle,
             )
         };
@@ -635,7 +635,7 @@ impl Context {
                 self.sessions.2,
                 null(),
                 public,
-                hierarchy.rh(),
+                hierarchy.esys_rh(),
                 &mut key_handle,
             )
         };
@@ -1214,7 +1214,7 @@ impl Context {
                 self.sessions.2,
                 &in_data,
                 hashing_algorithm.into(),
-                hierarchy.rh(),
+                hierarchy.esys_rh(),
                 &mut out_hash_ptr,
                 &mut validation_ptr,
             )

--- a/src/structures/tickets.rs
+++ b/src/structures/tickets.rs
@@ -24,7 +24,7 @@ macro_rules! impl_ticket_try_froms {
                 buffer[..digest.len()].clone_from_slice(&digest[..digest.len()]);
                 Ok($tss_ticket_type {
                     tag: <$ticket_type>::TAG.into(),
-                    hierarchy: ticket.hierarchy.rh(),
+                    hierarchy: ticket.hierarchy.esys_rh(),
                     digest: TPM2B_DIGEST {
                         size: digest.len().try_into().unwrap(), // should not fail based on the checks done above
                         buffer,


### PR DESCRIPTION
it fix log output / fallback in `esys_iutil.c` like:
```
ERROR:esys:src/tss2-esys/esys_iutil.c:389:iesys_handle_to_tpm_handle() Error: Esys invalid ESAPI handle (40000007).
WARNING:esys:src/tss2-esys/esys_iutil.c:410:iesys_is_platform_handle() Convert handle from TPM2_RH to ESYS_TR, got: 0x40000007
```