### PR TITLE
Improved handling of handles on drop.

### DIFF
--- a/src/context/handle_manager.rs
+++ b/src/context/handle_manager.rs
@@ -1,0 +1,133 @@
+use crate::{handles::ObjectHandle, tss2_esys::ESYS_TR, Error, Result, WrapperErrorKind};
+use log::error;
+use std::collections::HashMap;
+
+/// Enum representing the action to be taken
+/// when the handle is dropped.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HandleDropAction {
+    Close,
+    Flush,
+}
+
+/// The HandleManager is responsible for storing
+/// the handles used by Context iand thier states.
+/// In order to make sure the correct handles get
+/// flushed and closed when the Context is droped.
+#[derive(Debug)]
+pub struct HandleManager {
+    open_handles: HashMap<ObjectHandle, HandleDropAction>,
+}
+
+impl HandleManager {
+    /// Creates a new HandleManager
+    pub fn new() -> HandleManager {
+        HandleManager {
+            open_handles: HashMap::new(),
+        }
+    }
+
+    /// Adds a handle to the HandleManager
+    pub fn add_handle(
+        &mut self,
+        handle: ObjectHandle,
+        handle_drop_action: HandleDropAction,
+    ) -> Result<()> {
+        if handle == ObjectHandle::None || handle == ObjectHandle::Null {
+            error!("Handle manager does not handle None or Null handles");
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+
+        if self.open_handles.contains_key(&handle) {
+            error!("Handle({}) is already open", ESYS_TR::from(handle));
+            return Err(Error::local_error(WrapperErrorKind::InvalidHandleState));
+        }
+        let _ = self.open_handles.insert(handle, handle_drop_action);
+        Ok(())
+    }
+
+    /// Sets the handle as flushed which removes it from the manager.
+    ///
+    /// # Error
+    /// If the handle was not set to be flushed then this will cause an
+    /// error but the handle will still be removed from the handler.
+    pub fn set_as_flushed(&mut self, handle: ObjectHandle) -> Result<()> {
+        self.open_handles
+            .remove(&handle)
+            .ok_or_else(|| {
+                error!("Handle({}) does not exist", ESYS_TR::from(handle));
+                Error::local_error(WrapperErrorKind::InvalidHandleState)
+            })
+            .and_then(|handle_drop_action| {
+                if handle_drop_action == HandleDropAction::Flush {
+                    Ok(())
+                } else {
+                    error!(
+                        "Flushing handle({}) that should not have been flushed.",
+                        ESYS_TR::from(handle)
+                    );
+                    Err(Error::local_error(WrapperErrorKind::InvalidHandleState))
+                }
+            })
+    }
+
+    /// Sets the handles as closed which removes it from the handler.
+    ///
+    /// # Error
+    /// If the handle was set to be flushed then this will cause an
+    /// error but the handle will still be removed from the handler.
+    pub fn set_as_closed(&mut self, handle: ObjectHandle) -> Result<()> {
+        self.open_handles
+            .remove(&handle)
+            .ok_or_else(|| {
+                error!("Handle({}) does not exist", ESYS_TR::from(handle));
+                Error::local_error(WrapperErrorKind::InvalidHandleState)
+            })
+            .and_then(|handle_drop_action| {
+                if handle_drop_action == HandleDropAction::Close {
+                    Ok(())
+                } else {
+                    error!(
+                        "Closing handle({}) that should have been flushed",
+                        ESYS_TR::from(handle)
+                    );
+                    Err(Error::local_error(WrapperErrorKind::InvalidHandleState))
+                }
+            })
+    }
+
+    /// Retrieves all handles that needs to be flushed.
+    pub fn handles_to_flush(&self) -> Vec<ObjectHandle> {
+        self.open_handles
+            .iter()
+            .filter_map(|(open_handle, &handle_drop_action)| {
+                if handle_drop_action == HandleDropAction::Flush {
+                    Some(open_handle)
+                } else {
+                    None
+                }
+            })
+            .cloned()
+            .collect::<Vec<ObjectHandle>>()
+    }
+
+    /// Retrieves all handles that needs to be closed.
+    pub fn handles_to_close(&self) -> Vec<ObjectHandle> {
+        self.open_handles
+            .iter()
+            .filter_map(|(open_handle, &handle_drop_action)| {
+                if handle_drop_action == HandleDropAction::Close {
+                    Some(open_handle)
+                } else {
+                    None
+                }
+            })
+            .cloned()
+            .collect::<Vec<ObjectHandle>>()
+    }
+
+    /// Indicates if the manager has any open handles
+    pub fn has_open_handles(&self) -> bool {
+        !self.open_handles.is_empty()
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,9 +66,12 @@ pub enum WrapperErrorKind {
     InvalidParam,
     /// Returned when the TPM returns an invalid value from a call.
     WrongValueFromTpm,
-    /// Returned when when a session for authentication has not been set
+    /// Returned when a session for authentication has not been set
     /// before the call is made.
     MissingAuthSession,
+    /// Returned when a handle is required to be in a specific state
+    /// (i.g. Open, Flushed, Closed) but it is not.
+    InvalidHandleState,
 }
 
 impl std::fmt::Display for WrapperErrorKind {
@@ -93,6 +96,7 @@ impl std::fmt::Display for WrapperErrorKind {
             }
             WrapperErrorKind::WrongValueFromTpm => write!(f, "the TPM returned an invalid value."),
             WrapperErrorKind::MissingAuthSession => write!(f, "Missing authorization session"),
+            WrapperErrorKind::InvalidHandleState => write!(f, "Invalid handle state"),
         }
     }
 }

--- a/src/handles/mod.rs
+++ b/src/handles/mod.rs
@@ -14,6 +14,9 @@ pub use handle::nv_index::NvIndexHandle;
 pub use handle::object::ObjectHandle;
 pub use handle::pcr::PcrHandle;
 pub use handle::session::SessionHandle;
+pub(crate) mod handle_conversion {
+    pub(crate) use super::handle::conversions::*;
+}
 mod handle;
 /////////////////////////////////////////////////////////
 /// TPM Handles

--- a/src/handles/tpm.rs
+++ b/src/handles/tpm.rs
@@ -37,6 +37,19 @@ pub enum TpmHandle {
     AttachedComponent(attached_component::AttachedComponentTpmHandle),
 }
 
+impl TpmHandle {
+    /// Method that indicates if the flushing the
+    /// context of the handle is a valid action.
+    pub(crate) fn may_be_flushed(&self) -> bool {
+        match self {
+            TpmHandle::HmacSession(_) => true,
+            TpmHandle::LoadedSession(_) => true,
+            TpmHandle::Transient(_) => true,
+            _ => false,
+        }
+    }
+}
+
 impl From<TpmHandle> for TPM2_HANDLE {
     fn from(tpm_handle: TpmHandle) -> TPM2_HANDLE {
         match tpm_handle {


### PR DESCRIPTION
- Added a manager that holds the states of each handle
  and the actions that needs to be performed on the handle
  when the context is dropped.

- Made Context methods that opens, flushes or closes handles
  set the correct state for the handle they operate on in the 
  HandleManager. This should fix #152.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>