### PR TITLE
Add code coverage reporting

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,8 @@ name: Nightly Checks
 on:
   schedule:
     # Every night at midnight
-    - cron:  '0 0 * * *'
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   # This won't build on GA environment because of missing TSS
@@ -38,3 +39,13 @@ jobs:
         run: cargo install cargo-audit
       - name: Execute cargo audit
         run: cargo audit
+
+  coverage:
+    name: Calculate code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the container
+        run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu
+      - name: Run the container
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --security-opt seccomp=unconfined ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/coverage.sh

--- a/tss-esapi/tests/coverage.sh
+++ b/tss-esapi/tests/coverage.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euf -o pipefail
+
+#################################
+# Run the TPM simulation server #
+#################################
+tpm_server &
+sleep 5
+tpm2_startup -c -T mssim
+
+#############################
+# Install and run tarpaulin #
+#############################
+cargo install cargo-tarpaulin
+cargo tarpaulin --tests --out Xml --exclude-files="tests/*,../*" -- --test-threads=1 --nocapture
+
+#################
+# Upload report #
+#################
+bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This commit adds a script and a nightly run for generating code coverage
reports for the `tss-esapi` crate.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>