### PR TITLE
Make codecov recognize environment

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,3 +49,5 @@ jobs:
         run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu
       - name: Run the container
         run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --security-opt seccomp=unconfined ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/coverage.sh
+      - name: Collect coverage results
+        run: bash <(curl -s https://codecov.io/bash)

--- a/tss-esapi/tests/coverage.sh
+++ b/tss-esapi/tests/coverage.sh
@@ -17,8 +17,3 @@ tpm2_startup -c -T mssim
 #############################
 cargo install cargo-tarpaulin
 cargo tarpaulin --tests --out Xml --exclude-files="tests/*,../*" -- --test-threads=1 --nocapture
-
-#################
-# Upload report #
-#################
-bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This commit adds an environment variable to the nightly codecov run to
allow it to figure out that it's running in Github Actions.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>