### PR TITLE
ak, ek: allows use to pass options to key creation

### DIFF
--- a/tss-esapi/src/abstraction/ak.rs
+++ b/tss-esapi/src/abstraction/ak.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    abstraction::cipher::Cipher,
+    abstraction::{cipher::Cipher, DefaultKey, KeyCustomization},
     attributes::{ObjectAttributesBuilder, SessionAttributesBuilder},
     constants::{tss::*, SessionType},
     handles::{AuthHandle, KeyHandle},
@@ -19,22 +19,24 @@ use crate::{
 use log::error;
 use std::convert::{TryFrom, TryInto};
 
-fn create_ak_public(
+fn create_ak_public<K: KeyCustomization>(
     key_alg: AsymmetricAlgorithm,
     hash_alg: HashingAlgorithm,
     sign_alg: SignatureScheme,
+    key_customization: &K,
 ) -> Result<TPM2B_PUBLIC> {
-    let obj_attrs = ObjectAttributesBuilder::new()
+    let obj_attrs_builder = ObjectAttributesBuilder::new()
         .with_restricted(true)
         .with_user_with_auth(true)
         .with_sign_encrypt(true)
         .with_decrypt(false)
         .with_fixed_tpm(true)
         .with_fixed_parent(true)
-        .with_sensitive_data_origin(true)
-        .build()?;
+        .with_sensitive_data_origin(true);
 
-    match key_alg {
+    let obj_attrs = key_customization.attributes(obj_attrs_builder).build()?;
+
+    let key_builder = match key_alg {
         AsymmetricAlgorithm::Rsa => Tpm2BPublicBuilder::new()
             .with_type(TPM2_ALG_RSA)
             .with_name_alg(hash_alg.into())
@@ -86,8 +88,10 @@ fn create_ak_public(
             // TDOD: Figure out what to with Null.
             return Err(Error::local_error(WrapperErrorKind::UnsupportedParam));
         }
-    }
-    .build()
+    };
+
+    let key_builder = key_customization.template(key_builder);
+    key_builder.build()
 }
 
 /// This loads an Attestation Key previously generated under the Endorsement hierarchy
@@ -139,12 +143,13 @@ pub fn load_ak(
 }
 
 /// This creates an Attestation Key in the Endorsement hierarchy
-pub fn create_ak(
+pub fn create_ak_custom<K: KeyCustomization>(
     context: &mut Context,
     parent: KeyHandle,
     hash_alg: HashingAlgorithm,
     sign_alg: SignatureScheme,
     ak_auth_value: Option<&Auth>,
+    key_customization: &K,
 ) -> Result<CreateKeyResult> {
     let key_alg = AsymmetricAlgorithm::try_from(sign_alg).map_err(|e| {
         // sign_alg is either HMAC or Null.
@@ -152,7 +157,7 @@ pub fn create_ak(
         e
     })?;
 
-    let ak_pub = create_ak_public(key_alg, hash_alg, sign_alg)?;
+    let ak_pub = create_ak_public(key_alg, hash_alg, sign_alg, key_customization)?;
 
     let session = match context.start_auth_session(
         None,
@@ -187,4 +192,22 @@ pub fn create_ak(
             ctx.create(parent, &ak_pub, ak_auth_value, None, None, None)
         })
     })
+}
+
+/// This creates an Attestation Key in the Endorsement hierarchy
+pub fn create_ak(
+    context: &mut Context,
+    parent: KeyHandle,
+    hash_alg: HashingAlgorithm,
+    sign_alg: SignatureScheme,
+    ak_auth_value: Option<&Auth>,
+) -> Result<CreateKeyResult> {
+    create_ak_custom(
+        context,
+        parent,
+        hash_alg,
+        sign_alg,
+        ak_auth_value,
+        &DefaultKey,
+    )
 }

--- a/tss-esapi/src/abstraction/ek.rs
+++ b/tss-esapi/src/abstraction/ek.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    abstraction::nv,
+    abstraction::{nv, DefaultKey, KeyCustomization},
     attributes::ObjectAttributesBuilder,
     constants::tss::*,
     handles::{KeyHandle, NvIndexTpmHandle, TpmHandle},
@@ -26,8 +26,11 @@ const ECC_P256_EK_CERTIFICATE_NV_INDEX: u32 = 0x01c0000a;
 
 // Source: TCG EK Credential Profile for TPM Family 2.0; Level 0 Version 2.3 Revision 2
 // Appendix B.3.3 and B.3.4
-fn create_ek_public_from_default_template(alg: AsymmetricAlgorithm) -> Result<TPM2B_PUBLIC> {
-    let obj_attrs = ObjectAttributesBuilder::new()
+fn create_ek_public_from_default_template<K: KeyCustomization>(
+    alg: AsymmetricAlgorithm,
+    key_customization: &K,
+) -> Result<TPM2B_PUBLIC> {
+    let obj_attrs_builder = ObjectAttributesBuilder::new()
         .with_fixed_tpm(true)
         .with_st_clear(false)
         .with_fixed_parent(true)
@@ -38,8 +41,9 @@ fn create_ek_public_from_default_template(alg: AsymmetricAlgorithm) -> Result<TP
         .with_encrypted_duplication(false)
         .with_restricted(true)
         .with_decrypt(true)
-        .with_sign_encrypt(false)
-        .build()?;
+        .with_sign_encrypt(false);
+
+    let obj_attrs = key_customization.attributes(obj_attrs_builder).build()?;
 
     // TPM2_PolicySecret(TPM_RH_ENDORSEMENT)
     // With 32 null-bytes attached, because of the type of with_auth_policy
@@ -51,7 +55,7 @@ fn create_ek_public_from_default_template(alg: AsymmetricAlgorithm) -> Result<TP
         0x00, 0x00, 0x00, 0x00,
     ];
 
-    match alg {
+    let key_builder = match alg {
         AsymmetricAlgorithm::Rsa => Tpm2BPublicBuilder::new()
             .with_type(TPM2_ALG_RSA)
             .with_name_alg(TPM2_ALG_SHA256)
@@ -73,8 +77,7 @@ fn create_ek_public_from_default_template(alg: AsymmetricAlgorithm) -> Result<TP
             .with_unique(PublicIdUnion::Rsa(Box::new(TPM2B_PUBLIC_KEY_RSA {
                 size: 256,
                 buffer: [0; 512],
-            })))
-            .build(),
+            }))),
         AsymmetricAlgorithm::Ecc => Tpm2BPublicBuilder::new()
             .with_type(TPM2_ALG_ECC)
             .with_name_alg(TPM2_ALG_SHA256)
@@ -109,24 +112,35 @@ fn create_ek_public_from_default_template(alg: AsymmetricAlgorithm) -> Result<TP
                     size: 32,
                     buffer: [0; 128],
                 },
-            })))
-            .build(),
+            }))),
         AsymmetricAlgorithm::Null => {
             // TDOD: Figure out what to with Null.
-            Err(Error::local_error(WrapperErrorKind::UnsupportedParam))
+            return Err(Error::local_error(WrapperErrorKind::UnsupportedParam));
         }
-    }
+    };
+
+    let key_builder = key_customization.template(key_builder);
+    key_builder.build()
 }
 
 /// Create the Endorsement Key object from the specification templates
-pub fn create_ek_object(context: &mut Context, alg: AsymmetricAlgorithm) -> Result<KeyHandle> {
-    let ek_public = create_ek_public_from_default_template(alg)?;
+pub fn create_ek_object_custom<K: KeyCustomization>(
+    context: &mut Context,
+    alg: AsymmetricAlgorithm,
+    key_customization: &K,
+) -> Result<KeyHandle> {
+    let ek_public = create_ek_public_from_default_template(alg, key_customization)?;
 
     Ok(context
         .execute_with_nullauth_session(|ctx| {
             ctx.create_primary(Hierarchy::Endorsement, &ek_public, None, None, None, None)
         })?
         .key_handle)
+}
+
+/// Create the Endorsement Key object from the specification templates
+pub fn create_ek_object(context: &mut Context, alg: AsymmetricAlgorithm) -> Result<KeyHandle> {
+    create_ek_object_custom(context, alg, &DefaultKey)
 }
 
 /// Retreive the Endorsement Key public certificate from the TPM

--- a/tss-esapi/src/abstraction/mod.rs
+++ b/tss-esapi/src/abstraction/mod.rs
@@ -6,3 +6,24 @@ pub mod cipher;
 pub mod ek;
 pub mod nv;
 pub mod transient;
+
+use crate::attributes::ObjectAttributesBuilder;
+use crate::utils::Tpm2BPublicBuilder;
+
+/// KeyCustomizaion allows to adjust how a key is going to be created
+pub trait KeyCustomization {
+    /// Alter the attributes used on key creation
+    fn attributes(&self, attributes_builder: ObjectAttributesBuilder) -> ObjectAttributesBuilder {
+        attributes_builder
+    }
+
+    /// Alter the key template used on key creation
+    fn template(&self, template_builder: Tpm2BPublicBuilder) -> Tpm2BPublicBuilder {
+        template_builder
+    }
+}
+
+/// DefaultKey provides a blanket implementation of KeyCustomization
+#[derive(Copy, Clone, Debug)]
+pub struct DefaultKey;
+impl KeyCustomization for DefaultKey {}


### PR DESCRIPTION
This introduces a KeyCustomization arguments to create_ek and create_ak,
this allows a consumer of this API to alter the way a key would be
created.