### PR TITLE
Prepare the new crates versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-<!--
-  -- Copyright 2019 Contributors to the Parsec project.
-  -- SPDX-License-Identifier: Apache-2.0
---->
-
 # TSS 2.0 Enhanced System API Rust Wrapper
 
 The `tss-esapi` Rust crate provides an idiomatic interface to the TCG TSS 2.0 Enhanced System API. We expose both direct FFI bindings (under the `tss-esapi-sys` crate) and abstracted versions, aimed at improved convenience of using the API.
@@ -18,15 +13,16 @@ If you need support for other versions of the compiler, get in touch with us to 
 
 ## Community channel
 
-Come and talk to us in [our Slack channel](https://cloud-native.slack.com/archives/C01EARH2ZB3)!
-[Here](https://slack.cncf.io/) is where you can join the workspace.
+Come and talk to us in [our Slack channel](https://github.com/parallaxsecond/community#community-channel)!
 
 ## Contributing
 
 We would be happy for you to contribute to the `tss-esapi` crate!
-Please check the [**Contribution Guidelines**](https://parallaxsecond.github.io/parsec-book/contributing.html)
+Please check the [**Contribution Guidelines**](https://parallaxsecond.github.io/parsec-book/contributing/index.html)
 to know more about the contribution process.
 
 ## License
 
 The software is provided under Apache-2.0. Contributions to this project are accepted under the same license.
+
+*Copyright 2019 Contributors to the Parsec project.*

--- a/tss-esapi-sys/README.md
+++ b/tss-esapi-sys/README.md
@@ -1,9 +1,10 @@
-<!--
-  -- Copyright 2021 Contributors to the Parsec project.
-  -- SPDX-License-Identifier: Apache-2.0
---->
-
 # TPM2 Software Stack Rust Wrapper
+
+<p align="center">
+  <a href="https://crates.io/crates/tss-esapi-sys"><img alt="Crates.io" src="https://img.shields.io/crates/v/tss-esapi-sys"></a>
+  <a href="https://docs.rs/tss-esapi-sys"><img src="https://docs.rs/tss-esapi-sys/badge.svg" alt="Code documentation"/></a>
+  <a href="https://codecov.io/gh/parallaxsecond/rust-tss-esapi"><img src="https://codecov.io/gh/parallaxsecond/rust-tss-esapi/branch/main/graph/badge.svg?token=5T7SVCHWFE"/></a>
+</p>
 
 This is the lower-level wrapper that exposes a minimal, low-level C
 interface to Rust to [TSS](https://github.com/tpm2-software/tpm2-tss).
@@ -57,3 +58,5 @@ script around `pkg-config` can be seen [here](../tss-esapi/tests/pkg-config).
 
 Be advised that in some cases the linker used might need to be set manually in
 `.cargo/config`.
+
+*Copyright 2021 Contributors to the Parsec project.*

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "4.0.11-alpha.1"
+version = "5.0.0"
 authors = ["Parsec Project Contributors"]
 edition = "2018"
 description = "Rust-native wrapper around TSS 2.0 Enhanced System API"

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "4.0.10-alpha.2"
+version = "4.0.11-alpha.1"
 authors = ["Parsec Project Contributors"]
 edition = "2018"
 description = "Rust-native wrapper around TSS 2.0 Enhanced System API"
@@ -22,7 +22,7 @@ num-traits = "0.2.12"
 hostname-validator = "1.0.0"
 regex = "1.3.9"
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
-tss-esapi-sys = { path = "../tss-esapi-sys" }
+tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.1.0" }
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/tss-esapi/README.md
+++ b/tss-esapi/README.md
@@ -1,14 +1,9 @@
-<!--
-  -- Copyright 2021 Contributors to the Parsec project.
-  -- SPDX-License-Identifier: Apache-2.0
---->
-
 # TPM2 Software Stack Rust Wrapper 
 
 <p align="center">
   <a href="https://crates.io/crates/tss-esapi"><img alt="Crates.io" src="https://img.shields.io/crates/v/tss-esapi"></a>
   <a href="https://docs.rs/tss-esapi"><img src="https://docs.rs/tss-esapi/badge.svg" alt="Code documentation"/></a>
-  <a href="https://github.com/parallaxsecond/rust-tss-esapi/actions?query=workflow%3A%22Continuous+Integration%22"><img src="https://github.com/parallaxsecond/rust-tss-esapi/workflows/Continuous%20Integration/badge.svg" alt="CI tests"/></a>
+  <a href="https://codecov.io/gh/parallaxsecond/rust-tss-esapi"><img src="https://codecov.io/gh/parallaxsecond/rust-tss-esapi/branch/main/graph/badge.svg?token=5T7SVCHWFE"/></a>
 </p>
 
 This is the high-level, Rust idiomatic wrapper crate that exposes an interface 
@@ -29,3 +24,5 @@ The `tss-esapi` crate is still under development and thus the interface is not s
 ## Cross compiling
 
 For more information on cross-compiling the `tss-esapi` crate, please see the README of the `tss-esapi-sys` crate.
+
+*Copyright 2021 Contributors to the Parsec project.*

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -92,7 +92,7 @@
 //!
 //! Additionally, the TSS library will also generate its own log messages and these can be
 //! controlled through environment variables as explained
-//! [here](https://github.com/tpm2-software/tpm2-tss/blob/master/doc/logging.md#runtime-log-level).
+//! [here](https://github.com/tpm2-software/tpm2-tss/blob/main/doc/logging.md#runtime-log-level).
 //!
 pub use abstraction::transient::TransientKeyContext;
 pub use context::Context;


### PR DESCRIPTION
This is to upload `tss-esapi` to `4.0.11-alpha.1` and `tss-esapi-sys` to
`0.1.0`.