### PR TITLE
Added missing size check when converting native buffer into TSS buffer.

### DIFF
--- a/src/nv/storage/public.rs
+++ b/src/nv/storage/public.rs
@@ -75,7 +75,7 @@ impl TryFrom<NvPublic> for TPM2B_NV_PUBLIC {
                 nvIndex: nv_public.nv_index.into(),
                 nameAlg: nv_public.name_algorithm.into(),
                 attributes: nv_public.attributes.try_into()?,
-                authPolicy: nv_public.authorization_policy.try_into()?,
+                authPolicy: nv_public.authorization_policy.into(),
                 dataSize: nv_public.data_size as u16,
             },
         })

--- a/src/structures/buffers.rs
+++ b/src/structures/buffers.rs
@@ -71,16 +71,15 @@ macro_rules! named_field_buffer_type {
             }
         }
 
-        impl TryFrom<$native_type> for $tss_type {
-            type Error = Error;
-
-            fn try_from(native: $native_type) -> Result<Self> {
+        impl From<$native_type> for $tss_type {
+            fn from(native: $native_type) -> Self {
                 let mut buffer = $tss_type {
                     size: native.0.len() as u16,
                     ..Default::default()
                 };
+                buffer.size = native.0.len() as u16;
                 buffer.$buffer_field_name[..native.0.len()].copy_from_slice(&native.0);
-                Ok(buffer)
+                buffer
             }
         }
     };

--- a/src/structures/creation.rs
+++ b/src/structures/creation.rs
@@ -50,7 +50,7 @@ impl TryFrom<CreationData> for TPMS_CREATION_DATA {
     fn try_from(creation_data: CreationData) -> Result<Self> {
         Ok(TPMS_CREATION_DATA {
             pcrSelect: creation_data.pcr_select.into(),
-            pcrDigest: creation_data.pcr_digest.try_into()?,
+            pcrDigest: creation_data.pcr_digest.into(),
             locality: creation_data.locality,
             parentNameAlg: match creation_data.parent_name_alg {
                 None => TPM2_ALG_NULL,
@@ -58,7 +58,7 @@ impl TryFrom<CreationData> for TPMS_CREATION_DATA {
             },
             parentName: creation_data.parent_name.try_into()?,
             parentQualifiedName: creation_data.parent_qualified_name.try_into()?,
-            outsideInfo: creation_data.outside_info.try_into()?,
+            outsideInfo: creation_data.outside_info.into(),
         })
     }
 }

--- a/src/structures/lists/digest.rs
+++ b/src/structures/lists/digest.rs
@@ -4,7 +4,7 @@ use crate::structures::Digest;
 use crate::tss2_esys::TPML_DIGEST;
 use crate::{Error, Result, WrapperErrorKind};
 use log::error;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 #[derive(Debug, Clone, Default)]
 pub struct DigestList {
@@ -79,7 +79,7 @@ impl TryFrom<DigestList> for TPML_DIGEST {
 
         let mut tss_digest_list: TPML_DIGEST = Default::default();
         for digest in digest_list.digests.iter() {
-            tss_digest_list.digests[tss_digest_list.count as usize] = digest.clone().try_into()?;
+            tss_digest_list.digests[tss_digest_list.count as usize] = digest.clone().into();
             tss_digest_list.count += 1;
         }
         Ok(tss_digest_list)


### PR DESCRIPTION
For this size check there are two ways to deal with it and I chose to be pedantic and check the size even though it should never be problem.

The other way to deal with it is to change the conversion into  ```From``` conversion.