### PR TITLE
CI: Fix all-fedora swtpm_setup call

### DIFF
--- a/tss-esapi/tests/all-fedora.sh
+++ b/tss-esapi/tests/all-fedora.sh
@@ -16,7 +16,7 @@ set -euf -o pipefail
 mkdir /tmp/tpmdir
 swtpm_setup --tpm2 \
     --tpmstate /tmp/tpmdir \
-    --createek --allow-signing --decryption --create-ek-cert \
+    --createek --decryption --create-ek-cert \
     --create-platform-cert \
     --display
 swtpm socket --tpm2 \


### PR DESCRIPTION
Adding --allow-signing produces an Endorsement Certificate that doesn't
match the standard Endorsement Key.
This does not match at all for rust-tss-esapi, but it's a useful fix for
anyone grabbing this bit of the script to somewhere else.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>