### PR TITLE
Added proper documentation for pcr_* methods.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1274,9 +1274,86 @@ impl Context {
 
     /// Extends a PCR with the specified digests.
     ///
+    /// # Arguments
+    /// * `pcr_handle`- A [PcrHandle] to the PCR slot that is to be extended.
+    /// * `digests` - The [DigestValues] with which the slot shall be extended.
+    ///
     /// # Details
     /// This method is used to cause an update to the indicated PCR. The digests param
     /// contains the digests for specific algorithms that are to be used.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{
+    /// #     Context, Tcti,
+    /// #     constants::{
+    /// #         algorithm::Cipher,
+    /// #         types::session::SessionType,
+    /// #     },
+    /// #     session::SessionAttributesBuilder,
+    /// #     handles::PcrHandle,
+    /// #     structures::Digest,
+    /// # };
+    /// # use std::{env, str::FromStr};
+    /// # // Create TCTI that uses the correct software for testing
+    /// # let tcti = env::var("TEST_TCTI")
+    /// #   .map(|env_tcti_str| Tcti::from_str(&env_tcti_str).expect("Failed to parse TCTI string."))
+    /// #   .unwrap_or_else(|_| Tcti::Mssim(Default::default()));
+    /// # // Create context
+    /// # let mut context = unsafe {
+    /// #     Context::new(tcti).expect("Failed to create Context")
+    /// # };
+    /// # // Create session for a pcr
+    /// # let pcr_session = context
+    /// #     .start_auth_session(
+    /// #         None,
+    /// #         None,
+    /// #         None,
+    /// #         SessionType::Hmac,
+    /// #         Cipher::aes_256_cfb(),
+    /// #         tss_esapi::constants::algorithm::HashingAlgorithm::Sha256,
+    /// #     )
+    /// #     .expect("Failed to create session")
+    /// #     .expect("Recived invalid handle");
+    /// # let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new()
+    /// #     .with_decrypt(true)
+    /// #     .with_encrypt(true)
+    /// #     .build();
+    /// # context.tr_sess_set_attributes(pcr_session, session_attributes, session_attributes_mask)
+    /// #     .expect("Failed to set attributes on session");
+    /// #
+    /// # let digest_sha1 = Digest::try_from(vec![
+    /// #       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    /// #   ])
+    /// #   .expect("Failed to create sha1 Digest from data");
+    /// #
+    /// # let digest_sha256 = Digest::try_from(vec![
+    /// #        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+    /// #        24, 25, 26, 27, 28, 29, 30, 31, 32,
+    /// #    ]).expect("Failed to create Sha256 Digest from data");
+    /// use std::convert::TryFrom;
+    /// use tss_esapi::{
+    ///     structures::{DigestValues},
+    ///     constants::algorithm::HashingAlgorithm,
+    /// };
+    /// // Extend both sha256 and sha1
+    /// let mut vals = DigestValues::new();
+    /// vals.set(
+    ///     HashingAlgorithm::Sha1,
+    ///     digest_sha1,
+    /// );
+    /// vals.set(
+    ///     HashingAlgorithm::Sha256,
+    ///     digest_sha256,
+    /// );
+    /// // Use pcr_session for authorization when extending
+    /// // PCR 16 with the values for the banks specified in
+    /// // vals.
+    /// context.execute_with_session(Some(pcr_session), |ctx| {
+    ///     ctx.pcr_extend(PcrHandle::Pcr16, vals).expect("Call to pcr_extend failed");
+    /// });
+    /// ```
     pub fn pcr_extend(&mut self, pcr_handle: PcrHandle, digests: DigestValues) -> Result<()> {
         let ret = unsafe {
             Esys_PCR_Extend(
@@ -1298,12 +1375,63 @@ impl Context {
         }
     }
 
-    /// Resets the value in a PCR register.
+    /// Resets the value in a PCR.
+    ///
+    /// # Arguments
+    /// * `pcr_handle` -  A [PcrHandle] to the PCR slot that is to be resetted.
     ///
     /// # Details
     /// If the attributes of the PCR indicates that it is allowed
     /// to reset them and the proper authorization is provided then
-    /// this method can be used to set the PCR in all banks to 0.
+    /// this method can be used to set the the specified PCR in all
+    /// banks to 0.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{
+    /// #     Context, Tcti,
+    /// #     constants::{
+    /// #         algorithm::{HashingAlgorithm, Cipher},
+    /// #         types::session::SessionType,
+    /// #     },
+    /// #     session::SessionAttributesBuilder,
+    /// # };
+    /// # use std::{env, str::FromStr};
+    /// # // Create TCTI that uses the correct software for testing
+    /// # let tcti = env::var("TEST_TCTI")
+    /// #   .map(|env_tcti_str| Tcti::from_str(&env_tcti_str).expect("Failed to parse TCTI string."))
+    /// #   .unwrap_or_else(|_| Tcti::Mssim(Default::default()));
+    /// # // Create context
+    /// # let mut context = unsafe {
+    /// #     Context::new(tcti).expect("Failed to create Context")
+    /// # };
+    /// # // Create session for a pcr
+    /// # let pcr_session = context
+    /// #     .start_auth_session(
+    /// #         None,
+    /// #         None,
+    /// #         None,
+    /// #         SessionType::Hmac,
+    /// #         Cipher::aes_256_cfb(),
+    /// #         HashingAlgorithm::Sha256,
+    /// #     )
+    /// #     .expect("Failed to create session")
+    /// #     .expect("Recived invalid handle");
+    /// # let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new()
+    /// #     .with_decrypt(true)
+    /// #     .with_encrypt(true)
+    /// #     .build();
+    /// # context.tr_sess_set_attributes(pcr_session, session_attributes, session_attributes_mask)
+    /// #     .expect("Failed to set attributes on session");
+    ///
+    /// use tss_esapi::{
+    ///      handles::PcrHandle
+    /// };
+    /// context.execute_with_session(Some(pcr_session), |ctx| {
+    ///     ctx.pcr_reset(PcrHandle::Pcr16).expect("Call to pcr_reset failed");
+    /// });
+    /// ```
     pub fn pcr_reset(&mut self, pcr_handle: PcrHandle) -> Result<()> {
         let ret = unsafe {
             Esys_PCR_Reset(
@@ -1324,10 +1452,10 @@ impl Context {
         }
     }
 
-    /// Reads the values of PCR slots.
+    /// Reads the values of a PCR.
     ///
     /// # Arguments
-    /// *`pcr_selection_list` - A [PcrSelectionList] that contains pcr slots in
+    /// * `pcr_selection_list` - A [PcrSelectionList] that contains pcr slots in
     /// different banks that is going to be read.
     ///
     /// # Details
@@ -1343,19 +1471,21 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust, no_run
+    /// ```rust,
+    /// # use tss_esapi::{Context, Tcti};
+    /// # use std::{env, str::FromStr};
+    /// # // Create TCTI that uses the correct software for testing
+    /// # let tcti = env::var("TEST_TCTI")
+    /// #   .map(|env_tcti_str| Tcti::from_str(&env_tcti_str).expect("Failed to parse TCTI string."))
+    /// #   .unwrap_or_else(|_| Tcti::Mssim(Default::default()));
+    /// # // Create context
+    /// # let mut context = unsafe {
+    /// #     Context::new(tcti).expect("Failed to create Context")
+    /// # };
     /// use tss_esapi::{
-    ///     Context, Tcti,
     ///     constants::algorithm::HashingAlgorithm,
     ///     structures::{PcrSelectionListBuilder, PcrSlot},
     /// };
-    /// use std::str::FromStr;
-    ///
-    /// // Create context that uses Device TCTI.
-    /// let mut context = unsafe {
-    ///     Context::new(Tcti::Device(Default::default())).expect("Failed to create Context")
-    /// };
-    ///
     /// // Create PCR selection list with slots in a bank
     /// // that is going to be read.
     /// let pcr_selection_list = PcrSelectionListBuilder::new()


### PR DESCRIPTION
Added proper documentation to the pcr_* context methods. This includes detailed description, argument information, examples and links to relevant types.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>