### PR TITLE
Link to tss2-sys as well

### DIFF
--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -37,6 +37,10 @@ fn main() {
 
         pkg_config::Config::new()
             .atleast_version(MINIMUM_VERSION)
+            .probe("tss2-sys")
+            .expect("Failed to find tss2-sys library.");
+        pkg_config::Config::new()
+            .atleast_version(MINIMUM_VERSION)
             .probe("tss2-esys")
             .expect("Failed to find tss2-esys library.");
         pkg_config::Config::new()


### PR DESCRIPTION
This commit adds tss2-sys to the list of libraries we explicitly link
to. The reason is that Parsec was having issues linking correctly for
cross-compilation, and explicitly linking helped.
