### PR TITLE
Add TPM2_Certify

### DIFF
--- a/tss-esapi/src/constants/mod.rs
+++ b/tss-esapi/src/constants/mod.rs
@@ -9,6 +9,9 @@
 mod algorithm;
 pub use algorithm::AlgorithmIdentifier;
 
+/// Representation of TPM_GENERATED_VALUE
+pub const TPM_GENERATED_VALUE: u32 = 0xff544347;
+
 /// The contants defined in the TSS specification.
 #[allow(
     non_snake_case,

--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -1,18 +1,142 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    handles::KeyHandle,
-    structures::{Data, PcrSelectionList},
-    tss2_esys::*,
+    handles::{KeyHandle, ObjectHandle},
+    structures::{AttestBuffer, Data, PcrSelectionList, SignatureScheme},
+    tss2_esys::{Esys_Certify, Esys_Quote, TPM2B_ATTEST, TPMT_SIG_SCHEME},
     utils::Signature,
     Context, Error, Result,
 };
 use log::error;
 use mbox::MBox;
+use std::convert::TryFrom;
 use std::ptr::null_mut;
 
 impl Context {
-    // Missing function: Certify
+    /// Certify that an object is resident in the TPM.
+    ///
+    /// # Arguments
+    /// * `object_handle` - The object to be certified
+    /// * `signing_key_handle` - The key to be used for signing the
+    /// attestation structure.
+    /// * `qualifying_data` - Data provided by the caller, generally
+    /// to ensure freshness of the attestation.
+    /// * `scheme` - Signature scheme to be used with the signing key.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use std::convert::{TryFrom, TryInto};
+    /// # use tss_esapi::{
+    /// #   Context, Error, Tcti,
+    /// #   handles::KeyHandle,
+    /// #   structures::Auth,
+    /// #   tss2_esys::TPM2B_PUBLIC,
+    /// # };
+    /// # fn main() -> Result<(), Error> {
+    /// # let mut context = unsafe {
+    /// #     Context::new(
+    /// #         Tcti::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context")
+    /// # };
+    /// # let authentication_value = Auth::try_from(vec![0xff; 16]).unwrap();
+    /// # let primary_key_handle: KeyHandle = 0.try_into().unwrap();
+    /// # let attesting_key: KeyHandle = 1.try_into().unwrap();
+    /// # let challenge = vec![0; 8];
+    /// # let pub_params = TPM2B_PUBLIC::default();
+    /// use tss_esapi::{
+    ///     constants::SessionType,
+    ///     interface_types::algorithm::HashingAlgorithm,
+    ///     structures::{SymmetricDefinition, SignatureScheme, Data},
+    /// };
+    /// // Generate the key to be attested
+    /// let result = context
+    ///     .create(
+    ///         primary_key_handle,
+    ///         &pub_params,
+    ///         Some(&authentication_value),
+    ///         None,
+    ///         None,
+    ///         None,
+    ///     )?;
+    /// let attested_key = context
+    ///     .load(primary_key_handle, result.out_private, result.out_public)?;
+    /// // Create sessions for authenticating the two objects
+    /// let obj_session = context
+    ///     .start_auth_session(
+    ///         None,
+    ///         None,
+    ///         None,
+    ///         SessionType::Hmac,
+    ///         SymmetricDefinition::AES_256_CFB,
+    ///         HashingAlgorithm::Sha256,
+    ///     )?
+    ///     .expect("Failed to create session for certified object authentication");
+    /// let sign_session = context
+    ///     .start_auth_session(
+    ///         None,
+    ///         None,
+    ///         None,
+    ///         SessionType::Hmac,
+    ///         SymmetricDefinition::AES_256_CFB,
+    ///         HashingAlgorithm::Sha256,
+    ///     )?
+    ///     .expect("Failed to create session for signing key authentication");
+    ///
+    /// // Convert `challenge` byte vector to `Data`
+    /// let qualifying_data = Data::try_from(challenge).unwrap();
+    ///
+    /// // Execute `certify()` with the new sessions.
+    /// let (attest_buffer, signature) = context.execute_with_sessions((Some(obj_session), Some(sign_session), None), |ctx| {
+    ///     ctx
+    ///     .certify(
+    ///         attested_key.into(),
+    ///         attesting_key, // restricted signing key
+    ///         qualifying_data,
+    ///         SignatureScheme::NULL, // use default signing scheme
+    ///     )
+    /// })?;
+    /// # Ok(())
+    /// # } // end main() fn
+    pub fn certify(
+        &mut self,
+        object_handle: ObjectHandle,
+        signing_key_handle: KeyHandle,
+        qualifying_data: Data,
+        scheme: SignatureScheme,
+    ) -> Result<(AttestBuffer, Signature)> {
+        let mut signature = null_mut();
+        let mut certify_info = null_mut();
+        let ret = unsafe {
+            Esys_Certify(
+                self.mut_context(),
+                object_handle.into(),
+                signing_key_handle.into(),
+                self.optional_session_1(),
+                self.optional_session_2(),
+                self.optional_session_3(),
+                &qualifying_data.into(),
+                &scheme.into(),
+                &mut certify_info,
+                &mut signature,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+
+        if ret.is_success() {
+            let signature = unsafe { MBox::from_raw(signature) };
+            let certify_info = unsafe { MBox::from_raw(certify_info) };
+            Ok(unsafe {
+                (
+                    AttestBuffer::try_from(*certify_info)?,
+                    Signature::try_from(*signature)?,
+                )
+            })
+        } else {
+            error!("Error when certifying: {}", ret);
+            Err(ret)
+        }
+    }
+
     // Missing function: CertifyCreation
 
     /// Generate a quote on the selected PCRs

--- a/tss-esapi/src/structures/attestation.rs
+++ b/tss-esapi/src/structures/attestation.rs
@@ -1,0 +1,292 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::constants::tss::{
+    TPM2_ST_ATTEST_CERTIFY, TPM2_ST_ATTEST_COMMAND_AUDIT, TPM2_ST_ATTEST_CREATION,
+    TPM2_ST_ATTEST_NV, TPM2_ST_ATTEST_NV_DIGEST, TPM2_ST_ATTEST_QUOTE,
+    TPM2_ST_ATTEST_SESSION_AUDIT, TPM2_ST_ATTEST_TIME,
+};
+use crate::constants::TPM_GENERATED_VALUE;
+use crate::structures::{ClockInfo, Data, Name};
+use crate::tss2_esys::{
+    Tss2_MU_TPMS_ATTEST_Unmarshal, TPM2B_ATTEST, TPMI_ST_ATTEST, TPMS_ATTEST, TPMS_CERTIFY_INFO,
+    TPMU_ATTEST,
+};
+use crate::{Error, Result, WrapperErrorKind};
+use log::error;
+use std::convert::{TryFrom, TryInto};
+use std::ops::Deref;
+use zeroize::Zeroizing;
+
+/// Object attestation structure
+///
+/// # Details
+/// Corresponds to `TPMS_ATTEST`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attest {
+    qualified_signer: Name,
+    extra_data: Data,
+    clock_info: ClockInfo,
+    firmware_version: u64,
+    attested: AttestInfo,
+}
+
+impl Attest {
+    /// Get the type of attestation this was produced by.
+    pub fn attestation_type(&self) -> AttestationType {
+        self.attested.attestation_type()
+    }
+
+    /// Get the qualified name of the signing object.
+    pub fn qualified_signer(&self) -> &Name {
+        &self.qualified_signer
+    }
+
+    /// Get the extra data specified by the caller.
+    pub fn extra_data(&self) -> &Data {
+        &self.extra_data
+    }
+
+    /// Get internal TPM clock data.
+    pub fn clock_info(&self) -> &ClockInfo {
+        &self.clock_info
+    }
+
+    /// Get TPM firmware version number.
+    pub fn firmware_version(&self) -> u64 {
+        self.firmware_version
+    }
+
+    /// Get extra attestation information.
+    pub fn attested(&self) -> &AttestInfo {
+        &self.attested
+    }
+}
+
+impl TryFrom<Attest> for TPMS_ATTEST {
+    type Error = Error;
+
+    fn try_from(native: Attest) -> Result<Self> {
+        Ok(TPMS_ATTEST {
+            magic: TPM_GENERATED_VALUE,
+            type_: native.attestation_type().into(),
+            qualifiedSigner: native.qualified_signer.try_into()?,
+            extraData: native.extra_data.into(),
+            clockInfo: native.clock_info.into(),
+            firmwareVersion: native.firmware_version,
+            attested: native.attested.try_into()?,
+        })
+    }
+}
+
+impl TryFrom<TPMS_ATTEST> for Attest {
+    type Error = Error;
+
+    fn try_from(tss: TPMS_ATTEST) -> Result<Self> {
+        if tss.magic != TPM_GENERATED_VALUE {
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+
+        let attestation_type = AttestationType::try_from(tss.type_)?;
+        Ok(Attest {
+            attested: match attestation_type {
+                AttestationType::Certify => AttestInfo::Certify {
+                    name: Name::try_from(unsafe { tss.attested.certify.name })?,
+                    qualified_name: Name::try_from(unsafe { tss.attested.certify.qualifiedName })?,
+                },
+                _ => return Err(Error::local_error(WrapperErrorKind::UnsupportedParam)),
+            },
+            qualified_signer: Name::try_from(tss.qualifiedSigner)?,
+            extra_data: Data::try_from(tss.extraData)?,
+            clock_info: ClockInfo::try_from(tss.clockInfo)?,
+            firmware_version: tss.firmwareVersion,
+        })
+    }
+}
+
+/// Representation of extra attestation data.
+///
+/// # Details
+/// Corresponds to `TPMU_ATTEST`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AttestInfo {
+    Certify { name: Name, qualified_name: Name },
+}
+
+impl AttestInfo {
+    /// Get the `AttestationType` variant that corresponds to the info.
+    pub fn attestation_type(&self) -> AttestationType {
+        match self {
+            AttestInfo::Certify { .. } => AttestationType::Certify,
+        }
+    }
+}
+
+impl TryFrom<AttestInfo> for TPMU_ATTEST {
+    type Error = Error;
+
+    fn try_from(native: AttestInfo) -> Result<Self> {
+        Ok(match native {
+            AttestInfo::Certify {
+                name,
+                qualified_name,
+            } => TPMU_ATTEST {
+                certify: TPMS_CERTIFY_INFO {
+                    name: name.try_into()?,
+                    qualifiedName: qualified_name.try_into()?,
+                },
+            },
+        })
+    }
+}
+
+/// Type of attestation.
+///
+/// # Details
+/// Corresponds to `TPMI_ST_ATTEST`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttestationType {
+    Certify,
+    Quote,
+    SessionAudit,
+    CommandAudit,
+    Time,
+    Creation,
+    Nv,
+    NvDigest,
+}
+
+impl From<AttestationType> for TPMI_ST_ATTEST {
+    fn from(native: AttestationType) -> Self {
+        match native {
+            AttestationType::Certify => TPM2_ST_ATTEST_CERTIFY,
+            AttestationType::Quote => TPM2_ST_ATTEST_QUOTE,
+            AttestationType::SessionAudit => TPM2_ST_ATTEST_SESSION_AUDIT,
+            AttestationType::CommandAudit => TPM2_ST_ATTEST_COMMAND_AUDIT,
+            AttestationType::Time => TPM2_ST_ATTEST_TIME,
+            AttestationType::Creation => TPM2_ST_ATTEST_CREATION,
+            AttestationType::Nv => TPM2_ST_ATTEST_NV,
+            AttestationType::NvDigest => TPM2_ST_ATTEST_NV_DIGEST,
+        }
+    }
+}
+
+impl TryFrom<TPMI_ST_ATTEST> for AttestationType {
+    type Error = Error;
+
+    fn try_from(tss: TPMI_ST_ATTEST) -> Result<Self> {
+        match tss {
+            TPM2_ST_ATTEST_CERTIFY => Ok(AttestationType::Certify),
+            TPM2_ST_ATTEST_QUOTE => Ok(AttestationType::Quote),
+            TPM2_ST_ATTEST_TIME => Ok(AttestationType::Time),
+            TPM2_ST_ATTEST_CREATION => Ok(AttestationType::Creation),
+            TPM2_ST_ATTEST_NV => Ok(AttestationType::Nv),
+            TPM2_ST_ATTEST_NV_DIGEST => Ok(AttestationType::NvDigest),
+            TPM2_ST_ATTEST_SESSION_AUDIT => Ok(AttestationType::SessionAudit),
+            TPM2_ST_ATTEST_COMMAND_AUDIT => Ok(AttestationType::CommandAudit),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+/// Attestation data buffer.
+///
+/// # Details
+/// Corresponds to `TPM2B_ATTEST`. The contents of
+/// the buffer can be unmarshalled into an [Attest]
+/// structure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttestBuffer(Zeroizing<Vec<u8>>);
+
+impl Default for AttestBuffer {
+    fn default() -> Self {
+        AttestBuffer(Vec::new().into())
+    }
+}
+
+impl AttestBuffer {
+    pub const MAX_SIZE: usize = 2304;
+
+    pub fn value(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Deref for AttestBuffer {
+    type Target = Vec<u8>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TryFrom<Vec<u8>> for AttestBuffer {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self> {
+        if bytes.len() > Self::MAX_SIZE {
+            error!("Error: Invalid Vec<u8> size(> {})", Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        Ok(AttestBuffer(bytes.into()))
+    }
+}
+
+impl TryFrom<&[u8]> for AttestBuffer {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() > Self::MAX_SIZE {
+            error!("Error: Invalid &[u8] size(> {})", Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        Ok(AttestBuffer(bytes.to_vec().into()))
+    }
+}
+
+impl TryFrom<TPM2B_ATTEST> for AttestBuffer {
+    type Error = Error;
+
+    fn try_from(tss: TPM2B_ATTEST) -> Result<Self> {
+        let size = tss.size as usize;
+        if size > Self::MAX_SIZE {
+            error!("Error: Invalid buffer size(> {})", Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        Ok(AttestBuffer(tss.attestationData[..size].to_vec().into()))
+    }
+}
+
+impl TryFrom<AttestBuffer> for Attest {
+    type Error = Error;
+
+    fn try_from(buf: AttestBuffer) -> Result<Self> {
+        let buffer = buf.0.to_vec();
+        let mut attest = TPMS_ATTEST::default();
+        let buf_point: *const u8 = &buffer[0];
+        let mut offset = 0;
+        let ret = Error::from_tss_rc(unsafe {
+            Tss2_MU_TPMS_ATTEST_Unmarshal(
+                buf_point,
+                buffer.len().try_into().unwrap(),
+                &mut offset,
+                &mut attest,
+            )
+        });
+
+        if !ret.is_success() {
+            return Err(ret);
+        }
+        Attest::try_from(attest)
+    }
+}
+
+impl From<AttestBuffer> for TPM2B_ATTEST {
+    fn from(native: AttestBuffer) -> Self {
+        let mut buffer = TPM2B_ATTEST {
+            size: native.0.len() as u16,
+            ..Default::default()
+        };
+        buffer.attestationData[..native.0.len()].copy_from_slice(&native.0);
+        buffer
+    }
+}

--- a/tss-esapi/src/structures/clock.rs
+++ b/tss-esapi/src/structures/clock.rs
@@ -1,0 +1,66 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::tss2_esys::TPMS_CLOCK_INFO;
+use crate::{Error, Result, WrapperErrorKind};
+use std::convert::TryFrom;
+
+/// Information related to the internal temporal
+/// state of the TPM.
+///
+/// # Details
+/// Corresponds to `TPMS_CLOCK_INFO`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClockInfo {
+    clock: u64,
+    reset_count: u32,
+    restart_count: u32,
+    safe: bool,
+}
+
+impl ClockInfo {
+    pub fn clock(&self) -> u64 {
+        self.clock
+    }
+
+    pub fn reset_count(&self) -> u32 {
+        self.reset_count
+    }
+
+    pub fn restart_count(&self) -> u32 {
+        self.restart_count
+    }
+
+    pub fn safe(&self) -> bool {
+        self.safe
+    }
+}
+
+impl TryFrom<TPMS_CLOCK_INFO> for ClockInfo {
+    type Error = Error;
+
+    fn try_from(tss: TPMS_CLOCK_INFO) -> Result<Self> {
+        let safe = match tss.safe {
+            0 => false,
+            1 => true,
+            _ => return Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        };
+
+        Ok(ClockInfo {
+            clock: tss.clock,
+            reset_count: tss.resetCount,
+            restart_count: tss.restartCount,
+            safe,
+        })
+    }
+}
+
+impl From<ClockInfo> for TPMS_CLOCK_INFO {
+    fn from(native: ClockInfo) -> Self {
+        TPMS_CLOCK_INFO {
+            clock: native.clock,
+            resetCount: native.reset_count,
+            restartCount: native.restart_count,
+            safe: if native.safe { 1 } else { 0 },
+        }
+    }
+}

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -116,11 +116,26 @@ pub use tickets::HashcheckTicket;
 pub use tickets::Ticket;
 pub use tickets::VerifiedTicket;
 
+/////////////////////////////////////////////////////////
+/// The clock/counter section
+/////////////////////////////////////////////////////////
+mod clock;
+pub use clock::ClockInfo;
+
+/////////////////////////////////////////////////////////
+/// The attestation section
+/////////////////////////////////////////////////////////
+mod attestation;
+pub use attestation::{Attest, AttestBuffer, AttestInfo, AttestationType};
+
+/////////////////////////////////////////////////////////
+/// The algorithm structures section
+/////////////////////////////////////////////////////////
 mod schemes;
 pub use schemes::{HashScheme, HmacScheme, XorScheme};
 
 mod tagged;
 pub use tagged::{
-    schemes::KeyedHashScheme,
+    schemes::{KeyedHashScheme, SignatureScheme},
     symmetric::{SymmetricDefinition, SymmetricDefinitionObject},
 };

--- a/tss-esapi/src/structures/schemes.rs
+++ b/tss-esapi/src/structures/schemes.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     interface_types::algorithm::{HashingAlgorithm, KeyDerivationFunction},
-    tss2_esys::{TPMS_SCHEME_HASH, TPMS_SCHEME_HMAC, TPMS_SCHEME_XOR},
+    tss2_esys::{TPMS_SCHEME_ECDAA, TPMS_SCHEME_HASH, TPMS_SCHEME_HMAC, TPMS_SCHEME_XOR},
     Error, Result,
 };
 use std::convert::{TryFrom, TryInto};
@@ -118,5 +118,41 @@ impl From<XorScheme> for TPMS_SCHEME_XOR {
             hashAlg: xor_scheme.hashing_algorithm.into(),
             kdf: xor_scheme.key_derivation_function.into(),
         }
+    }
+}
+
+/// Struct for holding ECDAA scheme
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EcdaaScheme {
+    hashing_algorithm: HashingAlgorithm,
+    count: u16,
+}
+
+impl EcdaaScheme {
+    pub const fn new(hashing_algorithm: HashingAlgorithm, count: u16) -> Self {
+        EcdaaScheme {
+            hashing_algorithm,
+            count,
+        }
+    }
+}
+
+impl From<EcdaaScheme> for TPMS_SCHEME_ECDAA {
+    fn from(native: EcdaaScheme) -> Self {
+        TPMS_SCHEME_ECDAA {
+            hashAlg: native.hashing_algorithm.into(),
+            count: native.count,
+        }
+    }
+}
+
+impl TryFrom<TPMS_SCHEME_ECDAA> for EcdaaScheme {
+    type Error = Error;
+
+    fn try_from(tss: TPMS_SCHEME_ECDAA) -> Result<Self> {
+        Ok(EcdaaScheme {
+            hashing_algorithm: tss.hashAlg.try_into()?,
+            count: tss.count,
+        })
     }
 }

--- a/tss-esapi/src/structures/tagged/schemes.rs
+++ b/tss-esapi/src/structures/tagged/schemes.rs
@@ -1,9 +1,9 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    interface_types::algorithm::{HashingAlgorithm, KeyedHashSchemeAlgorithm},
-    structures::schemes::{HmacScheme, XorScheme},
-    tss2_esys::{TPMT_KEYEDHASH_SCHEME, TPMU_SCHEME_KEYEDHASH},
+    interface_types::algorithm::{self, HashingAlgorithm, KeyedHashSchemeAlgorithm},
+    structures::schemes::{EcdaaScheme, HashScheme, HmacScheme, XorScheme},
+    tss2_esys::{TPMT_KEYEDHASH_SCHEME, TPMT_SIG_SCHEME, TPMU_SCHEME_KEYEDHASH, TPMU_SIG_SCHEME},
     Error, Result,
 };
 use std::convert::{TryFrom, TryInto};
@@ -58,6 +58,117 @@ impl TryFrom<TPMT_KEYEDHASH_SCHEME> for KeyedHashScheme {
                 hmac_scheme: unsafe { tpmt_keyedhash_scheme.details.hmac }.try_into()?,
             }),
             KeyedHashSchemeAlgorithm::Null => Ok(KeyedHashScheme::Null),
+        }
+    }
+}
+
+/// Full description of signature schemes.
+///
+/// # Details
+/// Corresponds to `TPMT_SIG_SCHEME`.
+#[derive(Clone, Copy, Debug)]
+pub enum SignatureScheme {
+    RsaSsa { hash_scheme: HashScheme },
+    RsaPss { hash_scheme: HashScheme },
+    EcDsa { hash_scheme: HashScheme },
+    Sm2 { hash_scheme: HashScheme },
+    EcSchnorr { hash_scheme: HashScheme },
+    EcDaa { ecdaa_scheme: EcdaaScheme },
+    Hmac { hmac_scheme: HmacScheme },
+    Null { hash_scheme: HashScheme },
+}
+
+impl SignatureScheme {
+    /// Null scheme, representing "no scheme" or "default"
+    pub const NULL: SignatureScheme = SignatureScheme::Null {
+        hash_scheme: HashScheme::new(HashingAlgorithm::Null),
+    };
+}
+
+impl From<SignatureScheme> for TPMT_SIG_SCHEME {
+    fn from(native: SignatureScheme) -> TPMT_SIG_SCHEME {
+        match native {
+            SignatureScheme::EcDaa { ecdaa_scheme } => TPMT_SIG_SCHEME {
+                scheme: algorithm::SignatureScheme::EcDaa.into(),
+                details: TPMU_SIG_SCHEME {
+                    ecdaa: ecdaa_scheme.into(),
+                },
+            },
+            SignatureScheme::EcDsa { hash_scheme } => TPMT_SIG_SCHEME {
+                scheme: algorithm::SignatureScheme::EcDsa.into(),
+                details: TPMU_SIG_SCHEME {
+                    ecdsa: hash_scheme.into(),
+                },
+            },
+            SignatureScheme::EcSchnorr { hash_scheme } => TPMT_SIG_SCHEME {
+                scheme: algorithm::SignatureScheme::EcSchnorr.into(),
+                details: TPMU_SIG_SCHEME {
+                    ecschnorr: hash_scheme.into(),
+                },
+            },
+            SignatureScheme::Hmac { hmac_scheme } => TPMT_SIG_SCHEME {
+                scheme: algorithm::SignatureScheme::Hmac.into(),
+                details: TPMU_SIG_SCHEME {
+                    hmac: hmac_scheme.into(),
+                },
+            },
+            SignatureScheme::Null { hash_scheme } => TPMT_SIG_SCHEME {
+                scheme: algorithm::SignatureScheme::Null.into(),
+                details: TPMU_SIG_SCHEME {
+                    any: hash_scheme.into(),
+                },
+            },
+            SignatureScheme::RsaPss { hash_scheme } => TPMT_SIG_SCHEME {
+                scheme: algorithm::SignatureScheme::RsaPss.into(),
+                details: TPMU_SIG_SCHEME {
+                    rsapss: hash_scheme.into(),
+                },
+            },
+            SignatureScheme::RsaSsa { hash_scheme } => TPMT_SIG_SCHEME {
+                scheme: algorithm::SignatureScheme::RsaSsa.into(),
+                details: TPMU_SIG_SCHEME {
+                    rsassa: hash_scheme.into(),
+                },
+            },
+            SignatureScheme::Sm2 { hash_scheme } => TPMT_SIG_SCHEME {
+                scheme: algorithm::SignatureScheme::Sm2.into(),
+                details: TPMU_SIG_SCHEME {
+                    sm2: hash_scheme.into(),
+                },
+            },
+        }
+    }
+}
+
+impl TryFrom<TPMT_SIG_SCHEME> for SignatureScheme {
+    type Error = Error;
+
+    fn try_from(tss: TPMT_SIG_SCHEME) -> Result<Self> {
+        match algorithm::SignatureScheme::try_from(tss.scheme)? {
+            algorithm::SignatureScheme::EcDaa => Ok(SignatureScheme::EcDaa {
+                ecdaa_scheme: unsafe { tss.details.ecdaa }.try_into()?,
+            }),
+            algorithm::SignatureScheme::EcDsa => Ok(SignatureScheme::EcDsa {
+                hash_scheme: unsafe { tss.details.ecdsa }.try_into()?,
+            }),
+            algorithm::SignatureScheme::EcSchnorr => Ok(SignatureScheme::EcSchnorr {
+                hash_scheme: unsafe { tss.details.ecschnorr }.try_into()?,
+            }),
+            algorithm::SignatureScheme::Hmac => Ok(SignatureScheme::Hmac {
+                hmac_scheme: unsafe { tss.details.hmac }.try_into()?,
+            }),
+            algorithm::SignatureScheme::Null => Ok(SignatureScheme::Null {
+                hash_scheme: unsafe { tss.details.any }.try_into()?,
+            }),
+            algorithm::SignatureScheme::RsaPss => Ok(SignatureScheme::RsaPss {
+                hash_scheme: unsafe { tss.details.rsapss }.try_into()?,
+            }),
+            algorithm::SignatureScheme::RsaSsa => Ok(SignatureScheme::RsaSsa {
+                hash_scheme: unsafe { tss.details.rsassa }.try_into()?,
+            }),
+            algorithm::SignatureScheme::Sm2 => Ok(SignatureScheme::Sm2 {
+                hash_scheme: unsafe { tss.details.sm2 }.try_into()?,
+            }),
         }
     }
 }

--- a/tss-esapi/tests/context_tests/tpm_commands/attestation_commands_tests.rs
+++ b/tss-esapi/tests/context_tests/tpm_commands/attestation_commands_tests.rs
@@ -40,3 +40,129 @@ mod test_quote {
         assert!(res.0.size != 0);
     }
 }
+
+mod test_certify {
+    use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        constants::SessionType,
+        interface_types::algorithm::HashingAlgorithm,
+        interface_types::resource_handles::Hierarchy,
+        structures::{
+            Attest, AttestBuffer, AttestInfo, Auth, Data, SignatureScheme, SymmetricDefinition,
+        },
+    };
+
+    #[test]
+    fn test_certify() {
+        let mut context = create_ctx_with_session();
+        let random_digest = context.get_random(16).unwrap();
+        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+
+        let primary_key_handle = context
+            .create_primary(
+                Hierarchy::Owner,
+                &decryption_key_pub(),
+                Some(&key_auth),
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+            .key_handle;
+
+        // Generate the attesting key
+        let result = context
+            .create(
+                primary_key_handle,
+                &signing_key_pub(),
+                Some(&key_auth),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let attesting_key = context
+            .load(primary_key_handle, result.out_private, result.out_public)
+            .unwrap();
+        context
+            .tr_set_auth(attesting_key.into(), &key_auth)
+            .unwrap();
+
+        // Generate the key to be attested
+        let result = context
+            .create(
+                primary_key_handle,
+                &signing_key_pub(),
+                Some(&key_auth),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let attested_key = context
+            .load(primary_key_handle, result.out_private, result.out_public)
+            .unwrap();
+        context.tr_set_auth(attested_key.into(), &key_auth).unwrap();
+        // Get attested key name and qualified name
+        let (_, attested_key_name, attested_key_qualified_name) =
+            context.read_public(attested_key).unwrap();
+
+        // Create sessions for authenticating the two objects
+        let obj_session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Hmac,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .expect("obj_session: Failed to call start_auth_session")
+            .expect("obj_session: Failed invalid session value");
+        let sign_session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Hmac,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .expect("sign_session: Failed to call start_auth_session")
+            .expect("sign_session: Failed invalid session value");
+
+        let qualifying_data = Data::try_from(vec![1, 2, 3, 4, 5]).unwrap();
+        context.execute_with_sessions((Some(obj_session), Some(sign_session), None), |ctx| {
+            let (attest_buf, _sign) = ctx
+                .certify(
+                    attested_key.into(),
+                    attesting_key,
+                    qualifying_data,
+                    SignatureScheme::NULL,
+                )
+                .unwrap();
+            assert!(!attest_buf.value().is_empty());
+            let attest = Attest::try_from(attest_buf)
+                .expect("Failed to convert TPM2B_ATTEST to TPMS_ATTEST");
+            match attest.attested() {
+                AttestInfo::Certify {
+                    name,
+                    qualified_name,
+                } => {
+                    assert_eq!(name.value(), attested_key_name.value());
+                    assert_eq!(qualified_name.value(), attested_key_qualified_name.value());
+                }
+                _ => panic!("Got wrong type of attestation info"),
+            }
+        });
+    }
+
+    #[test]
+    fn attest_buffer_unmarshal_test() {
+        let buffer_content = vec![0xff; 16];
+        let attest =
+            AttestBuffer::try_from(buffer_content).expect("Failed to create Attest buffer");
+        assert!(Attest::try_from(attest).is_err());
+    }
+}


### PR DESCRIPTION
This commit adds the TPM2_Certify command and Rust native types for all
parameters and return types involved in the signature of the certify
function. A new test is also included.

TODO: 

- [x] documentation

- [x] more tests