### PR TITLE
Added NvIndexAttributesBuilder.

### DIFF
--- a/src/nv/storage/index.rs
+++ b/src/nv/storage/index.rs
@@ -48,7 +48,7 @@ impl TryFrom<TPM2_NT> for NvIndexType {
             TPM2_NT_PIN_FAIL => Ok(NvIndexType::PinFail),
             TPM2_NT_PIN_PASS => Ok(NvIndexType::PinPass),
             _ => {
-                error!("Error: Found invalid value when trying to parse Nv Index Type");
+                error!("Found invalid value when trying to parse Nv Index Type");
                 Err(Error::local_error(WrapperErrorKind::InvalidParam))
             }
         }
@@ -61,47 +61,370 @@ bitfield! {
     pub struct NvIndexAttributes(TPMA_NV);
     impl Debug;
     // NV Index Attributes
-    pub pp_write, set_pp_write: 0;
-    pub owner_write, set_owner_write: 1;
-    pub auth_write, set_auth_write: 2;
-    pub policy_write, set_policy_write: 3;
+    pub pp_write, _: 0;
+    _, set_pp_write: 0;
+    pub owner_write, _: 1;
+    _, set_owner_write: 1;
+    pub auth_write, _: 2;
+    _, set_auth_write: 2;
+    pub policy_write, _: 3;
+    _, set_policy_write: 3;
     TPM2_NT, tss_index_type, _: 7, 4; // private getter
-    pub TPM2_NT, from into NvIndexType, _, set_index_type: 7, 4;
+    TPM2_NT, from into NvIndexType, _, set_index_type: 7, 4;
     // Reserved 9,8
-    pub policy_delete, set_policy_delete: 10;
-    pub write_locked, set_write_locked: 11;
-    pub write_all, set_write_all: 12;
-    pub write_define, set_write_define: 13;
-    pub write_stclear, set_write_stclear: 14;
-    pub global_lock, set_global_lock: 15;
-    pub pp_read, set_pp_read: 16;
-    pub owner_read, set_owner_read: 17;
-    pub auth_read, set_auth_read: 18;
-    pub policy_read, set_policy_read: 19;
+    pub policy_delete, _: 10;
+    _, set_policy_delete: 10;
+    pub write_locked, _: 11;
+    _, set_write_locked: 11;
+    pub write_all, _: 12;
+    _, set_write_all: 12;
+    pub write_define, _: 13;
+    _, set_write_define: 13;
+    pub write_stclear, _: 14;
+    _, set_write_stclear: 14;
+    pub global_lock, _: 15;
+    _, set_global_lock: 15;
+    pub pp_read, _: 16;
+    _, set_pp_read: 16;
+    pub owner_read, _: 17;
+    _, set_owner_read: 17;
+    pub auth_read, _: 18;
+    _, set_auth_read: 18;
+    pub policy_read, _: 19;
+    _, set_policy_read: 19;
     // Reserved 24, 20
-    pub no_da, set_no_da: 25;
-    pub orderly, set_orderly: 26;
-    pub clear_stclear, set_clear_stclear: 27;
-    pub read_locked, set_read_locked: 28;
-    pub written, set_written: 29;
-    pub platform_create, set_platform_create: 30;
-    pub read_stclear, set_read_stclear: 31;
+    pub no_da, _: 25;
+    _, set_no_da: 25;
+    pub orderly, _: 26;
+    _, set_orderly: 26;
+    pub clear_stclear, _: 27;
+    _, set_clear_stclear: 27;
+    pub read_locked, _: 28;
+    _, set_read_locked: 28;
+    pub written, _: 29;
+    _, set_written: 29;
+    pub platform_create, _: 30;
+    _, set_platform_create: 30;
+    pub read_stclear, _: 31;
+    _, set_read_stclear: 31;
 }
 
 impl NvIndexAttributes {
+    /// Returns the `NvIndexType` of the `NvIndexAttributes`
     pub fn index_type(&self) -> Result<NvIndexType> {
         NvIndexType::try_from(self.tss_index_type())
     }
-}
 
-impl From<TPMA_NV> for NvIndexAttributes {
-    fn from(tss_nv_index_atttributes: TPMA_NV) -> NvIndexAttributes {
-        NvIndexAttributes(tss_nv_index_atttributes)
+    /// Validates the attributes
+    ///
+    /// # Details
+    /// Performs checks on `self` in order to verify
+    /// that the attributes conforms to the requirements
+    /// specified in the standard.
+    ///
+    /// # Errors
+    /// Returns an error if some attributes are missing
+    /// or are in conflict with eachother.
+    pub fn validate(&self) -> Result<()> {
+        // "At least one of TPMA_NV_PPREAD, TPMA_NV_OWNERREAD,
+        // TPMA_NV_AUTHREAD, or TPMA_NV_POLICYREAD shall be SET."
+        if !(self.pp_read() | self.owner_read() | self.auth_read() | self.policy_read()) {
+            error!("Non of the attributes PPREAD, OWERREAD, AUTHREAD, POLICYREAD have been set");
+            return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
+        }
+
+        // "At least one of TPMA_NV_PPWRITE, TPMA_NV_OWNERWRITE,
+        // TPMA_NV_AUTHWRITE, or TPMA_NV_POLICYWRITE shall be SET."
+        if !(self.pp_write() | self.owner_write() | self.auth_write() | self.policy_write()) {
+            error!(
+                "Non of the attributes PPWRITE, OWERWRITE, AUTHWRITE, POLICYWRITE have been set"
+            );
+            return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
+        }
+
+        // "If TPM_NT is TPM_NT_PIN_FAIL, TPMA_NV_NO_DA must be SET.
+        // This removes ambiguity over which Dictionary Attack defense
+        // protects a TPM_NV_PIN_FAIL's authValue."
+        if (self.index_type()? == NvIndexType::PinFail) & !self.no_da() {
+            error!("NvIndexType was PinFail but `no DA` attribute was not set");
+            return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
+        }
+
+        Ok(())
     }
 }
 
-impl From<NvIndexAttributes> for TPMA_NV {
-    fn from(nv_index_atttributes: NvIndexAttributes) -> TPMA_NV {
-        nv_index_atttributes.0
+impl TryFrom<TPMA_NV> for NvIndexAttributes {
+    type Error = Error;
+
+    fn try_from(tss_nv_index_atttributes: TPMA_NV) -> Result<NvIndexAttributes> {
+        let nv_index_attributes = NvIndexAttributes(tss_nv_index_atttributes);
+        nv_index_attributes.validate()?;
+        Ok(nv_index_attributes)
+    }
+}
+
+impl TryFrom<NvIndexAttributes> for TPMA_NV {
+    type Error = Error;
+    fn try_from(nv_index_atttributes: NvIndexAttributes) -> Result<TPMA_NV> {
+        nv_index_atttributes.validate()?;
+        Ok(nv_index_atttributes.0)
+    }
+}
+
+/// A builder NV index attributes
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct NvIndexAttributesBuilder {
+    nv_index_attributes: NvIndexAttributes,
+}
+
+impl NvIndexAttributesBuilder {
+    /// Creates a new nv index builder
+    pub const fn new() -> Self {
+        NvIndexAttributesBuilder {
+            nv_index_attributes: NvIndexAttributes(0),
+        }
+    }
+
+    /// Creates a new builder from existing `NvIndexAttributes`
+    pub const fn with_attributes(nv_index_attributes: NvIndexAttributes) -> Self {
+        NvIndexAttributesBuilder {
+            nv_index_attributes,
+        }
+    }
+
+    /// Controls the `pp write` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_pp_write(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_pp_write(set);
+        self
+    }
+
+    /// Controls the `owner write` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_owner_write(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_owner_write(set);
+        self
+    }
+
+    /// Controls the `auth write` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_auth_write(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_auth_write(set);
+        self
+    }
+
+    /// Controls the `policy write` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_policy_write(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_policy_write(set);
+        self
+    }
+
+    /// Controls the `nv index type` attribute
+    ///
+    /// # Arguments
+    /// * `nv_index_type` - The nv index type to be used.
+    pub fn with_nv_index_type(mut self, nv_index_type: NvIndexType) -> Self {
+        self.nv_index_attributes.set_index_type(nv_index_type);
+        self
+    }
+
+    /// Controls the `policy delete` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_policy_delete(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_policy_delete(set);
+        self
+    }
+
+    /// Controls the `write locked` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_write_locked(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_write_locked(set);
+        self
+    }
+
+    /// Controls the `write all` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_write_all(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_write_all(set);
+        self
+    }
+
+    /// Controls the `write define` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_write_define(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_write_define(set);
+        self
+    }
+
+    /// Controls the `write stclear` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_write_stclear(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_write_stclear(set);
+        self
+    }
+
+    /// Controls the `global lock` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_global_lock(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_global_lock(set);
+        self
+    }
+
+    /// Controls the `pp read` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_pp_read(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_pp_read(set);
+        self
+    }
+
+    /// Controls the `owner read` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_owner_read(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_owner_read(set);
+        self
+    }
+
+    /// Controls the `auth read` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_auth_read(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_auth_read(set);
+        self
+    }
+
+    /// Controls the `policy read` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_policy_read(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_policy_read(set);
+        self
+    }
+
+    /// Controls the `no DA` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_no_da(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_no_da(set);
+        self
+    }
+
+    /// Controls the `orderly` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_orderly(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_orderly(set);
+        self
+    }
+
+    /// Controls the `clear stclear` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_clear_stclear(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_clear_stclear(set);
+        self
+    }
+
+    /// Controls the `read locked` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_read_locked(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_read_locked(set);
+        self
+    }
+
+    /// Controls the `written` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_written(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_written(set);
+        self
+    }
+
+    /// Controls the `platform create` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_platform_create(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_platform_create(set);
+        self
+    }
+
+    /// Controls the `read stclear` attribute
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the attribute should have the value SET.
+    ///           `false`indicates that the attribute should have the value CLEAR.
+    pub fn with_read_stclear(mut self, set: bool) -> Self {
+        self.nv_index_attributes.set_read_stclear(set);
+        self
+    }
+
+    /// Builds the nv index attributes.
+    ///
+    /// # Errors
+    /// Returns an error if some attributes are missing
+    /// or are in conflict with eachother.
+    pub fn build(self) -> Result<NvIndexAttributes> {
+        self.nv_index_attributes.validate()?;
+        Ok(self.nv_index_attributes)
+    }
+}
+
+impl Default for NvIndexAttributesBuilder {
+    fn default() -> Self {
+        NvIndexAttributesBuilder::new()
     }
 }

--- a/src/nv/storage/mod.rs
+++ b/src/nv/storage/mod.rs
@@ -4,7 +4,7 @@
 /// This module conatins code that deaals with non volatile storage
 /// in the TPM.
 ///
-pub use index::{NvIndexAttributes, NvIndexType};
+pub use index::{NvIndexAttributes, NvIndexAttributesBuilder, NvIndexType};
 pub use public::{NvPublic, NvPublicBuilder};
 
 mod index;

--- a/src/nv/storage/public.rs
+++ b/src/nv/storage/public.rs
@@ -56,7 +56,7 @@ impl TryFrom<TPM2B_NV_PUBLIC> for NvPublic {
         Ok(NvPublic {
             nv_index: tss_nv_public.nvPublic.nvIndex.try_into()?,
             name_algorithm: tss_nv_public.nvPublic.nameAlg.try_into()?,
-            attributes: tss_nv_public.nvPublic.attributes.into(),
+            attributes: tss_nv_public.nvPublic.attributes.try_into()?,
             authorization_policy: tss_nv_public.nvPublic.authPolicy.try_into()?,
             data_size: tss_nv_public.nvPublic.dataSize as usize,
         })
@@ -74,7 +74,7 @@ impl TryFrom<NvPublic> for TPM2B_NV_PUBLIC {
             nvPublic: TPMS_NV_PUBLIC {
                 nvIndex: nv_public.nv_index.into(),
                 nameAlg: nv_public.name_algorithm.into(),
-                attributes: nv_public.attributes.into(),
+                attributes: nv_public.attributes.try_into()?,
                 authPolicy: nv_public.authorization_policy.try_into()?,
                 dataSize: nv_public.data_size as u16,
             },

--- a/tests/abstraction_nv_tests.rs
+++ b/tests/abstraction_nv_tests.rs
@@ -7,7 +7,7 @@ use tss_esapi::{
     constants::algorithm::HashingAlgorithm,
     handles::NvIndexTpmHandle,
     interface_types::resource_handles::NvAuth,
-    nv::storage::{NvIndexAttributes, NvPublicBuilder},
+    nv::storage::{NvIndexAttributesBuilder, NvPublicBuilder},
     structures::MaxNvBuffer,
 };
 
@@ -27,11 +27,13 @@ fn read_full() {
     let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
 
     // Create owner nv public.
-    let mut owner_nv_index_attributes = NvIndexAttributes(0);
-    owner_nv_index_attributes.set_owner_write(true);
-    owner_nv_index_attributes.set_owner_read(true);
-    owner_nv_index_attributes.set_pp_read(true);
-    owner_nv_index_attributes.set_owner_read(true);
+    let owner_nv_index_attributes = NvIndexAttributesBuilder::new()
+        .with_owner_write(true)
+        .with_owner_read(true)
+        .with_pp_read(true)
+        .with_owner_read(true)
+        .build()
+        .expect("Failed to create owner nv index attributes");
 
     let owner_nv_public = NvPublicBuilder::new()
         .with_nv_index(nv_index)

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -49,7 +49,7 @@ use tss_esapi::{
         dynamic_handles::Persistent,
         resource_handles::{Hierarchy, NvAuth, Provision},
     },
-    nv::storage::{NvIndexAttributes, NvPublicBuilder},
+    nv::storage::{NvIndexAttributesBuilder, NvPublicBuilder},
     session::{Session, SessionAttributesBuilder},
     structures::{
         Auth, CapabilityData, Data, Digest, DigestList, DigestValues, MaxBuffer, MaxNvBuffer,
@@ -2544,9 +2544,11 @@ mod test_nv_define_space {
         let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
 
         // Create owner nv public.
-        let mut owner_nv_index_attributes = NvIndexAttributes(0);
-        owner_nv_index_attributes.set_owner_write(true);
-        owner_nv_index_attributes.set_owner_read(true);
+        let owner_nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create owner nv index attributes");
 
         let owner_nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index)
@@ -2557,10 +2559,12 @@ mod test_nv_define_space {
             .unwrap();
 
         // Create platform nv public.
-        let mut platform_nv_index_attributes = NvIndexAttributes(0);
-        platform_nv_index_attributes.set_pp_write(true);
-        platform_nv_index_attributes.set_pp_read(true);
-        platform_nv_index_attributes.set_platform_create(true);
+        let platform_nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_pp_write(true)
+            .with_pp_read(true)
+            .with_platform_create(true)
+            .build()
+            .expect("Failed to create platform nv index attributes");
 
         let platform_nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index)
@@ -2587,9 +2591,11 @@ mod test_nv_define_space {
         let nv_index = NvIndexTpmHandle::new(0x01500016).unwrap();
 
         // Create owner nv public.
-        let mut owner_nv_index_attributes = NvIndexAttributes(0);
-        owner_nv_index_attributes.set_owner_write(true);
-        owner_nv_index_attributes.set_owner_read(true);
+        let owner_nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create owner nv index attributes");
 
         let owner_nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index)
@@ -2600,10 +2606,12 @@ mod test_nv_define_space {
             .unwrap();
 
         // Create platform nv public.
-        let mut platform_nv_index_attributes = NvIndexAttributes(0);
-        platform_nv_index_attributes.set_pp_write(true);
-        platform_nv_index_attributes.set_pp_read(true);
-        platform_nv_index_attributes.set_platform_create(true);
+        let platform_nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_pp_write(true)
+            .with_pp_read(true)
+            .with_platform_create(true)
+            .build()
+            .expect("Failed to create platform nv index attributes");
 
         let platform_nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index)
@@ -2644,9 +2652,11 @@ mod test_nv_undefine_space {
         let nv_index = NvIndexTpmHandle::new(0x01500017).unwrap();
 
         // Create owner nv public.
-        let mut owner_nv_index_attributes = NvIndexAttributes(0);
-        owner_nv_index_attributes.set_owner_write(true);
-        owner_nv_index_attributes.set_owner_read(true);
+        let owner_nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create owner nv index attributes");
 
         let owner_nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index)
@@ -2677,9 +2687,11 @@ mod test_nv_write {
         let nv_index = NvIndexTpmHandle::new(0x01500018).unwrap();
 
         // Create owner nv public.
-        let mut owner_nv_index_attributes = NvIndexAttributes(0);
-        owner_nv_index_attributes.set_owner_write(true);
-        owner_nv_index_attributes.set_owner_read(true);
+        let owner_nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create owner nv index attributes");
 
         let owner_nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index)
@@ -2720,9 +2732,11 @@ mod test_nv_read_public {
 
         let nv_index = NvIndexTpmHandle::new(0x01500019).unwrap();
 
-        let mut nv_index_attributes = NvIndexAttributes(0);
-        nv_index_attributes.set_owner_write(true);
-        nv_index_attributes.set_owner_read(true);
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create owner nv index attributes");
 
         let expected_nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index)
@@ -2763,9 +2777,11 @@ mod test_nv_read {
         let nv_index = NvIndexTpmHandle::new(0x01500020).unwrap();
 
         // Create owner nv public.
-        let mut owner_nv_index_attributes = NvIndexAttributes(0);
-        owner_nv_index_attributes.set_owner_write(true);
-        owner_nv_index_attributes.set_owner_read(true);
+        let owner_nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create owner nv index attributes");
 
         let owner_nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index)
@@ -2867,9 +2883,11 @@ mod test_tr_from_tpm_public {
         };
 
         // Create nv public.
-        let mut nv_index_attributes = NvIndexAttributes(0);
-        nv_index_attributes.set_owner_write(true);
-        nv_index_attributes.set_owner_read(true);
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create owner nv index attributes");
 
         let nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index_tpm_handle)
@@ -2944,9 +2962,11 @@ mod test_tr_from_tpm_public {
         };
 
         // Create nv public.
-        let mut nv_index_attributes = NvIndexAttributes(0);
-        nv_index_attributes.set_auth_write(true);
-        nv_index_attributes.set_auth_read(true);
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_auth_write(true)
+            .with_auth_read(true)
+            .build()
+            .expect("Failed to create auth nv index attributes");
 
         let nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index_tpm_handle)
@@ -3043,9 +3063,11 @@ mod test_tr_from_tpm_public {
         };
 
         // Create nv public. Only use auth for write.
-        let mut nv_index_attributes = NvIndexAttributes(0);
-        nv_index_attributes.set_auth_write(true);
-        nv_index_attributes.set_auth_read(true);
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_auth_write(true)
+            .with_auth_read(true)
+            .build()
+            .expect("Failed to create auth nv index attributes");
 
         let nv_public = NvPublicBuilder::new()
             .with_nv_index(nv_index_tpm_handle)

--- a/tests/nv_storage_nv_index_attributes_tests.rs
+++ b/tests/nv_storage_nv_index_attributes_tests.rs
@@ -1,6 +1,9 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use tss_esapi::nv::storage::{NvIndexAttributes, NvIndexType};
+use tss_esapi::{
+    nv::storage::{NvIndexAttributes, NvIndexAttributesBuilder, NvIndexType},
+    Error, WrapperErrorKind,
+};
 
 mod test_nv_storage_nv_index_attributes {
     use super::*;
@@ -60,78 +63,289 @@ mod test_nv_storage_nv_index_attributes {
         // 0(0000) - valid
     }
 
+    macro_rules! single_attribute_error {
+        ($method:ident) => {
+            assert_eq!(
+                Err(Error::WrapperError(WrapperErrorKind::ParamsMissing)),
+                NvIndexAttributesBuilder::new().$method(true).build()
+            );
+        };
+    }
+
     #[test]
-    fn test_attributes() {
-        let mut attributes = NvIndexAttributes(0x0);
+    fn test_nv_index_attributes_builder_missing_read_attribute_failure() {
+        // Test missing read error
 
-        attributes.set_pp_write(true);
-        assert_eq!(0b0000_0000_0000_0000_0000_0000_0000_0001u32, attributes.0);
+        // Building with only PP write set this should result in an error
+        single_attribute_error!(with_pp_write);
+        // Building with only owner write set this should result in an error
+        single_attribute_error!(with_owner_write);
+        // Building with only auth write set this should result in an error
+        single_attribute_error!(with_auth_write);
+        // Building with only policy write set this should result in an error
+        single_attribute_error!(with_policy_write);
+        // Building with all of them set still results in an error
+        assert_eq!(
+            Err(Error::WrapperError(WrapperErrorKind::ParamsMissing)),
+            NvIndexAttributesBuilder::new()
+                .with_pp_write(true)
+                .with_owner_write(true)
+                .with_auth_write(true)
+                .with_policy_write(true)
+                .build()
+        );
+    }
 
-        attributes.set_owner_write(true);
-        assert_eq!(0b0000_0000_0000_0000_0000_0000_0000_0011u32, attributes.0);
+    #[test]
+    fn test_nv_index_attributes_builder_missing_write_attribute_failure() {
+        // Test missing write error
 
-        attributes.set_auth_write(true);
-        assert_eq!(0b0000_0000_0000_0000_0000_0000_0000_0111u32, attributes.0);
+        // Building with only PP read set this should result in an error
+        single_attribute_error!(with_pp_read);
+        // Building with only owner read set this should result in an error
+        single_attribute_error!(with_owner_read);
+        // Building with only auth read set this should result in an error
+        single_attribute_error!(with_auth_read);
+        // Building with only policy read set this should result in an error
+        single_attribute_error!(with_policy_read);
+        // Building with all of them set still results in an error
+        assert_eq!(
+            Err(Error::WrapperError(WrapperErrorKind::ParamsMissing)),
+            NvIndexAttributesBuilder::new()
+                .with_pp_read(true)
+                .with_owner_read(true)
+                .with_auth_read(true)
+                .with_policy_read(true)
+                .build()
+        );
+    }
 
-        attributes.set_policy_write(true);
-        assert_eq!(0b0000_0000_0000_0000_0000_0000_0000_1111u32, attributes.0);
+    #[test]
+    fn test_nv_index_attributes_builder_missing_no_da_attribute_with_pin_fail_index_type() {
+        assert_eq!(
+            Err(Error::WrapperError(WrapperErrorKind::ParamsMissing)),
+            NvIndexAttributesBuilder::new()
+                .with_nv_index_type(NvIndexType::PinFail)
+                .build()
+        );
+    }
 
-        // PinPass = 1001 (7,4)
-        attributes.set_index_type(NvIndexType::PinPass);
-        assert_eq!(0b0000_0000_0000_0000_0000_0000_1001_1111u32, attributes.0);
-        assert_eq!(NvIndexType::PinPass, attributes.index_type().unwrap());
+    #[test]
+    fn test_attributes_builder() {
+        let mut builder = NvIndexAttributesBuilder::new();
+
+        // Need to set a read and write in order to be able to build.
+        builder = builder.with_pp_write(true).with_pp_read(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_0000_0000_0000_0001u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with pp_write and pp_read added")
+                .0
+        );
+
+        builder = builder.with_owner_write(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_0000_0000_0000_0011u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with owner_write added")
+                .0
+        );
+
+        builder = builder.with_auth_write(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_0000_0000_0000_0111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with auth_write added")
+                .0
+        );
+
+        builder = builder.with_policy_write(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_0000_0000_0000_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with policy_write added")
+                .0
+        );
+
+        {
+            // PinPass = 1001 (7,4)
+            builder = builder.with_nv_index_type(NvIndexType::PinPass);
+            let attributes = builder
+                .clone()
+                .build()
+                .expect("Failed to build with nv index type PinPass added");
+            assert_eq!(0b0000_0000_0000_0001_0000_0000_1001_1111u32, attributes.0);
+            assert_eq!(NvIndexType::PinPass, attributes.index_type().unwrap());
+        }
 
         // (8,9 Reserved)
-        attributes.set_policy_delete(true);
-        assert_eq!(0b0000_0000_0000_0000_0000_0100_1001_1111u32, attributes.0);
+        builder = builder.with_policy_delete(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_0000_0100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with policy_delete added")
+                .0
+        );
 
-        attributes.set_write_locked(true);
-        assert_eq!(0b0000_0000_0000_0000_0000_1100_1001_1111u32, attributes.0);
+        builder = builder.with_write_locked(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_0000_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with write_locked added")
+                .0
+        );
 
-        attributes.set_write_all(true);
-        assert_eq!(0b0000_0000_0000_0000_0001_1100_1001_1111u32, attributes.0);
+        builder = builder.with_write_all(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_0001_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with write_all added")
+                .0
+        );
 
-        attributes.set_write_define(true);
-        assert_eq!(0b0000_0000_0000_0000_0011_1100_1001_1111u32, attributes.0);
+        builder = builder.with_write_define(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_0011_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with write_define added")
+                .0
+        );
 
-        attributes.set_write_stclear(true);
-        assert_eq!(0b0000_0000_0000_0000_0111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_write_stclear(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_0111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with write_stclear added")
+                .0
+        );
 
-        attributes.set_global_lock(true);
-        assert_eq!(0b0000_0000_0000_0000_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_global_lock(true);
+        assert_eq!(
+            0b0000_0000_0000_0001_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with global_lock added")
+                .0
+        );
 
-        attributes.set_pp_read(true);
-        assert_eq!(0b0000_0000_0000_0001_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_owner_read(true);
+        assert_eq!(
+            0b0000_0000_0000_0011_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with owner_read added")
+                .0
+        );
 
-        attributes.set_owner_read(true);
-        assert_eq!(0b0000_0000_0000_0011_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_auth_read(true);
+        assert_eq!(
+            0b0000_0000_0000_0111_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with auth_read added")
+                .0
+        );
 
-        attributes.set_auth_read(true);
-        assert_eq!(0b0000_0000_0000_0111_1111_1100_1001_1111u32, attributes.0);
-
-        attributes.set_policy_read(true);
-        assert_eq!(0b0000_0000_0000_1111_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_policy_read(true);
+        assert_eq!(
+            0b0000_0000_0000_1111_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with policy_read added")
+                .0
+        );
 
         // Reserved (24, 20)
-        attributes.set_no_da(true);
-        assert_eq!(0b0000_0010_0000_1111_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_no_da(true);
+        assert_eq!(
+            0b0000_0010_0000_1111_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with no_da added")
+                .0
+        );
 
-        attributes.set_orderly(true);
-        assert_eq!(0b0000_0110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_orderly(true);
+        assert_eq!(
+            0b0000_0110_0000_1111_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with oderly added")
+                .0
+        );
 
-        attributes.set_clear_stclear(true);
-        assert_eq!(0b0000_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_clear_stclear(true);
+        assert_eq!(
+            0b0000_1110_0000_1111_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with clear_stclear added")
+                .0
+        );
 
-        attributes.set_read_locked(true);
-        assert_eq!(0b0001_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_read_locked(true);
+        assert_eq!(
+            0b0001_1110_0000_1111_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with read_locked added")
+                .0
+        );
 
-        attributes.set_written(true);
-        assert_eq!(0b0011_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_written(true);
+        assert_eq!(
+            0b0011_1110_0000_1111_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with written added")
+                .0
+        );
 
-        attributes.set_platform_create(true);
-        assert_eq!(0b0111_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_platform_create(true);
+        assert_eq!(
+            0b0111_1110_0000_1111_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with platform_create added")
+                .0
+        );
 
-        attributes.set_read_stclear(true);
-        assert_eq!(0b1111_1110_0000_1111_1111_1100_1001_1111u32, attributes.0);
+        builder = builder.with_read_stclear(true);
+        assert_eq!(
+            0b1111_1110_0000_1111_1111_1100_1001_1111u32,
+            builder
+                .clone()
+                .build()
+                .expect("Failed to build with read_stclear added")
+                .0
+        );
     }
 }


### PR DESCRIPTION
Added a builder for the NvIndexAttributes.

The advantage with this is that the builder can check
for missing or conflicting attributes and it does not
need to be mutable when creating the attributes.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>