### PR TITLE
ak, ek: allows use to pass options to key creation

### DIFF
--- a/tss-esapi/src/abstraction/mod.rs
+++ b/tss-esapi/src/abstraction/mod.rs
@@ -6,3 +6,56 @@ pub mod cipher;
 pub mod ek;
 pub mod nv;
 pub mod transient;
+
+use crate::attributes::ObjectAttributesBuilder;
+use crate::utils::Tpm2BPublicBuilder;
+
+/// KeyCustomizaion allows to adjust how a key is going to be created
+pub trait KeyCustomization {
+    /// Alter the attributes used on key creation
+    fn attributes(&self, attributes_builder: ObjectAttributesBuilder) -> ObjectAttributesBuilder {
+        attributes_builder
+    }
+
+    /// Alter the key template used on key creation
+    fn template(&self, template_builder: Tpm2BPublicBuilder) -> Tpm2BPublicBuilder {
+        template_builder
+    }
+}
+
+/// IntoKeyCustomization transforms a type into a type that support KeyCustomization
+pub trait IntoKeyCustomization {
+    type T: KeyCustomization;
+
+    fn into_key_customization(self) -> Option<Self::T>;
+}
+
+impl<T: KeyCustomization> IntoKeyCustomization for T {
+    type T = T;
+
+    fn into_key_customization(self) -> Option<Self::T> {
+        Some(self)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct DefaultKey;
+#[derive(Debug, Copy, Clone)]
+pub struct DefaultKeyImpl;
+impl KeyCustomization for DefaultKeyImpl {}
+
+impl IntoKeyCustomization for DefaultKey {
+    type T = DefaultKeyImpl;
+
+    fn into_key_customization(self) -> Option<Self::T> {
+        None
+    }
+}
+
+impl IntoKeyCustomization for Option<DefaultKey> {
+    type T = DefaultKeyImpl;
+
+    fn into_key_customization(self) -> Option<Self::T> {
+        None
+    }
+}

--- a/tss-esapi/tests/abstraction_ek_tests.rs
+++ b/tss-esapi/tests/abstraction_ek_tests.rs
@@ -33,6 +33,6 @@ fn test_retrieve_ek_pubcert() {
 fn test_create_ek() {
     let mut context = create_ctx_without_session();
 
-    let _ = ek::create_ek_object(&mut context, AsymmetricAlgorithm::Rsa).unwrap();
-    let _ = ek::create_ek_object(&mut context, AsymmetricAlgorithm::Ecc).unwrap();
+    let _ = ek::create_ek_object(&mut context, AsymmetricAlgorithm::Rsa, None).unwrap();
+    let _ = ek::create_ek_object(&mut context, AsymmetricAlgorithm::Ecc, None).unwrap();
 }


### PR DESCRIPTION
This introduces a KeyCustomization argument to create_ek and create_ak,
this allows a consumer of this API to alter the way a key would be
created.

An alternative implementation to #197