### PR TITLE
Implement utils::get_tpm_vendor

### DIFF
--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,0 +1,20 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{env, str::FromStr};
+use tss_esapi::{utils, Context, Tcti};
+
+pub fn create_ctx_without_session() -> Context {
+    let tcti = match env::var("TEST_TCTI") {
+        Err(_) => Tcti::Mssim(Default::default()),
+        Ok(tctistr) => Tcti::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
+    };
+    unsafe { Context::new(tcti).unwrap() }
+}
+
+#[test]
+fn get_tpm_vendor() {
+    let mut context = create_ctx_without_session();
+
+    utils::get_tpm_vendor(&mut context).unwrap();
+}


### PR DESCRIPTION
This function will return the name of the TPM vendor as provided by the
TPM VendorString{1, 2, 3, 4} properties.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>