### PR TITLE
Fixed interface types used for nv context methods.

### DIFF
--- a/tss-esapi/src/abstraction/nv.rs
+++ b/tss-esapi/src/abstraction/nv.rs
@@ -3,7 +3,8 @@
 
 use crate::{
     constants::{tags::PropertyTag, tss::*, types::capability::CapabilityType},
-    handles::{AuthHandle, NvIndexHandle, NvIndexTpmHandle, ObjectHandle, TpmHandle},
+    handles::{NvIndexHandle, NvIndexTpmHandle, ObjectHandle, TpmHandle},
+    interface_types::resource_handles::NvAuth,
     nv::storage::NvPublic,
     structures::{CapabilityData, Name},
     Context, Error, Result, WrapperErrorKind,
@@ -12,7 +13,7 @@ use crate::{
 /// Allows reading an NV Index completely, regardless of the max TPM NV buffer size
 pub fn read_full(
     context: &mut Context,
-    auth_handle: AuthHandle,
+    auth_handle: NvAuth,
     nv_index_handle: NvIndexTpmHandle,
 ) -> Result<Vec<u8>> {
     let maxsize = context

--- a/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
+++ b/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
@@ -1,7 +1,7 @@
 use crate::{
     context::handle_manager::HandleDropAction,
     handles::{AuthHandle, NvIndexHandle},
-    interface_types::resource_handles::NvAuth,
+    interface_types::resource_handles::{NvAuth, Provision},
     nv::storage::NvPublic,
     structures::{Auth, MaxNvBuffer, Name},
     tss2_esys::*,
@@ -18,9 +18,14 @@ impl Context {
     /// # Details
     /// This method will instruct the TPM to reserve space for an NV index
     /// with the attributes defined in the provided parameters.
+    ///
+    /// # Arguments
+    /// * `nv_auth` - The [Provision] used for authorization.
+    /// * `auth` - The authorization value.
+    /// * `public_info` - The public parameters of the NV area.
     pub fn nv_define_space(
         &mut self,
-        nv_auth: NvAuth,
+        nv_auth: Provision,
         auth: Option<&Auth>,
         public_info: &NvPublic,
     ) -> Result<NvIndexHandle> {
@@ -53,9 +58,14 @@ impl Context {
     /// # Details
     /// The method will instruct the TPM to remove a
     /// nv index.
+    ///
+    /// # Arguments
+    /// * `nv_auth` - The [Provision] used for authorization.
+    /// * `nv_index_handle`- The [NvIndexHandle] associated with
+    ///                      the nv area that is to be removed.
     pub fn nv_undefine_space(
         &mut self,
-        nv_auth: NvAuth,
+        nv_auth: Provision,
         nv_index_handle: NvIndexHandle,
     ) -> Result<()> {
         let ret = unsafe {
@@ -121,7 +131,7 @@ impl Context {
     /// the nv memory in the TPM.
     pub fn nv_write(
         &mut self,
-        auth_handle: AuthHandle,
+        auth_handle: NvAuth,
         nv_index_handle: NvIndexHandle,
         data: &MaxNvBuffer,
         offset: u16,
@@ -129,7 +139,7 @@ impl Context {
         let ret = unsafe {
             Esys_NV_Write(
                 self.mut_context(),
-                auth_handle.into(),
+                AuthHandle::from(auth_handle).into(),
                 nv_index_handle.into(),
                 self.optional_session_1(),
                 self.optional_session_2(),
@@ -160,7 +170,7 @@ impl Context {
     /// NV memory of the TPM.
     pub fn nv_read(
         &mut self,
-        auth_handle: AuthHandle,
+        auth_handle: NvAuth,
         nv_index_handle: NvIndexHandle,
         size: u16,
         offset: u16,
@@ -169,7 +179,7 @@ impl Context {
         let ret = unsafe {
             Esys_NV_Read(
                 self.mut_context(),
-                auth_handle.into(),
+                AuthHandle::from(auth_handle).into(),
                 nv_index_handle.into(),
                 self.optional_session_1(),
                 self.optional_session_2(),

--- a/tss-esapi/tests/abstraction_nv_tests.rs
+++ b/tss-esapi/tests/abstraction_nv_tests.rs
@@ -6,7 +6,7 @@ use tss_esapi::abstraction::nv;
 use tss_esapi::{
     constants::algorithm::HashingAlgorithm,
     handles::NvIndexTpmHandle,
-    interface_types::resource_handles::NvAuth,
+    interface_types::resource_handles::{NvAuth, Provision},
     nv::storage::{NvIndexAttributesBuilder, NvPublicBuilder},
     structures::MaxNvBuffer,
 };
@@ -44,7 +44,7 @@ fn read_full() {
         .unwrap();
 
     let owner_nv_index_handle = context
-        .nv_define_space(NvAuth::Owner, None, &owner_nv_public)
+        .nv_define_space(Provision::Owner, None, &owner_nv_public)
         .unwrap();
 
     let value = [1, 2, 3, 4, 5, 6, 7];
@@ -52,27 +52,17 @@ fn read_full() {
 
     // Write the data using Owner authorization
     context
-        .nv_write(
-            NvAuth::Owner.into(),
-            owner_nv_index_handle,
-            &expected_data,
-            0,
-        )
+        .nv_write(NvAuth::Owner, owner_nv_index_handle, &expected_data, 0)
         .unwrap();
     context
-        .nv_write(
-            NvAuth::Owner.into(),
-            owner_nv_index_handle,
-            &expected_data,
-            1024,
-        )
+        .nv_write(NvAuth::Owner, owner_nv_index_handle, &expected_data, 1024)
         .unwrap();
 
     // Now read it back
-    let read_result = nv::read_full(&mut context, NvAuth::Owner.into(), nv_index);
+    let read_result = nv::read_full(&mut context, NvAuth::Owner, nv_index);
 
     let _ = context
-        .nv_undefine_space(NvAuth::Owner, owner_nv_index_handle)
+        .nv_undefine_space(Provision::Owner, owner_nv_index_handle)
         .unwrap();
 
     let read_result = read_result.unwrap();


### PR DESCRIPTION
The nv_define_space and nv_undefine_space were using
the NvAuth interface type. Though according to the specification
they should be using the Provision interface type.

The other nv context methods were simply using an auth handle
that could be anything. This is probably not correct. According to
the TPM specification they should be using the NvAuth interface type.

These issues were mentioned in #184 and should with this be resolved.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>