### PR TITLE
Fix tests

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.11"
 enumflags2 = "0.6.4"
 num-derive = "0.3.2"
 num-traits = "0.2.12"
-hostname-validator = "1.0.0"
+hostname-validator = "1.1.0"
 regex = "1.3.9"
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.1.1" }

--- a/tss-esapi/src/tcti.rs
+++ b/tss-esapi/src/tcti.rs
@@ -334,9 +334,15 @@ fn validate_from_str_networktpm_config() {
     assert_eq!(config.host, "localhost".parse::<ServerAddress>().unwrap());
     assert_eq!(config.port, 1234);
 
+    let config = NetworkTPMConfig::from_str("host=1234.1234.1234.1234.12445.111").unwrap();
+    assert_eq!(
+        config.host,
+        ServerAddress::Hostname(String::from("1234.1234.1234.1234.12445.111"))
+    );
+
     let _ = NetworkTPMConfig::from_str("port=abdef").unwrap_err();
     let _ = NetworkTPMConfig::from_str("host=-timey-wimey").unwrap_err();
-    let _ = NetworkTPMConfig::from_str("host=1234.1234.1234.1234.12445.111").unwrap_err();
+    let _ = NetworkTPMConfig::from_str("host=abc@def").unwrap_err();
     let _ = NetworkTPMConfig::from_str("host=").unwrap_err();
     let _ = NetworkTPMConfig::from_str("port=").unwrap_err();
     let _ = NetworkTPMConfig::from_str("port=,host=,yas").unwrap_err();

--- a/tss-esapi/tests/abstraction_ek_tests.rs
+++ b/tss-esapi/tests/abstraction_ek_tests.rs
@@ -20,12 +20,12 @@ fn test_retrieve_ek_pubcert() {
     match ek::retrieve_ek_pubcert(&mut context, AsymmetricAlgorithm::Rsa) {
         Ok(_) => (),
         Err(Error::Tss2Error(Tss2ResponseCode::FormatOne(FormatOneResponseCode(395)))) => (),
-        Err(e) => panic!(format!("Error was unexpected: {:?}", e)),
+        Err(e) => panic!("Error was unexpected: {:?}", e),
     };
     match ek::retrieve_ek_pubcert(&mut context, AsymmetricAlgorithm::Ecc) {
         Ok(_) => (),
         Err(Error::Tss2Error(Tss2ResponseCode::FormatOne(FormatOneResponseCode(395)))) => (),
-        Err(e) => panic!(format!("Error was unexpected: {:?}", e)),
+        Err(e) => panic!("Error was unexpected: {:?}", e),
     };
 }
 

--- a/tss-esapi/tests/interface_types_resource_handle_tests.rs
+++ b/tss-esapi/tests/interface_types_resource_handle_tests.rs
@@ -19,17 +19,13 @@ mod test_hierarchy {
                 assert_eq!(ObjectHandle::from(hierarchy), esys_rh);
                 assert_eq!(TpmHandle::from(hierarchy), tpm_rh);
                 let from_esys_rh = Hierarchy::try_from(esys_rh).unwrap_or_else(|_| {
-                    panic!(format!(
-                        "Failed to create Hierarchy from ESYS_TR_RH={}",
-                        name
-                    ))
+                    panic!("Failed to create Hierarchy from ESYS_TR_RH={}", name)
                 });
                 assert_eq!(from_esys_rh, hierarchy);
                 assert_eq!(ObjectHandle::from(from_esys_rh), esys_rh);
                 assert_eq!(TpmHandle::from(from_esys_rh), tpm_rh);
-                let from_tpm_rh = Hierarchy::try_from(tpm_rh).unwrap_or_else(|_| {
-                    panic!(format!("Failed to create Hierarchy from TPM2_RH={}", name))
-                });
+                let from_tpm_rh = Hierarchy::try_from(tpm_rh)
+                    .unwrap_or_else(|_| panic!("Failed to create Hierarchy from TPM2_RH={}", name));
                 assert_eq!(from_tpm_rh, hierarchy);
                 assert_eq!(ObjectHandle::from(from_tpm_rh), esys_rh);
                 assert_eq!(TpmHandle::from(from_tpm_rh), tpm_rh);
@@ -71,14 +67,13 @@ mod test_enables {
                 assert_eq!(ObjectHandle::from(enables), esys_rh);
                 assert_eq!(TpmHandle::from(enables), tpm_rh);
                 let from_esys_rh = Enables::try_from(esys_rh).unwrap_or_else(|_| {
-                    panic!(format!("Failed to create Enables from ESYS_TR_RH={}", name))
+                    panic!("Failed to create Enables from ESYS_TR_RH={}", name)
                 });
                 assert_eq!(from_esys_rh, enables);
                 assert_eq!(ObjectHandle::from(from_esys_rh), esys_rh);
                 assert_eq!(TpmHandle::from(from_esys_rh), tpm_rh);
-                let from_tpm_rh = Enables::try_from(tpm_rh).unwrap_or_else(|_| {
-                    panic!(format!("Failed to create Enables from TPM2_RH={}", name))
-                });
+                let from_tpm_rh = Enables::try_from(tpm_rh)
+                    .unwrap_or_else(|_| panic!("Failed to create Enables from TPM2_RH={}", name));
                 assert_eq!(from_tpm_rh, enables);
                 assert_eq!(ObjectHandle::from(from_tpm_rh), esys_rh);
                 assert_eq!(TpmHandle::from(from_tpm_rh), tpm_rh);
@@ -128,20 +123,13 @@ mod test_hierarchy_auth {
             assert_eq!(ObjectHandle::from(hierarchy_auth), esys_rh);
             assert_eq!(TpmHandle::from(hierarchy_auth), tpm_rh);
             let from_esys_rh = HierarchyAuth::try_from(esys_rh).unwrap_or_else(|_| {
-                panic!(format!(
-                    "Failed to create HierarchyAuth from ESYS_TR_RH={}",
-                    name
-                ))
+                panic!("Failed to create HierarchyAuth from ESYS_TR_RH={}", name)
             });
             assert_eq!(from_esys_rh, hierarchy_auth);
             assert_eq!(ObjectHandle::from(from_esys_rh), esys_rh);
             assert_eq!(TpmHandle::from(from_esys_rh), tpm_rh);
-            let from_tpm_rh = HierarchyAuth::try_from(tpm_rh).unwrap_or_else(|_| {
-                panic!(format!(
-                    "Failed to create HierarchyAuth from TPM2_RH={}",
-                    name
-                ))
-            });
+            let from_tpm_rh = HierarchyAuth::try_from(tpm_rh)
+                .unwrap_or_else(|_| panic!("Failed to create HierarchyAuth from TPM2_RH={}", name));
             assert_eq!(from_tpm_rh, hierarchy_auth);
             assert_eq!(ObjectHandle::from(from_tpm_rh), esys_rh);
             assert_eq!(TpmHandle::from(from_tpm_rh), tpm_rh);


### PR DESCRIPTION
This commit fixes a few linting issues in tests, along with a failing
test for network TCTI hostname validation. This last fix is due to a
change in a dependency that modifies the format of hostnames allowed.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>