### PR TITLE
This is an attempt to fix tests that fails locally.

### DIFF
--- a/tss-esapi/tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -23,14 +23,16 @@ mod test_policy_signed {
             .key_handle;
 
         let trial_session = context
-            .start_auth_session(
-                None,
-                None,
-                None,
-                SessionType::Trial,
-                SymmetricDefinition::AES_256_CFB,
-                HashingAlgorithm::Sha256,
-            )
+            .execute_without_session(|ctx| {
+                ctx.start_auth_session(
+                    None,
+                    None,
+                    None,
+                    SessionType::Trial,
+                    SymmetricDefinition::AES_256_CFB,
+                    HashingAlgorithm::Sha256,
+                )
+            })
             .expect("Start auth session failed")
             .expect("Start auth session returned a NONE handle");
         let (trial_session_attributes, trial_session_attributes_mask) =
@@ -84,14 +86,16 @@ mod test_policy_secret {
         let mut context = create_ctx_with_session();
 
         let trial_session = context
-            .start_auth_session(
-                None,
-                None,
-                None,
-                SessionType::Trial,
-                SymmetricDefinition::AES_256_CFB,
-                HashingAlgorithm::Sha256,
-            )
+            .execute_without_session(|ctx| {
+                ctx.start_auth_session(
+                    None,
+                    None,
+                    None,
+                    SessionType::Trial,
+                    SymmetricDefinition::AES_256_CFB,
+                    HashingAlgorithm::Sha256,
+                )
+            })
             .expect("Start auth session failed")
             .expect("Start auth session returned a NONE handle");
         let (trial_session_attributes, trial_session_attributes_mask) =
@@ -120,7 +124,7 @@ mod test_policy_secret {
                 policy_ref,
                 Some(Duration::from_secs(3600)),
             )
-            .unwrap();
+            .expect("Failed to call policy_secret");
     }
 }
 

--- a/tss-esapi/tests/context_tests/tpm_commands/random_number_generator_tests.rs
+++ b/tss-esapi/tests/context_tests/tpm_commands/random_number_generator_tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod test_random {
-    use crate::common::create_ctx_with_session;
+    use crate::common::create_ctx_without_session;
     use std::convert::TryFrom;
     use tss_esapi::{
         attributes::SessionAttributesBuilder,
@@ -12,7 +12,7 @@ mod test_random {
 
     #[test]
     fn test_encrypted_get_rand() {
-        let mut context = create_ctx_with_session();
+        let mut context = create_ctx_without_session();
         let encrypted_sess = context
             .start_auth_session(
                 None,
@@ -39,7 +39,7 @@ mod test_random {
 
     #[test]
     fn test_authenticated_get_rand() {
-        let mut context = create_ctx_with_session();
+        let mut context = create_ctx_without_session();
         let auth_sess = context
             .start_auth_session(
                 None,
@@ -58,13 +58,13 @@ mod test_random {
 
     #[test]
     fn test_get_0_rand() {
-        let mut context = create_ctx_with_session();
+        let mut context = create_ctx_without_session();
         let _ = context.get_random(0);
     }
 
     #[test]
     fn test_stir_random() {
-        let mut context = create_ctx_with_session();
+        let mut context = create_ctx_without_session();
         let additional_data = SensitiveData::try_from(vec![1, 2, 3]).unwrap();
         context.stir_random(additional_data).unwrap();
     }


### PR DESCRIPTION
This change tries to address the issue described in #200 

Sometimes when trying to run tests locally they fail with
some cryptic message that a new auth session could not be
created due to authorization failure.

The cause behind this is that one session is being used
as an optional session for creating another session
whether this should be allowed or not is not quite clear.
Until this have been fully investigated this change remove
this behaviour.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>