### PR TITLE
Update bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 env_logger = "0.7.1"
 
 [build-dependencies]
-bindgen = "0.54.0"
+bindgen = "0.56.0"
 pkg-config = "0.3.18"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ case:
 $ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ```
 
+## Minimum Supported Rust Version (MSRV)
+
+At the moment we test (via CI) and support the following Rust compiler versions:
+
+* On Ubuntu we test with the latest stable compiler version, as accessible through `rustup`.
+* On Fedora we test with the compiler version included with the Fedora 33 release.
+
+If you need support for other versions of the compiler, get in touch with us to see what we can do!
+
 ## Community channel
 
 Come and talk to us in [our Slack channel](https://app.slack.com/client/T0JK1PCN6/CPMQ9D4H1)!

--- a/tests/all-ubuntu.sh
+++ b/tests/all-ubuntu.sh
@@ -31,33 +31,3 @@ RUST_BACKTRACE=1 cargo build
 # Run the tests #
 #################
 RUST_BACKTRACE=1 RUST_LOG=info cargo test -- --test-threads=1 --nocapture
-
-###################
-# Stop TPM server #
-###################
-pkill tpm_server
-
-#############################
-# Install nightly toolchain #
-#############################
-rustup toolchain install nightly
-
-############################
-# Install legacy toolchain #
-############################
-rustup toolchain install 1.38.0
-
-####################
-# Verify doc build #
-####################
-cargo +nightly doc --features docs --verbose --no-deps
-
-########################
-# Verify nightly build #
-########################
-cargo +nightly build
-
-#####################################
-# Verify build with legacy compiler #
-#####################################
-RUST_BACKTRACE=1 cargo +1.38.0 build


### PR DESCRIPTION
This uses the commit in #154 and removes the dependency on 1.38.0 and nightly.

If there is any other requirement that I forgot about, let me know.