### PR TITLE
ak: Ephemeral key / Protect against replay attacks

### DIFF
--- a/tss-esapi/src/abstraction/ak.rs
+++ b/tss-esapi/src/abstraction/ak.rs
@@ -32,6 +32,9 @@ fn create_ak_public(
         .with_fixed_tpm(true)
         .with_fixed_parent(true)
         .with_sensitive_data_origin(true)
+        // Prevent replay attacks.
+        // Ensure the key can't be reused after a TPM reset/reboot.
+        .with_st_clear(true)
         .build()?;
 
     match key_alg {


### PR DESCRIPTION
To give credit where credit is due:
 > https://safeboot.dev/attestation/#why-is-generating-a-quote-so-slow
 > By creating an ephemeral AK (with the stclear bit set in the
 > attributes), the TPM will not allow it to be persisted and will refuse
 > to reload it when the reboot counter increments.

The downside is that it's slow as one need to generate a key every time.