### PR TITLE
Add abstraction::nv::read_full to fully read an NV Index

### DIFF
--- a/src/abstraction/mod.rs
+++ b/src/abstraction/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod nv;
 pub mod transient;

--- a/src/abstraction/nv.rs
+++ b/src/abstraction/nv.rs
@@ -1,0 +1,39 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    constants::tags::PropertyTag,
+    handles::{AuthHandle, NvIndexHandle, NvIndexTpmHandle, TpmHandle},
+    Context, Result,
+};
+
+/// Allows reading an NV Index completely, regardless of the max TPM NV buffer size
+pub fn read_full(
+    context: &mut Context,
+    auth_handle: AuthHandle,
+    nv_index_handle: NvIndexTpmHandle,
+) -> Result<Vec<u8>> {
+    let maxsize = match context.get_tpm_property(PropertyTag::NvBufferMax)? {
+        Some(val) => val,
+        None => 512,
+    } as usize;
+
+    let nv_idx = TpmHandle::NvIndex(nv_index_handle);
+    let nv_idx = context.execute_without_session(|ctx| ctx.tr_from_tpm_public(nv_idx))?;
+    let nv_idx: NvIndexHandle = nv_idx.into();
+
+    let (nvpub, _) = context.execute_without_session(|ctx| ctx.nv_read_public(nv_idx))?;
+    let nvsize = nvpub.data_size();
+
+    let mut result = Vec::new();
+    result.reserve_exact(nvsize);
+
+    for offset in (0..nvsize).step_by(maxsize) {
+        let size: u16 = std::cmp::min(maxsize, nvsize - offset) as u16;
+
+        let res = context.nv_read(auth_handle, nv_idx, size, offset as u16)?;
+        result.extend_from_slice(&res);
+    }
+
+    Ok(result)
+}

--- a/src/constants/tags/mod.rs
+++ b/src/constants/tags/mod.rs
@@ -1,6 +1,13 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Contains property tag TPM_PT
+mod property;
+pub use property::PropertyTag;
+pub mod property_tag {
+    pub use super::property::*;
+}
+
 /// Contains structure tag TPM_ST
 mod structure;
 pub use structure_tag::StructureTag;

--- a/src/constants/tags/property.rs
+++ b/src/constants/tags/property.rs
@@ -1,0 +1,101 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{constants::tss::*, tss2_esys::TPM2_PT, Error, Result, WrapperErrorKind};
+use log::error;
+use num_derive::{FromPrimitive, ToPrimitive};
+use num_traits::{FromPrimitive, ToPrimitive};
+use std::convert::{From, TryFrom};
+
+#[derive(FromPrimitive, ToPrimitive, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u32)]
+pub enum PropertyTag {
+    None = TPM2_PT_NONE,
+    // Fixed
+    FamilyIndicator = TPM2_PT_FAMILY_INDICATOR,
+    Level = TPM2_PT_LEVEL,
+    Revision = TPM2_PT_REVISION,
+    DayOfYear = TPM2_PT_DAY_OF_YEAR,
+    Year = TPM2_PT_YEAR,
+    Manufacturer = TPM2_PT_MANUFACTURER,
+    VendorString1 = TPM2_PT_VENDOR_STRING_1,
+    VendorString2 = TPM2_PT_VENDOR_STRING_2,
+    VendorString3 = TPM2_PT_VENDOR_STRING_3,
+    VendorString4 = TPM2_PT_VENDOR_STRING_4,
+    VendorTPMType = TPM2_PT_VENDOR_TPM_TYPE,
+    FirmwareVersion1 = TPM2_PT_FIRMWARE_VERSION_1,
+    FirmwareVersion2 = TPM2_PT_FIRMWARE_VERSION_2,
+    InputBuffer = TPM2_PT_INPUT_BUFFER,
+    HrTransientMin = TPM2_PT_HR_TRANSIENT_MIN,
+    HrPersistentMin = TPM2_PT_HR_PERSISTENT_MIN,
+    HrLoadedMin = TPM2_PT_HR_LOADED_MIN,
+    ActiveSessionsMax = TPM2_PT_ACTIVE_SESSIONS_MAX,
+    PcrCount = TPM2_PT_PCR_COUNT,
+    PcrSelectMin = TPM2_PT_PCR_SELECT_MIN,
+    ContextGapMax = TPM2_PT_CONTEXT_GAP_MAX,
+    NvCountersMax = TPM2_PT_NV_COUNTERS_MAX,
+    NvIndexMax = TPM2_PT_NV_INDEX_MAX,
+    Memory = TPM2_PT_MEMORY,
+    ClockUpdate = TPM2_PT_CLOCK_UPDATE,
+    ContextHash = TPM2_PT_CONTEXT_HASH,
+    ContextSym = TPM2_PT_CONTEXT_SYM,
+    ContextSymSize = TPM2_PT_CONTEXT_SYM_SIZE,
+    OrderlyCount = TPM2_PT_ORDERLY_COUNT,
+    MaxCommandSize = TPM2_PT_MAX_COMMAND_SIZE,
+    MaxResponseSize = TPM2_PT_MAX_RESPONSE_SIZE,
+    MaxDigest = TPM2_PT_MAX_DIGEST,
+    MaxObjectContext = TPM2_PT_MAX_OBJECT_CONTEXT,
+    MaxSessionContext = TPM2_PT_MAX_SESSION_CONTEXT,
+    PsFamilyIndicator = TPM2_PT_PS_FAMILY_INDICATOR,
+    PsLevel = TPM2_PT_PS_LEVEL,
+    PsRevision = TPM2_PT_PS_REVISION,
+    PsDayOfYear = TPM2_PT_PS_DAY_OF_YEAR,
+    PsYear = TPM2_PT_PS_YEAR,
+    SplitMax = TPM2_PT_SPLIT_MAX,
+    TotalCommands = TPM2_PT_TOTAL_COMMANDS,
+    LibraryCommands = TPM2_PT_LIBRARY_COMMANDS,
+    VendorCommands = TPM2_PT_VENDOR_COMMANDS,
+    NvBufferMax = TPM2_PT_NV_BUFFER_MAX,
+    Modes = TPM2_PT_MODES,
+    // Variable
+    Permanent = TPM2_PT_PERMANENT,
+    StartupClear = TPM2_PT_STARTUP_CLEAR,
+    HrNvIndex = TPM2_PT_HR_NV_INDEX,
+    HrLoaded = TPM2_PT_HR_LOADED,
+    HrLoadedAvail = TPM2_PT_HR_LOADED_AVAIL,
+    HrActive = TPM2_PT_HR_ACTIVE,
+    HrActiveAvail = TPM2_PT_HR_ACTIVE_AVAIL,
+    HrTransientAvail = TPM2_PT_HR_TRANSIENT_AVAIL,
+    HrPersistent = TPM2_PT_HR_PERSISTENT,
+    HrPersistentAvail = TPM2_PT_HR_PERSISTENT_AVAIL,
+    NvCounters = TPM2_PT_NV_COUNTERS,
+    NvCountersAvail = TPM2_PT_NV_COUNTERS_AVAIL,
+    AlgorithmSet = TPM2_PT_ALGORITHM_SET,
+    LoadedCurves = TPM2_PT_LOADED_CURVES,
+    LockoutCounter = TPM2_PT_LOCKOUT_COUNTER,
+    MaxAuthFail = TPM2_PT_MAX_AUTH_FAIL,
+    LockoutInterval = TPM2_PT_LOCKOUT_INTERVAL,
+    LockoutRecovery = TPM2_PT_LOCKOUT_RECOVERY,
+    WriteRecovery = TPM2_PT_NV_WRITE_RECOVERY,
+    AuditCounter0 = TPM2_PT_AUDIT_COUNTER_0,
+    AuditCounter1 = TPM2_PT_AUDIT_COUNTER_1,
+}
+
+impl From<PropertyTag> for TPM2_PT {
+    fn from(property_tag: PropertyTag) -> TPM2_PT {
+        // The values are well defined so this cannot fail.
+        property_tag.to_u32().unwrap()
+    }
+}
+
+impl TryFrom<TPM2_PT> for PropertyTag {
+    type Error = Error;
+    fn try_from(tpm_property_tag: TPM2_PT) -> Result<PropertyTag> {
+        PropertyTag::from_u32(tpm_property_tag).ok_or_else(|| {
+            error!(
+                "Error: value = {} did not match any PropertyTag.",
+                tpm_property_tag
+            );
+            Error::local_error(WrapperErrorKind::InvalidParam)
+        })
+    }
+}

--- a/tests/abstraction_nv_tests.rs
+++ b/tests/abstraction_nv_tests.rs
@@ -1,0 +1,107 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{convert::TryFrom, env, str::FromStr};
+use tss_esapi::abstraction::nv;
+use tss_esapi::{
+    constants::{
+        algorithm::{Cipher, HashingAlgorithm},
+        tss::*,
+        types::session::SessionType,
+    },
+    handles::NvIndexTpmHandle,
+    nv::storage::{NvAuthorization, NvIndexAttributes, NvPublicBuilder},
+    structures::MaxNvBuffer,
+    utils::TpmaSessionBuilder,
+    Context, Tcti,
+};
+
+pub fn create_ctx_without_session() -> Context {
+    let tcti = match env::var("TEST_TCTI") {
+        Err(_) => Tcti::Mssim(Default::default()),
+        Ok(tctistr) => Tcti::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
+    };
+    unsafe { Context::new(tcti).unwrap() }
+}
+
+fn create_ctx_with_session() -> Context {
+    let mut ctx = create_ctx_without_session();
+    let session = ctx
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Hmac,
+            Cipher::aes_256_cfb(),
+            HashingAlgorithm::Sha256,
+        )
+        .unwrap();
+    let session_attr = TpmaSessionBuilder::new()
+        .with_flag(TPMA_SESSION_DECRYPT)
+        .with_flag(TPMA_SESSION_ENCRYPT)
+        .build();
+    ctx.tr_sess_set_attributes(session.unwrap(), session_attr)
+        .unwrap();
+    ctx.set_sessions((session, None, None));
+
+    ctx
+}
+
+#[test]
+fn read_full() {
+    let mut context = create_ctx_with_session();
+
+    let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
+
+    // Create owner nv public.
+    let mut owner_nv_index_attributes = NvIndexAttributes(0);
+    owner_nv_index_attributes.set_owner_write(true);
+    owner_nv_index_attributes.set_owner_read(true);
+    owner_nv_index_attributes.set_pp_read(true);
+    owner_nv_index_attributes.set_owner_read(true);
+
+    let owner_nv_public = NvPublicBuilder::new()
+        .with_nv_index(nv_index)
+        .with_index_name_algorithm(HashingAlgorithm::Sha256)
+        .with_index_attributes(owner_nv_index_attributes)
+        .with_data_area_size(1540)
+        .build()
+        .unwrap();
+
+    let owner_nv_index_handle = context
+        .nv_define_space(NvAuthorization::Owner, None, &owner_nv_public)
+        .unwrap();
+
+    let value = [1, 2, 3, 4, 5, 6, 7];
+    let expected_data = MaxNvBuffer::try_from(value.to_vec()).unwrap();
+
+    // Write the data using Owner authorization
+    context
+        .nv_write(
+            NvAuthorization::Owner.into(),
+            owner_nv_index_handle,
+            &expected_data,
+            0,
+        )
+        .unwrap();
+    context
+        .nv_write(
+            NvAuthorization::Owner.into(),
+            owner_nv_index_handle,
+            &expected_data,
+            1024,
+        )
+        .unwrap();
+
+    // Now read it back
+    let read_result = nv::read_full(&mut context, NvAuthorization::Owner.into(), nv_index);
+
+    let _ = context
+        .nv_undefine_space(NvAuthorization::Owner, owner_nv_index_handle)
+        .unwrap();
+
+    let read_result = read_result.unwrap();
+    assert_eq!(read_result.len(), 1540);
+    assert_eq!(read_result[0..7], [1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(read_result[1024..1031], [1, 2, 3, 4, 5, 6, 7]);
+}

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -39,6 +39,7 @@ use tss_esapi::{
     algorithm::structures::SensitiveData,
     constants::{
         algorithm::{Cipher, HashingAlgorithm},
+        tags::PropertyTag,
         tss::*,
         types::{capability::CapabilityType, session::SessionType},
     },
@@ -356,6 +357,23 @@ mod test_get_capability {
             }
             _ => panic!("Invalid properties returned"),
         };
+    }
+
+    #[test]
+    fn test_get_tpm_property() {
+        let mut context = create_ctx_without_session();
+
+        let rev = context
+            .get_tpm_property(PropertyTag::Revision)
+            .unwrap()
+            .unwrap();
+        assert_ne!(rev, 0);
+
+        let year = context
+            .get_tpm_property(PropertyTag::Year)
+            .unwrap()
+            .unwrap();
+        assert_ne!(year, 0);
     }
 }
 


### PR DESCRIPTION
It is not possible to read an NV Index in one request if the contents are larger than
the implementation's `TPM_PT_NV_BUFFER`.
This functions repeats over the length of the buffer, to ensure it is possible to read
everything.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>