### PR TITLE
Implement abstraction::ak

### DIFF
--- a/src/abstraction/ak.rs
+++ b/src/abstraction/ak.rs
@@ -20,22 +20,6 @@ use crate::{
     Context, Error, Result, WrapperErrorKind,
 };
 
-fn test_algs_compatibility(key_alg: AsymmetricAlgorithm, sign_alg: SignatureScheme) -> Result<()> {
-    match key_alg {
-        AsymmetricAlgorithm::Rsa => match sign_alg {
-            SignatureScheme::RsaPss | SignatureScheme::RsaSsa => Ok(()),
-            _ => Err(Error::local_error(WrapperErrorKind::InconsistentParams)),
-        },
-        AsymmetricAlgorithm::Ecc => match sign_alg {
-            SignatureScheme::EcDaa
-            | SignatureScheme::EcDsa
-            | SignatureScheme::EcSchnorr
-            | SignatureScheme::Sm2 => Ok(()),
-            _ => Err(Error::local_error(WrapperErrorKind::InconsistentParams)),
-        },
-    }
-}
-
 fn create_ak_public(
     key_alg: AsymmetricAlgorithm,
     hash_alg: HashingAlgorithm,
@@ -153,12 +137,11 @@ pub fn load_ak(
 pub fn create_ak(
     context: &mut Context,
     parent: KeyHandle,
-    key_alg: AsymmetricAlgorithm,
     hash_alg: HashingAlgorithm,
     sign_alg: SignatureScheme,
     ak_auth_value: Option<&Auth>,
 ) -> Result<CreateKeyResult> {
-    test_algs_compatibility(key_alg, sign_alg)?;
+    let key_alg = sign_alg.get_key_alg();
 
     let ak_pub = create_ak_public(key_alg, hash_alg, sign_alg)?;
 

--- a/src/abstraction/ak.rs
+++ b/src/abstraction/ak.rs
@@ -1,0 +1,198 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    constants::{
+        algorithm::{AsymmetricAlgorithm, Cipher, HashingAlgorithm, SignatureScheme},
+        tss::*,
+        types::session::SessionType,
+    },
+    handles::{AuthHandle, KeyHandle},
+    structures::{Auth, CreateKeyResult, Private},
+    tss2_esys::{
+        TPM2B_PUBLIC, TPMS_ECC_PARMS, TPMS_RSA_PARMS, TPMS_SCHEME_HASH, TPMT_ECC_SCHEME,
+        TPMT_KDF_SCHEME, TPMT_RSA_SCHEME, TPMT_SYM_DEF_OBJECT, TPMU_ASYM_SCHEME, TPMU_SYM_KEY_BITS,
+        TPMU_SYM_MODE,
+    },
+    utils::{
+        ObjectAttributes, PublicIdUnion, PublicParmsUnion, Tpm2BPublicBuilder, TpmaSessionBuilder,
+    },
+    Context, Error, Result, WrapperErrorKind,
+};
+
+fn test_algs_compatibility(key_alg: AsymmetricAlgorithm, sign_alg: SignatureScheme) -> Result<()> {
+    match key_alg {
+        AsymmetricAlgorithm::Rsa => match sign_alg {
+            SignatureScheme::RsaPss | SignatureScheme::RsaSsa => Ok(()),
+            _ => Err(Error::local_error(WrapperErrorKind::InconsistentParams)),
+        },
+        AsymmetricAlgorithm::Ecc => match sign_alg {
+            SignatureScheme::EcDaa
+            | SignatureScheme::EcDsa
+            | SignatureScheme::EcSchnorr
+            | SignatureScheme::Sm2 => Ok(()),
+            _ => Err(Error::local_error(WrapperErrorKind::InconsistentParams)),
+        },
+    }
+}
+
+fn create_ak_public(
+    key_alg: AsymmetricAlgorithm,
+    hash_alg: HashingAlgorithm,
+    sign_alg: SignatureScheme,
+) -> Result<TPM2B_PUBLIC> {
+    let mut obj_attrs = ObjectAttributes(0);
+    obj_attrs.set_restricted(true);
+    obj_attrs.set_user_with_auth(true);
+    obj_attrs.set_sign_encrypt(true);
+    obj_attrs.set_decrypt(false);
+    obj_attrs.set_fixed_tpm(true);
+    obj_attrs.set_fixed_parent(true);
+    obj_attrs.set_sensitive_data_origin(true);
+
+    match key_alg {
+        AsymmetricAlgorithm::Rsa => Tpm2BPublicBuilder::new()
+            .with_type(TPM2_ALG_RSA)
+            .with_name_alg(hash_alg.into())
+            .with_object_attributes(obj_attrs)
+            .with_parms(PublicParmsUnion::RsaDetail(TPMS_RSA_PARMS {
+                symmetric: TPMT_SYM_DEF_OBJECT {
+                    algorithm: TPM2_ALG_NULL,
+                    keyBits: TPMU_SYM_KEY_BITS { aes: 0 },
+                    mode: TPMU_SYM_MODE { aes: TPM2_ALG_NULL },
+                },
+                scheme: TPMT_RSA_SCHEME {
+                    scheme: sign_alg.into(),
+                    details: TPMU_ASYM_SCHEME {
+                        anySig: TPMS_SCHEME_HASH {
+                            hashAlg: hash_alg.into(),
+                        },
+                    },
+                },
+                keyBits: 2048,
+                exponent: 0,
+            }))
+            .with_unique(PublicIdUnion::Rsa(Box::new(Default::default()))),
+        AsymmetricAlgorithm::Ecc => Tpm2BPublicBuilder::new()
+            .with_type(TPM2_ALG_ECC)
+            .with_name_alg(hash_alg.into())
+            .with_object_attributes(obj_attrs)
+            .with_parms(PublicParmsUnion::EccDetail(TPMS_ECC_PARMS {
+                symmetric: TPMT_SYM_DEF_OBJECT {
+                    algorithm: TPM2_ALG_NULL,
+                    keyBits: TPMU_SYM_KEY_BITS { sym: 0 },
+                    mode: TPMU_SYM_MODE { sym: TPM2_ALG_NULL },
+                },
+                scheme: TPMT_ECC_SCHEME {
+                    scheme: TPM2_ALG_NULL,
+                    details: TPMU_ASYM_SCHEME {
+                        anySig: TPMS_SCHEME_HASH {
+                            hashAlg: hash_alg.into(),
+                        },
+                    },
+                },
+                curveID: TPM2_ECC_NIST_P256,
+                kdf: TPMT_KDF_SCHEME {
+                    scheme: TPM2_ALG_NULL,
+                    details: Default::default(),
+                },
+            }))
+            .with_unique(PublicIdUnion::Ecc(Box::new(Default::default()))),
+    }
+    .build()
+}
+
+/// This loads an Attestation Key previously generated under the Endorsement hierarchy
+pub fn load_ak(
+    context: &mut Context,
+    parent: KeyHandle,
+    ak_auth_value: Option<&Auth>,
+    private: Private,
+    public: TPM2B_PUBLIC,
+) -> Result<KeyHandle> {
+    let session = match context.start_auth_session(
+        None,
+        None,
+        None,
+        SessionType::Policy,
+        Cipher::aes_128_cfb(),
+        HashingAlgorithm::Sha256,
+    )? {
+        Some(ses) => ses,
+        None => return Err(Error::local_error(WrapperErrorKind::WrongValueFromTpm)),
+    };
+    let session_attr = TpmaSessionBuilder::new()
+        .with_flag(TPMA_SESSION_DECRYPT)
+        .with_flag(TPMA_SESSION_ENCRYPT)
+        .build();
+    context.tr_sess_set_attributes(session, session_attr)?;
+
+    let key_handle = context.execute_with_temporary_object(session.handle().into(), |ctx, _| {
+        let _ = ctx.execute_with_nullauth_session(|ctx| {
+            ctx.policy_secret(
+                session,
+                AuthHandle::Endorsement,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+            )
+        })?;
+
+        ctx.execute_with_session(Some(session), |ctx| ctx.load(parent, private, public))
+    })?;
+
+    if let Some(ak_auth_value) = ak_auth_value {
+        context.tr_set_auth(key_handle.into(), ak_auth_value)?;
+    }
+
+    Ok(key_handle)
+}
+
+/// This creates an Attestation Key in the Endorsement hierarchy
+pub fn create_ak(
+    context: &mut Context,
+    parent: KeyHandle,
+    key_alg: AsymmetricAlgorithm,
+    hash_alg: HashingAlgorithm,
+    sign_alg: SignatureScheme,
+    ak_auth_value: Option<&Auth>,
+) -> Result<CreateKeyResult> {
+    test_algs_compatibility(key_alg, sign_alg)?;
+
+    let ak_pub = create_ak_public(key_alg, hash_alg, sign_alg)?;
+
+    let session = match context.start_auth_session(
+        None,
+        None,
+        None,
+        SessionType::Policy,
+        Cipher::aes_128_cfb(),
+        HashingAlgorithm::Sha256,
+    )? {
+        Some(ses) => ses,
+        None => return Err(Error::local_error(WrapperErrorKind::WrongValueFromTpm)),
+    };
+    let session_attr = TpmaSessionBuilder::new()
+        .with_flag(TPMA_SESSION_DECRYPT)
+        .with_flag(TPMA_SESSION_ENCRYPT)
+        .build();
+    context.tr_sess_set_attributes(session, session_attr)?;
+
+    context.execute_with_temporary_object(session.handle().into(), |ctx, _| {
+        let _ = ctx.execute_with_nullauth_session(|ctx| {
+            ctx.policy_secret(
+                session,
+                AuthHandle::Endorsement,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+            )
+        })?;
+
+        ctx.execute_with_session(Some(session), |ctx| {
+            ctx.create_key(parent, &ak_pub, ak_auth_value, None, None, None)
+        })
+    })
+}

--- a/src/abstraction/mod.rs
+++ b/src/abstraction/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod ak;
 pub mod ek;
 pub mod nv;
 pub mod transient;

--- a/src/constants/algorithm.rs
+++ b/src/constants/algorithm.rs
@@ -254,23 +254,15 @@ impl TryFrom<TPM2_ALG_ID> for HashingAlgorithm {
 /// Enum containing signature schemes
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SignatureScheme {
-    RsaSsa,
-    RsaPss,
-    EcDsa,
-    EcDaa,
-    EcSchnorr,
-    Sm2,
+    Rsa(RsaSignatureScheme),
+    Ecc(EccSignatureScheme),
 }
 
 impl From<SignatureScheme> for TPM2_ALG_ID {
     fn from(signature_scheme: SignatureScheme) -> Self {
         match signature_scheme {
-            SignatureScheme::RsaSsa => TPM2_ALG_RSASSA,
-            SignatureScheme::RsaPss => TPM2_ALG_RSAPSS,
-            SignatureScheme::EcDsa => TPM2_ALG_ECDSA,
-            SignatureScheme::EcDaa => TPM2_ALG_ECDAA,
-            SignatureScheme::EcSchnorr => TPM2_ALG_ECSCHNORR,
-            SignatureScheme::Sm2 => TPM2_ALG_SM2,
+            SignatureScheme::Rsa(ss) => ss.into(),
+            SignatureScheme::Ecc(ss) => ss.into(),
         }
     }
 }
@@ -280,13 +272,22 @@ impl TryFrom<TPM2_ALG_ID> for SignatureScheme {
 
     fn try_from(algorithm_id: TPM2_ALG_ID) -> Result<Self> {
         match algorithm_id {
-            TPM2_ALG_RSASSA => Ok(SignatureScheme::RsaSsa),
-            TPM2_ALG_RSAPSS => Ok(SignatureScheme::RsaPss),
-            TPM2_ALG_ECDSA => Ok(SignatureScheme::EcDsa),
-            TPM2_ALG_ECDAA => Ok(SignatureScheme::EcDaa),
-            TPM2_ALG_ECSCHNORR => Ok(SignatureScheme::EcSchnorr),
-            TPM2_ALG_SM2 => Ok(SignatureScheme::Sm2),
+            TPM2_ALG_RSASSA => Ok(SignatureScheme::Rsa(RsaSignatureScheme::RsaSsa)),
+            TPM2_ALG_RSAPSS => Ok(SignatureScheme::Rsa(RsaSignatureScheme::RsaPss)),
+            TPM2_ALG_ECDSA => Ok(SignatureScheme::Ecc(EccSignatureScheme::EcDsa)),
+            TPM2_ALG_ECDAA => Ok(SignatureScheme::Ecc(EccSignatureScheme::EcDaa)),
+            TPM2_ALG_ECSCHNORR => Ok(SignatureScheme::Ecc(EccSignatureScheme::EcSchnorr)),
+            TPM2_ALG_SM2 => Ok(SignatureScheme::Ecc(EccSignatureScheme::Sm2)),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+impl SignatureScheme {
+    pub fn get_key_alg(&self) -> AsymmetricAlgorithm {
+        match self {
+            SignatureScheme::Rsa(_) => AsymmetricAlgorithm::Rsa,
+            SignatureScheme::Ecc(_) => AsymmetricAlgorithm::Ecc,
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -291,6 +291,19 @@ impl Context {
         res
     }
 
+    /// Execute the closure in f, and clear up the object after it's done before returning the result
+    /// This is a convenience function that ensures object is always closed, even if an error occurs
+    pub fn execute_with_temporary_object<F, T>(&mut self, object: ObjectHandle, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Context, ObjectHandle) -> Result<T>,
+    {
+        let res = f(self, object);
+
+        self.flush_context(object)?;
+
+        res
+    }
+
     /// Get current capability information about the TPM.
     pub fn get_capabilities(
         &mut self,

--- a/tests/abstraction_ak_tests.rs
+++ b/tests/abstraction_ak_tests.rs
@@ -6,7 +6,10 @@ use std::convert::{TryFrom, TryInto};
 use tss_esapi::{
     abstraction::{ak, ek},
     constants::{
-        algorithm::{AsymmetricAlgorithm, Cipher, HashingAlgorithm, SignatureScheme},
+        algorithm::{
+            AsymmetricAlgorithm, Cipher, EccSignatureScheme, HashingAlgorithm, RsaSignatureScheme,
+            SignatureScheme,
+        },
         types::session::SessionType,
     },
     handles::AuthHandle,
@@ -25,32 +28,11 @@ fn test_create_ak_rsa_rsa() {
     ak::create_ak(
         &mut context,
         ek_rsa,
-        AsymmetricAlgorithm::Rsa,
         HashingAlgorithm::Sha256,
-        SignatureScheme::RsaPss,
+        SignatureScheme::Rsa(RsaSignatureScheme::RsaPss),
         None,
     )
     .unwrap();
-}
-
-#[test]
-fn test_create_ak_rsa_ecc_invalid_sig_alg() {
-    let mut context = create_ctx_without_session();
-
-    let ek_rsa = ek::create_ek_object(&mut context, AsymmetricAlgorithm::Rsa).unwrap();
-    if ak::create_ak(
-        &mut context,
-        ek_rsa,
-        AsymmetricAlgorithm::Ecc,
-        HashingAlgorithm::Sha256,
-        SignatureScheme::RsaPss,
-        None,
-    )
-    .is_ok()
-    {
-        // We can't use unwrap_err because that requires Debug on the T
-        panic!("Should have errored");
-    }
 }
 
 #[test]
@@ -61,9 +43,8 @@ fn test_create_ak_rsa_ecc() {
     if ak::create_ak(
         &mut context,
         ek_rsa,
-        AsymmetricAlgorithm::Ecc,
         HashingAlgorithm::Sha256,
-        SignatureScheme::EcDsa,
+        SignatureScheme::Ecc(EccSignatureScheme::Sm2),
         None,
     )
     .is_ok()
@@ -82,9 +63,8 @@ fn test_create_and_use_ak() {
     let att_key = ak::create_ak(
         &mut context,
         ek_rsa,
-        AsymmetricAlgorithm::Rsa,
         HashingAlgorithm::Sha256,
-        SignatureScheme::RsaPss,
+        SignatureScheme::Rsa(RsaSignatureScheme::RsaPss),
         Some(&ak_auth),
     )
     .unwrap();

--- a/tests/abstraction_ak_tests.rs
+++ b/tests/abstraction_ak_tests.rs
@@ -1,0 +1,159 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::{TryFrom, TryInto};
+
+use tss_esapi::{
+    abstraction::{ak, ek},
+    constants::{
+        algorithm::{AsymmetricAlgorithm, Cipher, HashingAlgorithm, SignatureScheme},
+        types::session::SessionType,
+    },
+    handles::AuthHandle,
+    structures::{Auth, Digest},
+    utils::TpmaSessionBuilder,
+};
+
+mod common;
+use common::create_ctx_without_session;
+
+#[test]
+fn test_create_ak_rsa_rsa() {
+    let mut context = create_ctx_without_session();
+
+    let ek_rsa = ek::create_ek_object(&mut context, AsymmetricAlgorithm::Rsa).unwrap();
+    ak::create_ak(
+        &mut context,
+        ek_rsa,
+        AsymmetricAlgorithm::Rsa,
+        HashingAlgorithm::Sha256,
+        SignatureScheme::RsaPss,
+        None,
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_create_ak_rsa_ecc_invalid_sig_alg() {
+    let mut context = create_ctx_without_session();
+
+    let ek_rsa = ek::create_ek_object(&mut context, AsymmetricAlgorithm::Rsa).unwrap();
+    if ak::create_ak(
+        &mut context,
+        ek_rsa,
+        AsymmetricAlgorithm::Ecc,
+        HashingAlgorithm::Sha256,
+        SignatureScheme::RsaPss,
+        None,
+    )
+    .is_ok()
+    {
+        // We can't use unwrap_err because that requires Debug on the T
+        panic!("Should have errored");
+    }
+}
+
+#[test]
+fn test_create_ak_rsa_ecc() {
+    let mut context = create_ctx_without_session();
+
+    let ek_rsa = ek::create_ek_object(&mut context, AsymmetricAlgorithm::Rsa).unwrap();
+    if ak::create_ak(
+        &mut context,
+        ek_rsa,
+        AsymmetricAlgorithm::Ecc,
+        HashingAlgorithm::Sha256,
+        SignatureScheme::EcDsa,
+        None,
+    )
+    .is_ok()
+    {
+        // We can't use unwrap_err because that requires Debug on the T
+        panic!("Should have errored");
+    }
+}
+
+#[test]
+fn test_create_and_use_ak() {
+    let mut context = create_ctx_without_session();
+
+    let ek_rsa = ek::create_ek_object(&mut context, AsymmetricAlgorithm::Rsa).unwrap();
+    let ak_auth = Auth::try_from(vec![0x1, 0x2, 0x42]).unwrap();
+    let att_key = ak::create_ak(
+        &mut context,
+        ek_rsa,
+        AsymmetricAlgorithm::Rsa,
+        HashingAlgorithm::Sha256,
+        SignatureScheme::RsaPss,
+        Some(&ak_auth),
+    )
+    .unwrap();
+
+    let loaded_ak = ak::load_ak(
+        &mut context,
+        ek_rsa,
+        Some(&ak_auth),
+        att_key.out_private,
+        att_key.out_public,
+    )
+    .unwrap();
+
+    let (_, key_name, _) = context.read_public(loaded_ak).unwrap();
+    let cred = vec![1, 2, 3, 4, 5];
+    let expected = Digest::try_from(vec![1, 2, 3, 4, 5]).unwrap();
+
+    let session_attr = TpmaSessionBuilder::new().build();
+    let session_1 = context
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Hmac,
+            Cipher::aes_256_cfb(),
+            HashingAlgorithm::Sha256,
+        )
+        .unwrap();
+    context
+        .tr_sess_set_attributes(session_1.unwrap(), session_attr)
+        .unwrap();
+    let session_2 = context
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Policy,
+            Cipher::aes_256_cfb(),
+            HashingAlgorithm::Sha256,
+        )
+        .unwrap();
+    context
+        .tr_sess_set_attributes(session_2.unwrap(), session_attr)
+        .unwrap();
+
+    let (credential_blob, secret) = context
+        .execute_without_session(|ctx| {
+            ctx.make_credential(ek_rsa, cred.try_into().unwrap(), key_name)
+        })
+        .unwrap();
+
+    let _ = context
+        .execute_with_session(session_1, |ctx| {
+            ctx.policy_secret(
+                session_2.unwrap(),
+                AuthHandle::Endorsement,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+            )
+        })
+        .unwrap();
+
+    context.set_sessions((session_1, session_2, None));
+
+    let decrypted = context
+        .activate_credential(loaded_ak, ek_rsa, credential_blob, secret)
+        .unwrap();
+
+    assert_eq!(expected, decrypted);
+}

--- a/tests/algorithm_specifier_tests.rs
+++ b/tests/algorithm_specifier_tests.rs
@@ -224,27 +224,27 @@ mod test_signature_scheme {
     #[test]
     fn test_into_alogithm_id() {
         assert_eq!(
-            Into::<TPM2_ALG_ID>::into(SignatureScheme::RsaSsa),
+            Into::<TPM2_ALG_ID>::into(SignatureScheme::Rsa(RsaSignatureScheme::RsaSsa)),
             TPM2_ALG_RSASSA
         );
         assert_eq!(
-            Into::<TPM2_ALG_ID>::into(SignatureScheme::RsaPss),
+            Into::<TPM2_ALG_ID>::into(SignatureScheme::Rsa(RsaSignatureScheme::RsaPss)),
             TPM2_ALG_RSAPSS
         );
         assert_eq!(
-            Into::<TPM2_ALG_ID>::into(SignatureScheme::EcDsa),
+            Into::<TPM2_ALG_ID>::into(SignatureScheme::Ecc(EccSignatureScheme::EcDsa)),
             TPM2_ALG_ECDSA
         );
         assert_eq!(
-            Into::<TPM2_ALG_ID>::into(SignatureScheme::EcDaa),
+            Into::<TPM2_ALG_ID>::into(SignatureScheme::Ecc(EccSignatureScheme::EcDaa)),
             TPM2_ALG_ECDAA
         );
         assert_eq!(
-            Into::<TPM2_ALG_ID>::into(SignatureScheme::EcSchnorr),
+            Into::<TPM2_ALG_ID>::into(SignatureScheme::Ecc(EccSignatureScheme::EcSchnorr)),
             TPM2_ALG_ECSCHNORR
         );
         assert_eq!(
-            Into::<TPM2_ALG_ID>::into(SignatureScheme::Sm2),
+            Into::<TPM2_ALG_ID>::into(SignatureScheme::Ecc(EccSignatureScheme::Sm2)),
             TPM2_ALG_SM2
         );
     }
@@ -253,27 +253,27 @@ mod test_signature_scheme {
     fn test_try_from_alogithm_id() {
         assert_eq!(
             SignatureScheme::try_from(TPM2_ALG_RSASSA).unwrap(),
-            SignatureScheme::RsaSsa
+            SignatureScheme::Rsa(RsaSignatureScheme::RsaSsa)
         );
         assert_eq!(
             SignatureScheme::try_from(TPM2_ALG_RSAPSS).unwrap(),
-            SignatureScheme::RsaPss
+            SignatureScheme::Rsa(RsaSignatureScheme::RsaPss)
         );
         assert_eq!(
             SignatureScheme::try_from(TPM2_ALG_ECDSA).unwrap(),
-            SignatureScheme::EcDsa
+            SignatureScheme::Ecc(EccSignatureScheme::EcDsa)
         );
         assert_eq!(
             SignatureScheme::try_from(TPM2_ALG_ECDAA).unwrap(),
-            SignatureScheme::EcDaa
+            SignatureScheme::Ecc(EccSignatureScheme::EcDaa)
         );
         assert_eq!(
             SignatureScheme::try_from(TPM2_ALG_ECSCHNORR).unwrap(),
-            SignatureScheme::EcSchnorr
+            SignatureScheme::Ecc(EccSignatureScheme::EcSchnorr)
         );
         assert_eq!(
             SignatureScheme::try_from(TPM2_ALG_SM2).unwrap(),
-            SignatureScheme::Sm2
+            SignatureScheme::Ecc(EccSignatureScheme::Sm2)
         );
         assert!(
             SignatureScheme::try_from(TPM2_ALG_ERROR).is_err(),


### PR DESCRIPTION
This adds a function to create an AK object and return it
from the template from the tss2-tools, and also a function
to load a created AK object.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>