### PR TITLE
Set session params only when it makes sense

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1380,7 +1380,7 @@ impl Context {
             random.truncate(buffer.size.try_into().unwrap()); // should not panic given the TryInto above
             Ok(Digest::try_from(random)?)
         } else {
-            error!("Error in flushing context: {}.", ret);
+            error!("Error in getting random bytes: {}.", ret);
             Err(ret)
         }
     }


### PR DESCRIPTION
This commit changes the places where `encrypt` and `decrypt` are set for
the session use by the transient object context. The params are only set
when the operations invoked support them.

Note: this is fixing an issue we saw on a RaspberryPI with a TPM attached;
we're not sure exactly what the version of TSS2 was used. 