### PR TITLE
Ensure PcrSelectionList retains order

### DIFF
--- a/tss-esapi/src/structures/pcr/selection.rs
+++ b/tss-esapi/src/structures/pcr/selection.rs
@@ -35,6 +35,10 @@ impl PcrSelection {
         self.hashing_algorithm
     }
 
+    pub fn selected_pcrs(&self) -> &BitFlags<PcrSlot> {
+        &self.selected_pcrs
+    }
+
     pub fn merge(&mut self, other: &Self) -> Result<()> {
         // Check that the hashing algorithm match
         if self.hashing_algorithm != other.hashing_algorithm {


### PR DESCRIPTION
PcrSelectionList would (possibly) reorder and merge the different
TPML_PCR_SELECTION entries.
This is not valid in the case where for example the PcrSelectionList is
the result of a pcr_read() call: in that case, the actual PCR values are
in the same order as the TPML_PRC_SELECTION entries.
This means that "subtracting" a PcrSelectionList becomes practically
impossible.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>