### PR TITLE
Move create_ctx_with{,out}_session from tests to common module

### DIFF
--- a/tests/abstraction_ek_tests.rs
+++ b/tests/abstraction_ek_tests.rs
@@ -1,19 +1,13 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, str::FromStr};
 use tss_esapi::abstraction::ek;
+use tss_esapi::constants::algorithm::AsymmetricAlgorithm;
 use tss_esapi::constants::response_code::{FormatOneResponseCode, Tss2ResponseCode};
 use tss_esapi::Error;
-use tss_esapi::{constants::algorithm::AsymmetricAlgorithm, Context, Tcti};
 
-pub fn create_ctx_without_session() -> Context {
-    let tcti = match env::var("TEST_TCTI") {
-        Err(_) => Tcti::Mssim(Default::default()),
-        Ok(tctistr) => Tcti::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
-    };
-    unsafe { Context::new(tcti).unwrap() }
-}
+mod common;
+use common::create_ctx_without_session;
 
 #[test]
 fn test_retrieve_ek_pubcert() {

--- a/tests/abstraction_nv_tests.rs
+++ b/tests/abstraction_nv_tests.rs
@@ -1,51 +1,17 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{convert::TryFrom, env, str::FromStr};
+use std::convert::TryFrom;
 use tss_esapi::abstraction::nv;
 use tss_esapi::{
-    constants::{
-        algorithm::{Cipher, HashingAlgorithm},
-        tss::*,
-        types::session::SessionType,
-    },
+    constants::algorithm::HashingAlgorithm,
     handles::NvIndexTpmHandle,
     nv::storage::{NvAuthorization, NvIndexAttributes, NvPublicBuilder},
     structures::MaxNvBuffer,
-    utils::TpmaSessionBuilder,
-    Context, Tcti,
 };
 
-pub fn create_ctx_without_session() -> Context {
-    let tcti = match env::var("TEST_TCTI") {
-        Err(_) => Tcti::Mssim(Default::default()),
-        Ok(tctistr) => Tcti::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
-    };
-    unsafe { Context::new(tcti).unwrap() }
-}
-
-fn create_ctx_with_session() -> Context {
-    let mut ctx = create_ctx_without_session();
-    let session = ctx
-        .start_auth_session(
-            None,
-            None,
-            None,
-            SessionType::Hmac,
-            Cipher::aes_256_cfb(),
-            HashingAlgorithm::Sha256,
-        )
-        .unwrap();
-    let session_attr = TpmaSessionBuilder::new()
-        .with_flag(TPMA_SESSION_DECRYPT)
-        .with_flag(TPMA_SESSION_ENCRYPT)
-        .build();
-    ctx.tr_sess_set_attributes(session.unwrap(), session_attr)
-        .unwrap();
-    ctx.set_sessions((session, None, None));
-
-    ctx
-}
+mod common;
+use common::create_ctx_with_session;
 
 #[test]
 fn read_full() {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,61 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use std::{env, str::FromStr, sync::Once};
+
+use tss_esapi::{
+    constants::{
+        algorithm::{Cipher, HashingAlgorithm},
+        tss::*,
+        types::session::SessionType,
+    },
+    utils::TpmaSessionBuilder,
+    Context, Tcti,
+};
+
+static LOG_INIT: Once = Once::new();
+#[allow(dead_code)]
+pub fn setup_logging() {
+    LOG_INIT.call_once(|| {
+        env_logger::init();
+    });
+}
+
+#[allow(dead_code)]
+pub fn create_tcti() -> Tcti {
+    setup_logging();
+
+    match env::var("TEST_TCTI") {
+        Err(_) => Tcti::Mssim(Default::default()),
+        Ok(tctistr) => Tcti::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
+    }
+}
+
+#[allow(dead_code)]
+pub fn create_ctx_without_session() -> Context {
+    let tcti = create_tcti();
+    unsafe { Context::new(tcti).unwrap() }
+}
+
+#[allow(dead_code)]
+pub fn create_ctx_with_session() -> Context {
+    let mut ctx = create_ctx_without_session();
+    let session = ctx
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Hmac,
+            Cipher::aes_256_cfb(),
+            HashingAlgorithm::Sha256,
+        )
+        .unwrap();
+    let session_attr = TpmaSessionBuilder::new()
+        .with_flag(TPMA_SESSION_DECRYPT)
+        .with_flag(TPMA_SESSION_ENCRYPT)
+        .build();
+    ctx.tr_sess_set_attributes(session.unwrap(), session_attr)
+        .unwrap();
+    ctx.set_sessions((session, None, None));
+
+    ctx
+}

--- a/tests/structures_capabilitydata.rs
+++ b/tests/structures_capabilitydata.rs
@@ -1,19 +1,13 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, str::FromStr};
-use tss_esapi::{constants::types::capability::CapabilityType, Context, Tcti};
+use tss_esapi::constants::types::capability::CapabilityType;
+
+mod common;
+use common::create_ctx_without_session;
 
 mod test_capabs {
     use super::*;
-
-    pub fn create_ctx_without_session() -> Context {
-        let tcti = match env::var("TEST_TCTI") {
-            Err(_) => Tcti::Mssim(Default::default()),
-            Ok(tctistr) => Tcti::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
-        };
-        unsafe { Context::new(tcti).unwrap() }
-    }
 
     #[test]
     fn test_algorithms() {

--- a/tests/transient_key_context.rs
+++ b/tests/transient_key_context.rs
@@ -9,11 +9,13 @@ use tss_esapi::{Error, WrapperErrorKind as ErrorKind};
 
 use tss_esapi::structures::{Auth, Digest, PublicKeyRSA};
 use tss_esapi::utils::{AsymSchemeUnion, PublicKey, Signature, SignatureData};
-use tss_esapi::Tcti;
 use tss_esapi::{
     abstraction::transient::{KeyParams, RsaExponent, TransientKeyContextBuilder},
     TransientKeyContext,
 };
+
+mod common;
+use common::create_tcti;
 
 const HASH: [u8; 32] = [
     0x69, 0x3E, 0xDB, 0x1B, 0x22, 0x79, 0x03, 0xF4, 0xC0, 0xBF, 0xD6, 0x91, 0x76, 0x37, 0x84, 0xA2,
@@ -23,7 +25,7 @@ const HASH: [u8; 32] = [
 fn create_ctx() -> TransientKeyContext {
     unsafe {
         TransientKeyContextBuilder::new()
-            .with_tcti(Tcti::Mssim(Default::default()))
+            .with_tcti(create_tcti())
             .build()
             .unwrap()
     }
@@ -34,7 +36,7 @@ fn wrong_key_sizes() {
     assert_eq!(
         unsafe {
             TransientKeyContextBuilder::new()
-                .with_tcti(Tcti::Mssim(Default::default()))
+                .with_tcti(create_tcti())
                 .with_root_key_size(1023)
                 .build()
                 .unwrap_err()
@@ -44,7 +46,7 @@ fn wrong_key_sizes() {
     assert_eq!(
         unsafe {
             TransientKeyContextBuilder::new()
-                .with_tcti(Tcti::Mssim(Default::default()))
+                .with_tcti(create_tcti())
                 .with_root_key_size(1025)
                 .build()
                 .unwrap_err()
@@ -54,7 +56,7 @@ fn wrong_key_sizes() {
     assert_eq!(
         unsafe {
             TransientKeyContextBuilder::new()
-                .with_tcti(Tcti::Mssim(Default::default()))
+                .with_tcti(create_tcti())
                 .with_root_key_size(2047)
                 .build()
                 .unwrap_err()
@@ -64,7 +66,7 @@ fn wrong_key_sizes() {
     assert_eq!(
         unsafe {
             TransientKeyContextBuilder::new()
-                .with_tcti(Tcti::Mssim(Default::default()))
+                .with_tcti(create_tcti())
                 .with_root_key_size(2049)
                 .build()
                 .unwrap_err()
@@ -78,7 +80,7 @@ fn wrong_auth_size() {
     assert_eq!(
         unsafe {
             TransientKeyContextBuilder::new()
-                .with_tcti(Tcti::Mssim(Default::default()))
+                .with_tcti(create_tcti())
                 .with_root_key_auth_size(33)
                 .build()
                 .unwrap_err()

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,16 +1,10 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, str::FromStr};
-use tss_esapi::{utils, Context, Tcti};
+use tss_esapi::utils;
 
-pub fn create_ctx_without_session() -> Context {
-    let tcti = match env::var("TEST_TCTI") {
-        Err(_) => Tcti::Mssim(Default::default()),
-        Ok(tctistr) => Tcti::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
-    };
-    unsafe { Context::new(tcti).unwrap() }
-}
+mod common;
+use common::create_ctx_without_session;
 
 #[test]
 fn get_tpm_vendor() {


### PR DESCRIPTION
This ensures that all the tests initialize the context and TCTI in a
consistent way, and TEST_TCTI is useful throughout the tests.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>