### PR TITLE
Add tss2-sys when generating bindings too

### DIFF
--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -56,6 +56,10 @@ fn main() {
 
 #[cfg(feature = "generate-bindings")]
 pub fn generate_from_system(esapi_out: PathBuf) {
+    pkg_config::Config::new()
+        .atleast_version(MINIMUM_VERSION)
+        .probe("tss2-sys")
+        .expect("Failed to find tss2-sys library.");
     let tss2_esys = pkg_config::Config::new()
         .atleast_version(MINIMUM_VERSION)
         .probe("tss2-esys")


### PR DESCRIPTION
The tss2-sys is only being linked to explicitly when the bindings are
not generated, after #226. This fixes that discrepancy.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>