### PR TITLE
Update registry for Dockerfiles

### DIFF
--- a/tss-esapi/tests/Dockerfile-ubuntu
+++ b/tss-esapi/tests/Dockerfile-ubuntu
@@ -1,4 +1,4 @@
-FROM tpm2software/tpm2-tss:ubuntu-18.04
+FROM ghcr.io/tpm2-software/ubuntu-18.04:latest
 
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 


### PR DESCRIPTION
This commit updates the registry used for the Ubuntu Dockerfile,
as the packages were moves to the Github registry.

Announced [here](https://lists.01.org/hyperkitty/list/tpm2@lists.01.org/thread/MJLXGAQ3RYXE7IDPYR5KKUDVBYTVT4GR/)