### PR TITLE
Added support for tpm2-tss 3

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,13 @@ fn main() {
             .probe("tss2-mu")
             .expect("Error with pkg-config finding tss2-mu.");
 
+        // Check version to automatically set compatability flag.
+        match tss2_esys.version.chars().next().unwrap() {
+            '2' => println!("cargo:rustc-cfg=tpm2_tss_version=\"2\""),
+            '3' => println!("cargo:rustc-cfg=tpm2_tss_version=\"3\""),
+            major => panic!("Unsupported TSS version: {}", major),
+        }
+
         // These three pkg-config files should contain only one include/lib path.
         let tss2_esys_include_path = tss2_esys.include_paths[0]
             .clone()

--- a/src/abstraction/transient.rs
+++ b/src/abstraction/transient.rs
@@ -696,7 +696,7 @@ impl TransientKeyContextBuilder {
 
         if !self.hierarchy_auth.is_empty() {
             let auth_hierarchy = Auth::try_from(self.hierarchy_auth)?;
-            context.tr_set_auth(self.hierarchy.esys_rh().into(), &auth_hierarchy)?;
+            context.tr_set_auth(self.hierarchy.into(), &auth_hierarchy)?;
         }
 
         let creation_pcrs = PcrSelectionListBuilder::new().build();

--- a/src/constants/tss.rs
+++ b/src/constants/tss.rs
@@ -510,6 +510,8 @@ pub const TPM2_RH_PLATFORM: TPM2_RH = 0x4000000C; /* K A P */
 pub const TPM2_RH_PLATFORM_NV: TPM2_RH = 0x4000000D; /* C */
 pub const TPM2_RH_AUTH_00: TPM2_RH = 0x40000010; /* A */
 pub const TPM2_RH_AUTH_FF: TPM2_RH = 0x4000010F; /* A */
+pub const TPM2_RH_ACT_0: TPM2_RH = 0x40000110; /* A P */
+pub const TPM2_RH_ACT_F: TPM2_RH = 0x4000011F; /* A P */
 pub const TPM2_RH_LAST: TPM2_RH = 0x4000010F; /* R */
 
 pub const TPM2_HR_HANDLE_MASK: TPM2_HC = 0x00FFFFFF; /* to mask off the HR */

--- a/src/context.rs
+++ b/src/context.rs
@@ -737,7 +737,11 @@ impl Context {
                 self.optional_session_3(),
                 private,
                 public,
-                hierarchy.rh(),
+                if cfg!(tpm2_tss_version = "3") {
+                    hierarchy.esys_rh()
+                } else {
+                    hierarchy.rh()
+                },
                 &mut esys_key_handle,
             )
         };
@@ -769,7 +773,11 @@ impl Context {
                 self.optional_session_3(),
                 null(),
                 public,
-                hierarchy.rh(),
+                if cfg!(tpm2_tss_version = "3") {
+                    hierarchy.esys_rh()
+                } else {
+                    hierarchy.rh()
+                },
                 &mut esys_key_handle,
             )
         };
@@ -1425,7 +1433,11 @@ impl Context {
                 self.optional_session_3(),
                 &in_data,
                 hashing_algorithm.into(),
-                hierarchy.rh(),
+                if cfg!(tpm2_tss_version = "3") {
+                    hierarchy.esys_rh()
+                } else {
+                    hierarchy.rh()
+                },
                 &mut out_hash_ptr,
                 &mut validation_ptr,
             )

--- a/src/context.rs
+++ b/src/context.rs
@@ -385,7 +385,7 @@ impl Context {
         let ret = unsafe {
             Esys_CreatePrimary(
                 self.mut_context(),
-                primary_handle.esys_rh(),
+                ObjectHandle::from(primary_handle).into(),
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
@@ -738,9 +738,9 @@ impl Context {
                 private,
                 public,
                 if cfg!(tpm2_tss_version = "3") {
-                    hierarchy.esys_rh()
+                    ObjectHandle::from(hierarchy).into()
                 } else {
-                    hierarchy.rh()
+                    TpmHandle::from(hierarchy).into()
                 },
                 &mut esys_key_handle,
             )
@@ -774,9 +774,9 @@ impl Context {
                 null(),
                 public,
                 if cfg!(tpm2_tss_version = "3") {
-                    hierarchy.esys_rh()
+                    ObjectHandle::from(hierarchy).into()
                 } else {
-                    hierarchy.rh()
+                    TpmHandle::from(hierarchy).into()
                 },
                 &mut esys_key_handle,
             )
@@ -1434,9 +1434,9 @@ impl Context {
                 &in_data,
                 hashing_algorithm.into(),
                 if cfg!(tpm2_tss_version = "3") {
-                    hierarchy.esys_rh()
+                    ObjectHandle::from(hierarchy).into()
                 } else {
-                    hierarchy.rh()
+                    TpmHandle::from(hierarchy).into()
                 },
                 &mut out_hash_ptr,
                 &mut validation_ptr,

--- a/src/handles/handle.rs
+++ b/src/handles/handle.rs
@@ -59,7 +59,10 @@ macro_rules! add_constant_handle {
 /// Object handle module
 ///
 pub mod object {
-    use crate::tss2_esys::{ESYS_TR_NONE, ESYS_TR_PASSWORD};
+    use crate::tss2_esys::{
+        ESYS_TR_NONE, ESYS_TR_PASSWORD, ESYS_TR_RH_ENDORSEMENT, ESYS_TR_RH_LOCKOUT,
+        ESYS_TR_RH_NULL, ESYS_TR_RH_OWNER, ESYS_TR_RH_PLATFORM, ESYS_TR_RH_PLATFORM_NV,
+    };
     impl_basic_handle!(
         /// General handle type.
         ObjectHandle
@@ -67,6 +70,12 @@ pub mod object {
 
     add_constant_handle!(ObjectHandle, PasswordHandle, ESYS_TR_PASSWORD);
     add_constant_handle!(ObjectHandle, NoneHandle, ESYS_TR_NONE);
+    add_constant_handle!(ObjectHandle, OwnerHandle, ESYS_TR_RH_OWNER);
+    add_constant_handle!(ObjectHandle, LockoutHandle, ESYS_TR_RH_LOCKOUT);
+    add_constant_handle!(ObjectHandle, EndorsementHandle, ESYS_TR_RH_ENDORSEMENT);
+    add_constant_handle!(ObjectHandle, PlatformHandle, ESYS_TR_RH_PLATFORM);
+    add_constant_handle!(ObjectHandle, PlatformNvHandle, ESYS_TR_RH_PLATFORM_NV);
+    add_constant_handle!(ObjectHandle, NullHandle, ESYS_TR_RH_NULL);
 }
 
 ///
@@ -269,7 +278,7 @@ pub mod auth {
     // The following constant handles can be used for authorization
     // according to the TCG TPM2 r1p59 Structures specification.
     add_constant_handle!(AuthHandle, OwnerHandle, ESYS_TR_RH_OWNER);
-    add_constant_handle!(AuthHandle, Lockout, ESYS_TR_RH_LOCKOUT);
+    add_constant_handle!(AuthHandle, LockoutHandle, ESYS_TR_RH_LOCKOUT);
     add_constant_handle!(AuthHandle, EndorsementHandle, ESYS_TR_RH_ENDORSEMENT);
     add_constant_handle!(AuthHandle, PlatformHandle, ESYS_TR_RH_PLATFORM);
     // TODO: Figure out how to add AUTH_00 to AUTH_FF range

--- a/src/handles/mod.rs
+++ b/src/handles/mod.rs
@@ -19,15 +19,15 @@ mod handle;
 /////////////////////////////////////////////////////////
 /// TPM Handles
 /////////////////////////////////////////////////////////
-pub use tpm::AttachedComponentTpmHandle;
-pub use tpm::HmacSessionTpmHandle;
-pub use tpm::LoadedSessionTpmHandle;
-pub use tpm::NvIndexTpmHandle;
-pub use tpm::PcrTpmHandle;
-pub use tpm::PermanentTpmHandle;
-pub use tpm::PersistentTpmHandle;
-pub use tpm::PolicySessionTpmHandle;
-pub use tpm::SavedSessionTpmHandle;
+pub use tpm::attached_component::AttachedComponentTpmHandle;
+pub use tpm::hmac_session::HmacSessionTpmHandle;
+pub use tpm::loaded_session::LoadedSessionTpmHandle;
+pub use tpm::nv_index::NvIndexTpmHandle;
+pub use tpm::pcr::PcrTpmHandle;
+pub use tpm::permanent::PermanentTpmHandle;
+pub use tpm::persistent::PersistentTpmHandle;
+pub use tpm::policy_session::PolicySessionTpmHandle;
+pub use tpm::saved_session::SavedSessionTpmHandle;
+pub use tpm::transient::TransientTpmHandle;
 pub use tpm::TpmHandle;
-pub use tpm::TransientTpmHandle;
 mod tpm;

--- a/src/handles/mod.rs
+++ b/src/handles/mod.rs
@@ -14,7 +14,6 @@ pub use handle::nv_index::NvIndexHandle;
 pub use handle::object::ObjectHandle;
 pub use handle::pcr::PcrHandle;
 pub use handle::session::SessionHandle;
-pub use handle::tpm_constants::TpmConstantsHandle;
 mod handle;
 /////////////////////////////////////////////////////////
 /// TPM Handles

--- a/src/handles/tpm.rs
+++ b/src/handles/tpm.rs
@@ -249,7 +249,6 @@ pub mod policy_session {
 }
 
 pub mod permanent {
-    //! Module for permanent TPM handles
     use super::*;
     use crate::constants::tss::{
         TPM2_HT_PERMANENT, TPM2_PERMANENT_FIRST, TPM2_PERMANENT_LAST, TPM2_RH_ACT_0, TPM2_RH_ACT_F,
@@ -267,42 +266,34 @@ pub mod permanent {
         TPM2_PERMANENT_LAST
     );
 
-    add_constant_handle!(PermanentTpmHandle, FirstHandle, TPM2_RH_FIRST);
-    add_constant_handle!(PermanentTpmHandle, StorageRootKeyHandle, TPM2_RH_SRK);
-    add_constant_handle!(PermanentTpmHandle, OwnerHandle, TPM2_RH_OWNER);
-    add_constant_handle!(PermanentTpmHandle, RevokeHandle, TPM2_RH_REVOKE);
-    add_constant_handle!(PermanentTpmHandle, TransportHandle, TPM2_RH_TRANSPORT);
-    add_constant_handle!(PermanentTpmHandle, OperatorHandle, TPM2_RH_OPERATOR);
-    add_constant_handle!(PermanentTpmHandle, AdminHandle, TPM2_RH_ADMIN);
-    add_constant_handle!(PermanentTpmHandle, EndorsementKeyHandle, TPM2_RH_EK);
-    add_constant_handle!(PermanentTpmHandle, NullHandle, TPM2_RH_NULL);
-    add_constant_handle!(PermanentTpmHandle, UnassignedHandle, TPM2_RH_UNASSIGNED);
-    add_constant_handle!(PermanentTpmHandle, PasswordSessionHandle, TPM2_RS_PW);
-    add_constant_handle!(PermanentTpmHandle, LockoutHandle, TPM2_RH_LOCKOUT);
-    add_constant_handle!(PermanentTpmHandle, EndorsementHandle, TPM2_RH_ENDORSEMENT);
-    add_constant_handle!(PermanentTpmHandle, PlatformHandle, TPM2_RH_PLATFORM);
-    add_constant_handle!(PermanentTpmHandle, PlatformNvHandle, TPM2_RH_PLATFORM_NV);
+    add_constant_handle!(PermanentTpmHandle, First, TPM2_RH_FIRST);
+    add_constant_handle!(PermanentTpmHandle, StorageRootKey, TPM2_RH_SRK);
+    add_constant_handle!(PermanentTpmHandle, Owner, TPM2_RH_OWNER);
+    add_constant_handle!(PermanentTpmHandle, Revoke, TPM2_RH_REVOKE);
+    add_constant_handle!(PermanentTpmHandle, Transport, TPM2_RH_TRANSPORT);
+    add_constant_handle!(PermanentTpmHandle, Operator, TPM2_RH_OPERATOR);
+    add_constant_handle!(PermanentTpmHandle, Admin, TPM2_RH_ADMIN);
+    add_constant_handle!(PermanentTpmHandle, EndorsementKey, TPM2_RH_EK);
+    add_constant_handle!(PermanentTpmHandle, Null, TPM2_RH_NULL);
+    add_constant_handle!(PermanentTpmHandle, Unassigned, TPM2_RH_UNASSIGNED);
+    add_constant_handle!(PermanentTpmHandle, PasswordSession, TPM2_RS_PW);
+    add_constant_handle!(PermanentTpmHandle, Lockout, TPM2_RH_LOCKOUT);
+    add_constant_handle!(PermanentTpmHandle, Endorsement, TPM2_RH_ENDORSEMENT);
+    add_constant_handle!(PermanentTpmHandle, Platform, TPM2_RH_PLATFORM);
+    add_constant_handle!(PermanentTpmHandle, PlatformNv, TPM2_RH_PLATFORM_NV);
     add_constant_handle!(
         PermanentTpmHandle,
-        VendorSpecificAuthorizationFirstHandle,
+        VendorSpecificAuthorizationFirst,
         TPM2_RH_AUTH_00
     );
     add_constant_handle!(
         PermanentTpmHandle,
-        VendorSpecificAuthorizationLastHandle,
+        VendorSpecificAuthorizationLast,
         TPM2_RH_AUTH_FF
     );
-    add_constant_handle!(
-        PermanentTpmHandle,
-        AuthenticatedTimersFirstHandle,
-        TPM2_RH_ACT_0
-    );
-    add_constant_handle!(
-        PermanentTpmHandle,
-        AuthenticatedTimersLastHandle,
-        TPM2_RH_ACT_F
-    );
-    add_constant_handle!(PermanentTpmHandle, LastHandle, TPM2_RH_LAST);
+    add_constant_handle!(PermanentTpmHandle, AuthenticatedTimersFirst, TPM2_RH_ACT_0);
+    add_constant_handle!(PermanentTpmHandle, AuthenticatedTimersLast, TPM2_RH_ACT_F);
+    add_constant_handle!(PermanentTpmHandle, Last, TPM2_RH_LAST);
 }
 
 pub mod saved_session {

--- a/src/interface_types/resource_handles.rs
+++ b/src/interface_types/resource_handles.rs
@@ -3,7 +3,7 @@
 use crate::{
     handles::{
         AttachedComponentTpmHandle, AuthHandle, NvIndexHandle, NvIndexTpmHandle, ObjectHandle,
-        PermanentTpmHandle, TpmConstantsHandle, TpmHandle,
+        PermanentTpmHandle, TpmHandle,
     },
     Error, Result, WrapperErrorKind,
 };
@@ -24,10 +24,10 @@ pub enum Hierarchy {
 impl From<Hierarchy> for ObjectHandle {
     fn from(hierarchy: Hierarchy) -> ObjectHandle {
         match hierarchy {
-            Hierarchy::Owner => ObjectHandle::OwnerHandle,
-            Hierarchy::Platform => ObjectHandle::PlatformHandle,
-            Hierarchy::Endorsement => ObjectHandle::EndorsementHandle,
-            Hierarchy::Null => ObjectHandle::NullHandle,
+            Hierarchy::Owner => ObjectHandle::Owner,
+            Hierarchy::Platform => ObjectHandle::Platform,
+            Hierarchy::Endorsement => ObjectHandle::Endorsement,
+            Hierarchy::Null => ObjectHandle::Null,
         }
     }
 }
@@ -35,10 +35,10 @@ impl From<Hierarchy> for ObjectHandle {
 impl From<Hierarchy> for TpmHandle {
     fn from(hierarchy: Hierarchy) -> TpmHandle {
         match hierarchy {
-            Hierarchy::Owner => TpmHandle::Permanent(PermanentTpmHandle::OwnerHandle),
-            Hierarchy::Platform => TpmHandle::Permanent(PermanentTpmHandle::PlatformHandle),
-            Hierarchy::Endorsement => TpmHandle::Permanent(PermanentTpmHandle::EndorsementHandle),
-            Hierarchy::Null => TpmHandle::Permanent(PermanentTpmHandle::NullHandle),
+            Hierarchy::Owner => TpmHandle::Permanent(PermanentTpmHandle::Owner),
+            Hierarchy::Platform => TpmHandle::Permanent(PermanentTpmHandle::Platform),
+            Hierarchy::Endorsement => TpmHandle::Permanent(PermanentTpmHandle::Endorsement),
+            Hierarchy::Null => TpmHandle::Permanent(PermanentTpmHandle::Null),
         }
     }
 }
@@ -48,10 +48,10 @@ impl TryFrom<ObjectHandle> for Hierarchy {
 
     fn try_from(object_handle: ObjectHandle) -> Result<Hierarchy> {
         match object_handle {
-            ObjectHandle::OwnerHandle => Ok(Hierarchy::Owner),
-            ObjectHandle::PlatformHandle => Ok(Hierarchy::Platform),
-            ObjectHandle::EndorsementHandle => Ok(Hierarchy::Endorsement),
-            ObjectHandle::NullHandle => Ok(Hierarchy::Null),
+            ObjectHandle::Owner => Ok(Hierarchy::Owner),
+            ObjectHandle::Platform => Ok(Hierarchy::Platform),
+            ObjectHandle::Endorsement => Ok(Hierarchy::Endorsement),
+            ObjectHandle::Null => Ok(Hierarchy::Null),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
@@ -63,10 +63,10 @@ impl TryFrom<TpmHandle> for Hierarchy {
     fn try_from(tpm_handle: TpmHandle) -> Result<Hierarchy> {
         match tpm_handle {
             TpmHandle::Permanent(permanent_handle) => match permanent_handle {
-                PermanentTpmHandle::OwnerHandle => Ok(Hierarchy::Owner),
-                PermanentTpmHandle::PlatformHandle => Ok(Hierarchy::Platform),
-                PermanentTpmHandle::EndorsementHandle => Ok(Hierarchy::Endorsement),
-                PermanentTpmHandle::NullHandle => Ok(Hierarchy::Null),
+                PermanentTpmHandle::Owner => Ok(Hierarchy::Owner),
+                PermanentTpmHandle::Platform => Ok(Hierarchy::Platform),
+                PermanentTpmHandle::Endorsement => Ok(Hierarchy::Endorsement),
+                PermanentTpmHandle::Null => Ok(Hierarchy::Null),
                 _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
             },
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
@@ -89,11 +89,11 @@ pub enum Enables {
 impl From<Enables> for ObjectHandle {
     fn from(enables: Enables) -> ObjectHandle {
         match enables {
-            Enables::Owner => ObjectHandle::OwnerHandle,
-            Enables::Platform => ObjectHandle::PlatformHandle,
-            Enables::Endorsement => ObjectHandle::EndorsementHandle,
-            Enables::PlatformNv => ObjectHandle::PlatformNvHandle,
-            Enables::Null => ObjectHandle::NullHandle,
+            Enables::Owner => ObjectHandle::Owner,
+            Enables::Platform => ObjectHandle::Platform,
+            Enables::Endorsement => ObjectHandle::Endorsement,
+            Enables::PlatformNv => ObjectHandle::PlatformNv,
+            Enables::Null => ObjectHandle::Null,
         }
     }
 }
@@ -101,11 +101,11 @@ impl From<Enables> for ObjectHandle {
 impl From<Enables> for TpmHandle {
     fn from(enables: Enables) -> TpmHandle {
         match enables {
-            Enables::Owner => TpmHandle::Permanent(PermanentTpmHandle::OwnerHandle),
-            Enables::Platform => TpmHandle::Permanent(PermanentTpmHandle::PlatformHandle),
-            Enables::Endorsement => TpmHandle::Permanent(PermanentTpmHandle::EndorsementHandle),
-            Enables::PlatformNv => TpmHandle::Permanent(PermanentTpmHandle::PlatformNvHandle),
-            Enables::Null => TpmHandle::Permanent(PermanentTpmHandle::NullHandle),
+            Enables::Owner => TpmHandle::Permanent(PermanentTpmHandle::Owner),
+            Enables::Platform => TpmHandle::Permanent(PermanentTpmHandle::Platform),
+            Enables::Endorsement => TpmHandle::Permanent(PermanentTpmHandle::Endorsement),
+            Enables::PlatformNv => TpmHandle::Permanent(PermanentTpmHandle::PlatformNv),
+            Enables::Null => TpmHandle::Permanent(PermanentTpmHandle::Null),
         }
     }
 }
@@ -115,11 +115,11 @@ impl TryFrom<ObjectHandle> for Enables {
 
     fn try_from(object_handle: ObjectHandle) -> Result<Enables> {
         match object_handle {
-            ObjectHandle::OwnerHandle => Ok(Enables::Owner),
-            ObjectHandle::PlatformHandle => Ok(Enables::Platform),
-            ObjectHandle::EndorsementHandle => Ok(Enables::Endorsement),
-            ObjectHandle::PlatformNvHandle => Ok(Enables::PlatformNv),
-            ObjectHandle::NullHandle => Ok(Enables::Null),
+            ObjectHandle::Owner => Ok(Enables::Owner),
+            ObjectHandle::Platform => Ok(Enables::Platform),
+            ObjectHandle::Endorsement => Ok(Enables::Endorsement),
+            ObjectHandle::PlatformNv => Ok(Enables::PlatformNv),
+            ObjectHandle::Null => Ok(Enables::Null),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
@@ -131,11 +131,11 @@ impl TryFrom<TpmHandle> for Enables {
     fn try_from(tpm_handle: TpmHandle) -> Result<Enables> {
         match tpm_handle {
             TpmHandle::Permanent(permanent_handle) => match permanent_handle {
-                PermanentTpmHandle::OwnerHandle => Ok(Enables::Owner),
-                PermanentTpmHandle::PlatformHandle => Ok(Enables::Platform),
-                PermanentTpmHandle::EndorsementHandle => Ok(Enables::Endorsement),
-                PermanentTpmHandle::PlatformNvHandle => Ok(Enables::PlatformNv),
-                PermanentTpmHandle::NullHandle => Ok(Enables::Null),
+                PermanentTpmHandle::Owner => Ok(Enables::Owner),
+                PermanentTpmHandle::Platform => Ok(Enables::Platform),
+                PermanentTpmHandle::Endorsement => Ok(Enables::Endorsement),
+                PermanentTpmHandle::PlatformNv => Ok(Enables::PlatformNv),
+                PermanentTpmHandle::Null => Ok(Enables::Null),
                 _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
             },
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
@@ -157,10 +157,10 @@ pub enum HierarchyAuth {
 impl From<HierarchyAuth> for ObjectHandle {
     fn from(hierarchy_auth: HierarchyAuth) -> ObjectHandle {
         match hierarchy_auth {
-            HierarchyAuth::Owner => ObjectHandle::OwnerHandle,
-            HierarchyAuth::Platform => ObjectHandle::PlatformHandle,
-            HierarchyAuth::Endorsement => ObjectHandle::EndorsementHandle,
-            HierarchyAuth::Lockout => ObjectHandle::LockoutHandle,
+            HierarchyAuth::Owner => ObjectHandle::Owner,
+            HierarchyAuth::Platform => ObjectHandle::Platform,
+            HierarchyAuth::Endorsement => ObjectHandle::Endorsement,
+            HierarchyAuth::Lockout => ObjectHandle::Lockout,
         }
     }
 }
@@ -168,12 +168,10 @@ impl From<HierarchyAuth> for ObjectHandle {
 impl From<HierarchyAuth> for TpmHandle {
     fn from(hierarchy_auth: HierarchyAuth) -> TpmHandle {
         match hierarchy_auth {
-            HierarchyAuth::Owner => TpmHandle::Permanent(PermanentTpmHandle::OwnerHandle),
-            HierarchyAuth::Platform => TpmHandle::Permanent(PermanentTpmHandle::PlatformHandle),
-            HierarchyAuth::Endorsement => {
-                TpmHandle::Permanent(PermanentTpmHandle::EndorsementHandle)
-            }
-            HierarchyAuth::Lockout => TpmHandle::Permanent(PermanentTpmHandle::LockoutHandle),
+            HierarchyAuth::Owner => TpmHandle::Permanent(PermanentTpmHandle::Owner),
+            HierarchyAuth::Platform => TpmHandle::Permanent(PermanentTpmHandle::Platform),
+            HierarchyAuth::Endorsement => TpmHandle::Permanent(PermanentTpmHandle::Endorsement),
+            HierarchyAuth::Lockout => TpmHandle::Permanent(PermanentTpmHandle::Lockout),
         }
     }
 }
@@ -183,10 +181,10 @@ impl TryFrom<ObjectHandle> for HierarchyAuth {
 
     fn try_from(object_handle: ObjectHandle) -> Result<HierarchyAuth> {
         match object_handle {
-            ObjectHandle::OwnerHandle => Ok(HierarchyAuth::Owner),
-            ObjectHandle::PlatformHandle => Ok(HierarchyAuth::Platform),
-            ObjectHandle::EndorsementHandle => Ok(HierarchyAuth::Endorsement),
-            ObjectHandle::LockoutHandle => Ok(HierarchyAuth::Lockout),
+            ObjectHandle::Owner => Ok(HierarchyAuth::Owner),
+            ObjectHandle::Platform => Ok(HierarchyAuth::Platform),
+            ObjectHandle::Endorsement => Ok(HierarchyAuth::Endorsement),
+            ObjectHandle::Lockout => Ok(HierarchyAuth::Lockout),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
@@ -198,10 +196,10 @@ impl TryFrom<TpmHandle> for HierarchyAuth {
     fn try_from(tpm_handle: TpmHandle) -> Result<HierarchyAuth> {
         match tpm_handle {
             TpmHandle::Permanent(permanent_handle) => match permanent_handle {
-                PermanentTpmHandle::OwnerHandle => Ok(HierarchyAuth::Owner),
-                PermanentTpmHandle::PlatformHandle => Ok(HierarchyAuth::Platform),
-                PermanentTpmHandle::EndorsementHandle => Ok(HierarchyAuth::Endorsement),
-                PermanentTpmHandle::LockoutHandle => Ok(HierarchyAuth::Lockout),
+                PermanentTpmHandle::Owner => Ok(HierarchyAuth::Owner),
+                PermanentTpmHandle::Platform => Ok(HierarchyAuth::Platform),
+                PermanentTpmHandle::Endorsement => Ok(HierarchyAuth::Endorsement),
+                PermanentTpmHandle::Lockout => Ok(HierarchyAuth::Lockout),
                 _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
             },
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
@@ -222,7 +220,7 @@ pub enum Platform {
 
 impl From<Platform> for AuthHandle {
     fn from(_: Platform) -> AuthHandle {
-        AuthHandle::PlatformHandle
+        AuthHandle::Platform
     }
 }
 
@@ -231,7 +229,7 @@ impl TryFrom<AuthHandle> for Platform {
 
     fn try_from(auth_handle: AuthHandle) -> Result<Platform> {
         match auth_handle {
-            AuthHandle::PlatformHandle => Ok(Platform::Platform),
+            AuthHandle::Platform => Ok(Platform::Platform),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
@@ -242,25 +240,25 @@ impl TryFrom<AuthHandle> for Platform {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Owner {
     Owner,
-    Null, // TODO: Remove null and use Option instead?
+    Null,
 }
 
-impl From<Owner> for TpmConstantsHandle {
-    fn from(owner: Owner) -> TpmConstantsHandle {
+impl From<Owner> for ObjectHandle {
+    fn from(owner: Owner) -> ObjectHandle {
         match owner {
-            Owner::Owner => TpmConstantsHandle::Owner,
-            Owner::Null => TpmConstantsHandle::Null,
+            Owner::Owner => ObjectHandle::Owner,
+            Owner::Null => ObjectHandle::Null,
         }
     }
 }
 
-impl TryFrom<TpmConstantsHandle> for Owner {
+impl TryFrom<ObjectHandle> for Owner {
     type Error = Error;
 
-    fn try_from(tpm_constant_handle: TpmConstantsHandle) -> Result<Owner> {
-        match tpm_constant_handle {
-            TpmConstantsHandle::Owner => Ok(Owner::Owner),
-            TpmConstantsHandle::Null => Ok(Owner::Null),
+    fn try_from(object_handle: ObjectHandle) -> Result<Owner> {
+        match object_handle {
+            ObjectHandle::Owner => Ok(Owner::Owner),
+            ObjectHandle::Null => Ok(Owner::Null),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
@@ -274,22 +272,22 @@ pub enum Endorsement {
     Null,
 }
 
-impl From<Endorsement> for TpmConstantsHandle {
-    fn from(endorsement: Endorsement) -> TpmConstantsHandle {
+impl From<Endorsement> for ObjectHandle {
+    fn from(endorsement: Endorsement) -> ObjectHandle {
         match endorsement {
-            Endorsement::Endorsement => TpmConstantsHandle::Endorsement,
-            Endorsement::Null => TpmConstantsHandle::Null,
+            Endorsement::Endorsement => ObjectHandle::Endorsement,
+            Endorsement::Null => ObjectHandle::Null,
         }
     }
 }
 
-impl TryFrom<TpmConstantsHandle> for Endorsement {
+impl TryFrom<ObjectHandle> for Endorsement {
     type Error = Error;
 
-    fn try_from(tpm_constants_handle: TpmConstantsHandle) -> Result<Endorsement> {
-        match tpm_constants_handle {
-            TpmConstantsHandle::Endorsement => Ok(Endorsement::Endorsement),
-            TpmConstantsHandle::Null => Ok(Endorsement::Null),
+    fn try_from(object_handle: ObjectHandle) -> Result<Endorsement> {
+        match object_handle {
+            ObjectHandle::Endorsement => Ok(Endorsement::Endorsement),
+            ObjectHandle::Null => Ok(Endorsement::Null),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
@@ -306,8 +304,8 @@ pub enum Provision {
 impl From<Provision> for AuthHandle {
     fn from(provision: Provision) -> AuthHandle {
         match provision {
-            Provision::Owner => AuthHandle::OwnerHandle,
-            Provision::Platform => AuthHandle::PlatformHandle,
+            Provision::Owner => AuthHandle::Owner,
+            Provision::Platform => AuthHandle::Platform,
         }
     }
 }
@@ -317,8 +315,8 @@ impl TryFrom<AuthHandle> for Provision {
 
     fn try_from(auth_handle: AuthHandle) -> Result<Provision> {
         match auth_handle {
-            AuthHandle::OwnerHandle => Ok(Provision::Owner),
-            AuthHandle::PlatformHandle => Ok(Provision::Platform),
+            AuthHandle::Owner => Ok(Provision::Owner),
+            AuthHandle::Platform => Ok(Provision::Platform),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
@@ -335,8 +333,8 @@ pub enum Clear {
 impl From<Clear> for AuthHandle {
     fn from(clear: Clear) -> AuthHandle {
         match clear {
-            Clear::Owner => AuthHandle::OwnerHandle,
-            Clear::Platform => AuthHandle::PlatformHandle,
+            Clear::Owner => AuthHandle::Owner,
+            Clear::Platform => AuthHandle::Platform,
         }
     }
 }
@@ -346,8 +344,8 @@ impl TryFrom<AuthHandle> for Clear {
 
     fn try_from(auth_handle: AuthHandle) -> Result<Self> {
         match auth_handle {
-            AuthHandle::OwnerHandle => Ok(Clear::Owner),
-            AuthHandle::PlatformHandle => Ok(Clear::Platform),
+            AuthHandle::Owner => Ok(Clear::Owner),
+            AuthHandle::Platform => Ok(Clear::Platform),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
@@ -365,8 +363,8 @@ pub enum NvAuth {
 impl From<NvAuth> for AuthHandle {
     fn from(nv_auth: NvAuth) -> AuthHandle {
         match nv_auth {
-            NvAuth::Platform => AuthHandle::PlatformHandle,
-            NvAuth::Owner => AuthHandle::OwnerHandle,
+            NvAuth::Platform => AuthHandle::Platform,
+            NvAuth::Owner => AuthHandle::Owner,
             NvAuth::NvIndex(nv_index_handle) => nv_index_handle.into(),
         }
     }
@@ -377,8 +375,8 @@ impl TryFrom<AuthHandle> for NvAuth {
 
     fn try_from(auth_handle: AuthHandle) -> Result<NvAuth> {
         match auth_handle {
-            AuthHandle::PlatformHandle => Ok(NvAuth::Platform),
-            AuthHandle::OwnerHandle => Ok(NvAuth::Owner),
+            AuthHandle::Platform => Ok(NvAuth::Platform),
+            AuthHandle::Owner => Ok(NvAuth::Owner),
             _ => Ok(NvAuth::NvIndex(NvIndexHandle::from(auth_handle))),
         }
     }
@@ -391,18 +389,18 @@ pub enum Lockout {
     Lockout,
 }
 
-impl From<Lockout> for TpmConstantsHandle {
-    fn from(_: Lockout) -> TpmConstantsHandle {
-        TpmConstantsHandle::Lockout
+impl From<Lockout> for ObjectHandle {
+    fn from(_: Lockout) -> ObjectHandle {
+        ObjectHandle::Lockout
     }
 }
 
-impl TryFrom<TpmConstantsHandle> for Lockout {
+impl TryFrom<ObjectHandle> for Lockout {
     type Error = Error;
 
-    fn try_from(tpm_constants_handle: TpmConstantsHandle) -> Result<Lockout> {
-        match tpm_constants_handle {
-            TpmConstantsHandle::Lockout => Ok(Lockout::Lockout),
+    fn try_from(object_handle: ObjectHandle) -> Result<Lockout> {
+        match object_handle {
+            ObjectHandle::Lockout => Ok(Lockout::Lockout),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -27,7 +27,7 @@ impl Session {
         session_handle: SessionHandle,
         auth_hash: HashingAlgorithm,
     ) -> Option<Session> {
-        if session_handle != SessionHandle::NoneHandle {
+        if session_handle != SessionHandle::None {
             Some(match session_type {
                 SessionType::Hmac => Session::Hmac(HmacSession::new(session_handle, auth_hash)),
                 SessionType::Policy => {
@@ -43,9 +43,7 @@ impl Session {
     /// Function for retrieving the SessionHandle from Option<Session>
     ///
     pub fn handle_from_option(session: Option<Session>) -> SessionHandle {
-        session
-            .map(|v| v.handle())
-            .unwrap_or(SessionHandle::NoneHandle)
+        session.map(|v| v.handle()).unwrap_or(SessionHandle::None)
     }
     ///
     /// Function for retrieving the session handle associated with
@@ -56,7 +54,7 @@ impl Session {
             Session::Hmac(session_object) => session_object.handle(),
             Session::Policy(session_object) => session_object.handle(),
             Session::Trial(session_object) => session_object.handle(),
-            Session::Password => SessionHandle::PasswordHandle,
+            Session::Password => SessionHandle::Password,
         }
     }
     ///

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -2410,15 +2410,11 @@ mod test_nv_read {
         let expected_data = MaxNvBuffer::try_from(value.to_vec()).unwrap();
 
         // Write the data using Owner authorization
-        let write_result = context.nv_write(
-            AuthHandle::OwnerHandle,
-            owner_nv_index_handle,
-            &expected_data,
-            0,
-        );
+        let write_result =
+            context.nv_write(AuthHandle::Owner, owner_nv_index_handle, &expected_data, 0);
         // read data using owner authorization
         let read_result = context.nv_read(
-            AuthHandle::OwnerHandle,
+            AuthHandle::Owner,
             owner_nv_index_handle,
             value.len() as u16,
             0,
@@ -2704,7 +2700,7 @@ mod test_tr_from_tpm_public {
             .tr_close(&mut handle_to_be_closed)
             .map_err(|e| cleanup(&mut context, e, initial_nv_index_handle, "tr_close"))
             .unwrap();
-        assert_eq!(handle_to_be_closed, ObjectHandle::NoneHandle);
+        assert_eq!(handle_to_be_closed, ObjectHandle::None);
         // The value of the handle_to_be_closed will be set to a 'None' handle
         // if the operations was successful.
 

--- a/tests/handles_handle_test.rs
+++ b/tests/handles_handle_test.rs
@@ -1,52 +1,29 @@
-mod test_tpm_constants_handle {
-    use std::convert::{From, TryFrom};
+mod constant_object_handles {
+    use std::convert::From;
     use tss_esapi::{
-        handles::{ObjectHandle, TpmConstantsHandle},
+        handles::ObjectHandle,
         tss2_esys::{
-            ESYS_TR, ESYS_TR_RH_ENDORSEMENT, ESYS_TR_RH_LOCKOUT, ESYS_TR_RH_NULL, ESYS_TR_RH_OWNER,
-            ESYS_TR_RH_PLATFORM, ESYS_TR_RH_PLATFORM_NV,
+            ESYS_TR, ESYS_TR_NONE, ESYS_TR_RH_ENDORSEMENT, ESYS_TR_RH_LOCKOUT, ESYS_TR_RH_NULL,
+            ESYS_TR_RH_OWNER, ESYS_TR_RH_PLATFORM, ESYS_TR_RH_PLATFORM_NV,
         },
     };
 
     #[test]
-    fn test_conversion_of_invalid_handle() {
-        let invalid_value: ESYS_TR = 0xFFFFFFFF;
-        let invalid_object_handle: ObjectHandle = ObjectHandle::from(invalid_value);
-        let _ = TpmConstantsHandle::try_from(invalid_value).unwrap_err();
-        let _ = TpmConstantsHandle::try_from(invalid_object_handle).unwrap_err();
-    }
-
-    #[test]
-    fn test_conversion_of_valid_handle() {
+    fn test_constants_conversions() {
         // closure used for the repeated tests
-        let conversion_check = |valid_esys_tr_value: ESYS_TR| {
-            let valid_object_handle = ObjectHandle::try_from(valid_esys_tr_value).unwrap();
-
-            // Conversion from ESYS_TR and ObjectHandle.
-            let from_esys_tr = TpmConstantsHandle::try_from(valid_esys_tr_value).unwrap();
-            let from_object_handle = TpmConstantsHandle::try_from(valid_esys_tr_value).unwrap();
-            assert_eq!(from_esys_tr, from_object_handle);
-
-            // Conversion into ObjectHandle
-            let into_object_handle_1: ObjectHandle = from_esys_tr.into();
-            let into_object_handle_2: ObjectHandle = from_object_handle.into();
-            assert_eq!(valid_object_handle, into_object_handle_1);
-            assert_eq!(valid_object_handle, into_object_handle_2);
-
-            // Conversion into ESYS_TR
-            let into_esys_tr_1: ESYS_TR = from_esys_tr.into();
-            let into_esys_tr_2: ESYS_TR = from_object_handle.into();
-            assert_eq!(valid_esys_tr_value, into_esys_tr_1);
-            assert_eq!(valid_esys_tr_value, into_esys_tr_2);
+        let conversion_check = |esys_handle: ESYS_TR, object_handle: ObjectHandle| {
+            assert_eq!(esys_handle, ESYS_TR::from(object_handle));
+            assert_eq!(object_handle, ObjectHandle::from(esys_handle));
         };
 
-        // Check the valid values
-        conversion_check(ESYS_TR_RH_OWNER);
-        conversion_check(ESYS_TR_RH_NULL);
-        conversion_check(ESYS_TR_RH_LOCKOUT);
-        conversion_check(ESYS_TR_RH_ENDORSEMENT);
-        conversion_check(ESYS_TR_RH_PLATFORM);
-        conversion_check(ESYS_TR_RH_PLATFORM_NV);
+        // Check conversion of esys handles to TPM constants
+        conversion_check(ESYS_TR_RH_OWNER, ObjectHandle::Owner);
+        conversion_check(ESYS_TR_RH_NULL, ObjectHandle::Null);
+        conversion_check(ESYS_TR_RH_LOCKOUT, ObjectHandle::Lockout);
+        conversion_check(ESYS_TR_RH_ENDORSEMENT, ObjectHandle::Endorsement);
+        conversion_check(ESYS_TR_RH_PLATFORM, ObjectHandle::Platform);
+        conversion_check(ESYS_TR_RH_PLATFORM_NV, ObjectHandle::PlatformNv);
+        conversion_check(ESYS_TR_NONE, ObjectHandle::None);
     }
 }
 
@@ -133,42 +110,67 @@ mod test_pcr_handle {
     }
 }
 
-mod test_passowrd_handle {
-    use std::convert::From;
+mod test_auth_handle {
     use tss_esapi::{
-        handles::{ObjectHandle, SessionHandle},
-        tss2_esys::{ESYS_TR, ESYS_TR_PASSWORD},
+        handles::{AuthHandle, ObjectHandle},
+        tss2_esys::{
+            ESYS_TR, ESYS_TR_RH_ENDORSEMENT, ESYS_TR_RH_LOCKOUT, ESYS_TR_RH_OWNER,
+            ESYS_TR_RH_PLATFORM,
+        },
     };
 
     #[test]
-    fn test_conversion_of_valid_handle() {
-        let valid_esys_handle: ESYS_TR = ESYS_TR_PASSWORD;
-        let valid_object_handle = ObjectHandle::from(valid_esys_handle);
-        let valid_session_handle = SessionHandle::from(valid_esys_handle);
-        assert_eq!(ObjectHandle::PasswordHandle, valid_object_handle);
-        assert_eq!(SessionHandle::PasswordHandle, valid_session_handle);
+    fn test_constants_conversions() {
+        let conversion_check =
+            |esys_handle: ESYS_TR, object_handle: ObjectHandle, auth_handle: AuthHandle| {
+                assert_eq!(esys_handle, ESYS_TR::from(auth_handle));
+                assert_eq!(auth_handle, AuthHandle::from(esys_handle));
+                assert_eq!(object_handle, ObjectHandle::from(auth_handle));
+                assert_eq!(auth_handle, AuthHandle::from(object_handle));
+            };
 
-        let esys_handle_1: ESYS_TR = ObjectHandle::PasswordHandle.into();
-        let esys_handle_2: ESYS_TR = SessionHandle::PasswordHandle.into();
-        assert_eq!(valid_esys_handle, esys_handle_1);
-        assert_eq!(valid_esys_handle, esys_handle_2);
+        // Check conversion of esys handles to TPM constants
+        conversion_check(ESYS_TR_RH_OWNER, ObjectHandle::Owner, AuthHandle::Owner);
+        conversion_check(
+            ESYS_TR_RH_LOCKOUT,
+            ObjectHandle::Lockout,
+            AuthHandle::Lockout,
+        );
+        conversion_check(
+            ESYS_TR_RH_ENDORSEMENT,
+            ObjectHandle::Endorsement,
+            AuthHandle::Endorsement,
+        );
+        conversion_check(
+            ESYS_TR_RH_PLATFORM,
+            ObjectHandle::Platform,
+            AuthHandle::Platform,
+        );
     }
 }
 
-mod test_none_handle {
+mod test_session_handle {
     use std::convert::From;
     use tss_esapi::{
-        handles::ObjectHandle,
-        tss2_esys::{ESYS_TR, ESYS_TR_NONE},
+        handles::{ObjectHandle, SessionHandle},
+        tss2_esys::{ESYS_TR, ESYS_TR_NONE, ESYS_TR_PASSWORD},
     };
 
     #[test]
-    fn test_conversion_of_valid_handle() {
-        let valid_esys_handle: ESYS_TR = ESYS_TR_NONE;
-        let valid_object_handle = ObjectHandle::from(valid_esys_handle);
-        assert_eq!(ObjectHandle::NoneHandle, valid_object_handle);
+    fn test_constants_conversions() {
+        let conversion_check =
+            |esys_handle: ESYS_TR, object_handle: ObjectHandle, session_handle: SessionHandle| {
+                assert_eq!(esys_handle, ESYS_TR::from(session_handle));
+                assert_eq!(session_handle, SessionHandle::from(esys_handle));
+                assert_eq!(object_handle, ObjectHandle::from(session_handle));
+                assert_eq!(session_handle, SessionHandle::from(object_handle));
+            };
 
-        let esys_handle_1: ESYS_TR = ObjectHandle::NoneHandle.into();
-        assert_eq!(valid_esys_handle, esys_handle_1);
+        conversion_check(
+            ESYS_TR_PASSWORD,
+            ObjectHandle::Password,
+            SessionHandle::Password,
+        );
+        conversion_check(ESYS_TR_NONE, ObjectHandle::None, SessionHandle::None);
     }
 }

--- a/tests/interface_types_resource_handle_tests.rs
+++ b/tests/interface_types_resource_handle_tests.rs
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::convert::TryFrom;
 use tss_esapi::{
-    constants::tss::{TPM2_RH_ENDORSEMENT, TPM2_RH_NULL, TPM2_RH_OWNER, TPM2_RH_PLATFORM},
-    handles::{AuthHandle, NvIndexHandle, TpmConstantsHandle},
+    handles::{
+        AuthHandle, NvIndexHandle, ObjectHandle, PermanentTpmHandle, TpmConstantsHandle, TpmHandle,
+    },
     interface_types::resource_handles::{
-        Clear, Endorsement, Hierarchy, HierarchyAuth, Lockout, NvAuth, Owner, Platform, Provision,
+        Clear, Enables, Endorsement, Hierarchy, HierarchyAuth, Lockout, NvAuth, Owner, Platform,
+        Provision,
     },
-    tss2_esys::{
-        ESYS_TR, ESYS_TR_RH_ENDORSEMENT, ESYS_TR_RH_NULL, ESYS_TR_RH_OWNER, ESYS_TR_RH_PLATFORM,
-        TPM2_RH,
-    },
+    tss2_esys::ESYS_TR,
 };
 
 mod test_hierarchy {
@@ -18,9 +17,9 @@ mod test_hierarchy {
     #[test]
     fn test_conversions() {
         let test_conversion =
-            |hierarchy: Hierarchy, tpm_rh: TPM2_RH, esys_rh: ESYS_TR, name: &str| {
-                assert_eq!(hierarchy.esys_rh(), esys_rh);
-                assert_eq!(hierarchy.rh(), tpm_rh);
+            |hierarchy: Hierarchy, tpm_rh: TpmHandle, esys_rh: ObjectHandle, name: &str| {
+                assert_eq!(ObjectHandle::from(hierarchy), esys_rh);
+                assert_eq!(TpmHandle::from(hierarchy), tpm_rh);
                 let from_esys_rh = Hierarchy::try_from(esys_rh).unwrap_or_else(|_| {
                     panic!(format!(
                         "Failed to create Hierarchy from ESYS_TR_RH={}",
@@ -28,30 +27,95 @@ mod test_hierarchy {
                     ))
                 });
                 assert_eq!(from_esys_rh, hierarchy);
-                assert_eq!(from_esys_rh.esys_rh(), esys_rh);
-                assert_eq!(from_esys_rh.rh(), tpm_rh);
+                assert_eq!(ObjectHandle::from(from_esys_rh), esys_rh);
+                assert_eq!(TpmHandle::from(from_esys_rh), tpm_rh);
                 let from_tpm_rh = Hierarchy::try_from(tpm_rh).unwrap_or_else(|_| {
                     panic!(format!("Failed to create Hierarchy from TPM2_RH={}", name))
                 });
                 assert_eq!(from_tpm_rh, hierarchy);
-                assert_eq!(from_tpm_rh.esys_rh(), esys_rh);
-                assert_eq!(from_tpm_rh.rh(), tpm_rh);
+                assert_eq!(ObjectHandle::from(from_tpm_rh), esys_rh);
+                assert_eq!(TpmHandle::from(from_tpm_rh), tpm_rh);
             };
 
-        test_conversion(Hierarchy::Owner, TPM2_RH_OWNER, ESYS_TR_RH_OWNER, "OWNER");
+        test_conversion(
+            Hierarchy::Owner,
+            TpmHandle::Permanent(PermanentTpmHandle::OwnerHandle),
+            ObjectHandle::OwnerHandle,
+            "OWNER",
+        );
         test_conversion(
             Hierarchy::Platform,
-            TPM2_RH_PLATFORM,
-            ESYS_TR_RH_PLATFORM,
+            TpmHandle::Permanent(PermanentTpmHandle::PlatformHandle),
+            ObjectHandle::PlatformHandle,
             "PLATFORM",
         );
         test_conversion(
             Hierarchy::Endorsement,
-            TPM2_RH_ENDORSEMENT,
-            ESYS_TR_RH_ENDORSEMENT,
+            TpmHandle::Permanent(PermanentTpmHandle::EndorsementHandle),
+            ObjectHandle::EndorsementHandle,
             "ENDORSEMENT",
         );
-        test_conversion(Hierarchy::Null, TPM2_RH_NULL, ESYS_TR_RH_NULL, "NULL");
+        test_conversion(
+            Hierarchy::Null,
+            TpmHandle::Permanent(PermanentTpmHandle::NullHandle),
+            ObjectHandle::NullHandle,
+            "NULL",
+        );
+    }
+}
+
+mod test_enables {
+    use super::*;
+    #[test]
+    fn test_conversions() {
+        let test_conversion =
+            |enables: Enables, tpm_rh: TpmHandle, esys_rh: ObjectHandle, name: &str| {
+                assert_eq!(ObjectHandle::from(enables), esys_rh);
+                assert_eq!(TpmHandle::from(enables), tpm_rh);
+                let from_esys_rh = Enables::try_from(esys_rh).unwrap_or_else(|_| {
+                    panic!(format!("Failed to create Enables from ESYS_TR_RH={}", name))
+                });
+                assert_eq!(from_esys_rh, enables);
+                assert_eq!(ObjectHandle::from(from_esys_rh), esys_rh);
+                assert_eq!(TpmHandle::from(from_esys_rh), tpm_rh);
+                let from_tpm_rh = Enables::try_from(tpm_rh).unwrap_or_else(|_| {
+                    panic!(format!("Failed to create Enables from TPM2_RH={}", name))
+                });
+                assert_eq!(from_tpm_rh, enables);
+                assert_eq!(ObjectHandle::from(from_tpm_rh), esys_rh);
+                assert_eq!(TpmHandle::from(from_tpm_rh), tpm_rh);
+            };
+
+        test_conversion(
+            Enables::Owner,
+            TpmHandle::Permanent(PermanentTpmHandle::OwnerHandle),
+            ObjectHandle::OwnerHandle,
+            "OWNER",
+        );
+        test_conversion(
+            Enables::Platform,
+            TpmHandle::Permanent(PermanentTpmHandle::PlatformHandle),
+            ObjectHandle::PlatformHandle,
+            "PLATFORM",
+        );
+        test_conversion(
+            Enables::Endorsement,
+            TpmHandle::Permanent(PermanentTpmHandle::EndorsementHandle),
+            ObjectHandle::EndorsementHandle,
+            "ENDORSEMENT",
+        );
+        test_conversion(
+            Enables::PlatformNv,
+            TpmHandle::Permanent(PermanentTpmHandle::PlatformNvHandle),
+            ObjectHandle::PlatformNvHandle,
+            "PLATFORM_NV",
+        );
+        test_conversion(
+            Enables::Null,
+            TpmHandle::Permanent(PermanentTpmHandle::NullHandle),
+            ObjectHandle::NullHandle,
+            "NULL",
+        );
     }
 }
 
@@ -59,47 +123,55 @@ mod test_hierarchy_auth {
     use super::*;
     #[test]
     fn test_conversions() {
-        let test_conversion =
-            |hierarchy_auth: HierarchyAuth, tpm_rh: TPM2_RH, esys_rh: ESYS_TR, name: &str| {
-                assert_eq!(hierarchy_auth.esys_rh(), esys_rh);
-                assert_eq!(hierarchy_auth.rh(), tpm_rh);
-                let from_esys_rh = HierarchyAuth::try_from(esys_rh).unwrap_or_else(|_| {
-                    panic!(format!(
-                        "Failed to create HierarchyAuth from ESYS_TR_RH={}",
-                        name
-                    ))
-                });
-                assert_eq!(from_esys_rh, hierarchy_auth);
-                assert_eq!(from_esys_rh.esys_rh(), esys_rh);
-                assert_eq!(from_esys_rh.rh(), tpm_rh);
-                let from_tpm_rh = HierarchyAuth::try_from(tpm_rh).unwrap_or_else(|_| {
-                    panic!(format!(
-                        "Failed to create HierarchyAuth from TPM2_RH={}",
-                        name
-                    ))
-                });
-                assert_eq!(from_tpm_rh, hierarchy_auth);
-                assert_eq!(from_tpm_rh.esys_rh(), esys_rh);
-                assert_eq!(from_tpm_rh.rh(), tpm_rh);
-            };
+        let test_conversion = |hierarchy_auth: HierarchyAuth,
+                               tpm_rh: TpmHandle,
+                               esys_rh: ObjectHandle,
+                               name: &str| {
+            assert_eq!(ObjectHandle::from(hierarchy_auth), esys_rh);
+            assert_eq!(TpmHandle::from(hierarchy_auth), tpm_rh);
+            let from_esys_rh = HierarchyAuth::try_from(esys_rh).unwrap_or_else(|_| {
+                panic!(format!(
+                    "Failed to create HierarchyAuth from ESYS_TR_RH={}",
+                    name
+                ))
+            });
+            assert_eq!(from_esys_rh, hierarchy_auth);
+            assert_eq!(ObjectHandle::from(from_esys_rh), esys_rh);
+            assert_eq!(TpmHandle::from(from_esys_rh), tpm_rh);
+            let from_tpm_rh = HierarchyAuth::try_from(tpm_rh).unwrap_or_else(|_| {
+                panic!(format!(
+                    "Failed to create HierarchyAuth from TPM2_RH={}",
+                    name
+                ))
+            });
+            assert_eq!(from_tpm_rh, hierarchy_auth);
+            assert_eq!(ObjectHandle::from(from_tpm_rh), esys_rh);
+            assert_eq!(TpmHandle::from(from_tpm_rh), tpm_rh);
+        };
 
         test_conversion(
             HierarchyAuth::Owner,
-            TPM2_RH_OWNER,
-            ESYS_TR_RH_OWNER,
+            TpmHandle::Permanent(PermanentTpmHandle::OwnerHandle),
+            ObjectHandle::OwnerHandle,
             "OWNER",
         );
         test_conversion(
             HierarchyAuth::Platform,
-            TPM2_RH_PLATFORM,
-            ESYS_TR_RH_PLATFORM,
+            TpmHandle::Permanent(PermanentTpmHandle::PlatformHandle),
+            ObjectHandle::PlatformHandle,
             "PLATFORM",
         );
         test_conversion(
             HierarchyAuth::Endorsement,
-            TPM2_RH_ENDORSEMENT,
-            ESYS_TR_RH_ENDORSEMENT,
+            TpmHandle::Permanent(PermanentTpmHandle::EndorsementHandle),
+            ObjectHandle::EndorsementHandle,
             "ENDORSEMENT",
+        );
+        test_conversion(
+            HierarchyAuth::Lockout,
+            TpmHandle::Permanent(PermanentTpmHandle::LockoutHandle),
+            ObjectHandle::LockoutHandle,
+            "LOCKOUT",
         );
     }
 }

--- a/tests/interface_types_resource_handle_tests.rs
+++ b/tests/interface_types_resource_handle_tests.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::convert::TryFrom;
 use tss_esapi::{
-    handles::{
-        AuthHandle, NvIndexHandle, ObjectHandle, PermanentTpmHandle, TpmConstantsHandle, TpmHandle,
-    },
+    handles::{AuthHandle, NvIndexHandle, ObjectHandle, PermanentTpmHandle, TpmHandle},
     interface_types::resource_handles::{
         Clear, Enables, Endorsement, Hierarchy, HierarchyAuth, Lockout, NvAuth, Owner, Platform,
         Provision,
@@ -39,26 +37,26 @@ mod test_hierarchy {
 
         test_conversion(
             Hierarchy::Owner,
-            TpmHandle::Permanent(PermanentTpmHandle::OwnerHandle),
-            ObjectHandle::OwnerHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Owner),
+            ObjectHandle::Owner,
             "OWNER",
         );
         test_conversion(
             Hierarchy::Platform,
-            TpmHandle::Permanent(PermanentTpmHandle::PlatformHandle),
-            ObjectHandle::PlatformHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Platform),
+            ObjectHandle::Platform,
             "PLATFORM",
         );
         test_conversion(
             Hierarchy::Endorsement,
-            TpmHandle::Permanent(PermanentTpmHandle::EndorsementHandle),
-            ObjectHandle::EndorsementHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Endorsement),
+            ObjectHandle::Endorsement,
             "ENDORSEMENT",
         );
         test_conversion(
             Hierarchy::Null,
-            TpmHandle::Permanent(PermanentTpmHandle::NullHandle),
-            ObjectHandle::NullHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Null),
+            ObjectHandle::Null,
             "NULL",
         );
     }
@@ -88,32 +86,32 @@ mod test_enables {
 
         test_conversion(
             Enables::Owner,
-            TpmHandle::Permanent(PermanentTpmHandle::OwnerHandle),
-            ObjectHandle::OwnerHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Owner),
+            ObjectHandle::Owner,
             "OWNER",
         );
         test_conversion(
             Enables::Platform,
-            TpmHandle::Permanent(PermanentTpmHandle::PlatformHandle),
-            ObjectHandle::PlatformHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Platform),
+            ObjectHandle::Platform,
             "PLATFORM",
         );
         test_conversion(
             Enables::Endorsement,
-            TpmHandle::Permanent(PermanentTpmHandle::EndorsementHandle),
-            ObjectHandle::EndorsementHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Endorsement),
+            ObjectHandle::Endorsement,
             "ENDORSEMENT",
         );
         test_conversion(
-            Enables::PlatformNv,
-            TpmHandle::Permanent(PermanentTpmHandle::PlatformNvHandle),
-            ObjectHandle::PlatformNvHandle,
+            Enables::Endorsement,
+            TpmHandle::Permanent(PermanentTpmHandle::Endorsement),
+            ObjectHandle::Endorsement,
             "PLATFORM_NV",
         );
         test_conversion(
             Enables::Null,
-            TpmHandle::Permanent(PermanentTpmHandle::NullHandle),
-            ObjectHandle::NullHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Null),
+            ObjectHandle::Null,
             "NULL",
         );
     }
@@ -151,26 +149,26 @@ mod test_hierarchy_auth {
 
         test_conversion(
             HierarchyAuth::Owner,
-            TpmHandle::Permanent(PermanentTpmHandle::OwnerHandle),
-            ObjectHandle::OwnerHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Owner),
+            ObjectHandle::Owner,
             "OWNER",
         );
         test_conversion(
             HierarchyAuth::Platform,
-            TpmHandle::Permanent(PermanentTpmHandle::PlatformHandle),
-            ObjectHandle::PlatformHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Platform),
+            ObjectHandle::Platform,
             "PLATFORM",
         );
         test_conversion(
             HierarchyAuth::Endorsement,
-            TpmHandle::Permanent(PermanentTpmHandle::EndorsementHandle),
-            ObjectHandle::EndorsementHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Endorsement),
+            ObjectHandle::Endorsement,
             "ENDORSEMENT",
         );
         test_conversion(
             HierarchyAuth::Lockout,
-            TpmHandle::Permanent(PermanentTpmHandle::LockoutHandle),
-            ObjectHandle::LockoutHandle,
+            TpmHandle::Permanent(PermanentTpmHandle::Lockout),
+            ObjectHandle::Lockout,
             "LOCKOUT",
         );
     }
@@ -180,12 +178,9 @@ mod test_platform {
     use super::*;
     #[test]
     fn test_conversions() {
+        assert_eq!(AuthHandle::from(Platform::Platform), AuthHandle::Platform);
         assert_eq!(
-            AuthHandle::from(Platform::Platform),
-            AuthHandle::PlatformHandle
-        );
-        assert_eq!(
-            Platform::try_from(AuthHandle::PlatformHandle)
+            Platform::try_from(AuthHandle::Platform)
                 .expect("Failed to convert AuthHandle into Platform"),
             Platform::Platform
         );
@@ -196,21 +191,15 @@ mod test_owner {
     use super::*;
     #[test]
     fn test_conversions() {
+        assert_eq!(ObjectHandle::from(Owner::Owner), ObjectHandle::Owner);
+        assert_eq!(ObjectHandle::from(Owner::Null), ObjectHandle::Null);
         assert_eq!(
-            TpmConstantsHandle::from(Owner::Owner),
-            TpmConstantsHandle::Owner
-        );
-        assert_eq!(
-            TpmConstantsHandle::from(Owner::Null),
-            TpmConstantsHandle::Null
-        );
-        assert_eq!(
-            Owner::try_from(TpmConstantsHandle::Owner)
+            Owner::try_from(ObjectHandle::Owner)
                 .expect("Failed to convert TpmConstantHandle into Owner"),
             Owner::Owner
         );
         assert_eq!(
-            Owner::try_from(TpmConstantsHandle::Null)
+            Owner::try_from(ObjectHandle::Null)
                 .expect("Failed to convert TpmConstantHandle into Owner"),
             Owner::Null
         );
@@ -222,20 +211,17 @@ mod test_endorsement {
     #[test]
     fn test_conversions() {
         assert_eq!(
-            TpmConstantsHandle::from(Endorsement::Endorsement),
-            TpmConstantsHandle::Endorsement
+            ObjectHandle::from(Endorsement::Endorsement),
+            ObjectHandle::Endorsement
         );
+        assert_eq!(ObjectHandle::from(Endorsement::Null), ObjectHandle::Null);
         assert_eq!(
-            TpmConstantsHandle::from(Endorsement::Null),
-            TpmConstantsHandle::Null
-        );
-        assert_eq!(
-            Endorsement::try_from(TpmConstantsHandle::Endorsement)
+            Endorsement::try_from(ObjectHandle::Endorsement)
                 .expect("Failed to convert TpmConstantHandle into Endorsement"),
             Endorsement::Endorsement
         );
         assert_eq!(
-            Endorsement::try_from(TpmConstantsHandle::Null)
+            Endorsement::try_from(ObjectHandle::Null)
                 .expect("Failed to convert TpmConstantHandle into Endorsement"),
             Endorsement::Null
         );
@@ -246,18 +232,15 @@ mod test_provision {
     use super::*;
     #[test]
     fn test_conversions() {
-        assert_eq!(AuthHandle::from(Provision::Owner), AuthHandle::OwnerHandle);
+        assert_eq!(AuthHandle::from(Provision::Owner), AuthHandle::Owner);
+        assert_eq!(AuthHandle::from(Provision::Platform), AuthHandle::Platform);
         assert_eq!(
-            AuthHandle::from(Provision::Platform),
-            AuthHandle::PlatformHandle
-        );
-        assert_eq!(
-            Provision::try_from(AuthHandle::OwnerHandle)
+            Provision::try_from(AuthHandle::Owner)
                 .expect("Failed to convert AuthHandle into Provision"),
             Provision::Owner
         );
         assert_eq!(
-            Provision::try_from(AuthHandle::PlatformHandle)
+            Provision::try_from(AuthHandle::Platform)
                 .expect("Failed to convert AuthHandle into Provision"),
             Provision::Platform
         );
@@ -268,18 +251,14 @@ mod test_clear {
     use super::*;
     #[test]
     fn test_conversions() {
-        assert_eq!(AuthHandle::from(Clear::Owner), AuthHandle::OwnerHandle);
+        assert_eq!(AuthHandle::from(Clear::Owner), AuthHandle::Owner);
+        assert_eq!(AuthHandle::from(Clear::Platform), AuthHandle::Platform);
         assert_eq!(
-            AuthHandle::from(Clear::Platform),
-            AuthHandle::PlatformHandle
-        );
-        assert_eq!(
-            Clear::try_from(AuthHandle::OwnerHandle)
-                .expect("Failed to convert AuthHandle into Clear"),
+            Clear::try_from(AuthHandle::Owner).expect("Failed to convert AuthHandle into Clear"),
             Clear::Owner
         );
         assert_eq!(
-            Clear::try_from(AuthHandle::PlatformHandle)
+            Clear::try_from(AuthHandle::Platform)
                 .expect("Failed to convert AuthHandle into Provision"),
             Clear::Platform
         );
@@ -291,11 +270,8 @@ mod test_nv_auth {
 
     #[test]
     fn test_conversions() {
-        assert_eq!(
-            AuthHandle::from(NvAuth::Platform),
-            AuthHandle::PlatformHandle
-        );
-        assert_eq!(AuthHandle::from(NvAuth::Owner), AuthHandle::OwnerHandle);
+        assert_eq!(AuthHandle::from(NvAuth::Platform), AuthHandle::Platform);
+        assert_eq!(AuthHandle::from(NvAuth::Owner), AuthHandle::Owner);
 
         let esys_handle: ESYS_TR = 0x12345678;
         let nv_index_handle = NvIndexHandle::from(esys_handle);
@@ -305,13 +281,12 @@ mod test_nv_auth {
         );
 
         assert_eq!(
-            NvAuth::try_from(AuthHandle::PlatformHandle)
+            NvAuth::try_from(AuthHandle::Platform)
                 .expect("Failed to convert AuthHandle into NvAuth"),
             NvAuth::Platform
         );
         assert_eq!(
-            NvAuth::try_from(AuthHandle::OwnerHandle)
-                .expect("Failed to convert AuthHandle into NvAuth"),
+            NvAuth::try_from(AuthHandle::Owner).expect("Failed to convert AuthHandle into NvAuth"),
             NvAuth::Owner
         );
         assert_eq!(
@@ -326,12 +301,9 @@ mod test_lockout {
     use super::*;
     #[test]
     fn test_conversions() {
+        assert_eq!(ObjectHandle::from(Lockout::Lockout), ObjectHandle::Lockout);
         assert_eq!(
-            TpmConstantsHandle::from(Lockout::Lockout),
-            TpmConstantsHandle::Lockout
-        );
-        assert_eq!(
-            Lockout::try_from(TpmConstantsHandle::Lockout)
+            Lockout::try_from(ObjectHandle::Lockout)
                 .expect("Failed to convert TpmConstantHandle into Lockout"),
             Lockout::Lockout
         );


### PR DESCRIPTION
- Made custom build step provide the major version of the tpm2-tss lib
  as suggested by @puiterwijk [here](https://github.com/parallaxsecond/rust-tss-esapi/pull/145#issuecomment-725917955)
- Changed some Context methods to convert the Hierarchy to either
  a TpmHandle or ObjectHandle depending on the tpm2-tss major version.
- Added the permamnent handles that can be found in the specification to PermenentTpmHandle.
- Added more constant handles to ObjectHandle.
- Made it possible to convert Hierarchy, HierarchyAuth and Enables to and from ObjectHandle and Tpmhandle.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>