### PR TITLE
Creates native rust type for TPM2B_PUBLIC.

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -23,6 +23,7 @@ hostname-validator = "1.1.0"
 regex = "1.3.9"
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.2.0" }
+primal = "0.3.0"
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/tss-esapi/src/abstraction/mod.rs
+++ b/tss-esapi/src/abstraction/mod.rs
@@ -7,8 +7,7 @@ pub mod ek;
 pub mod nv;
 pub mod transient;
 
-use crate::attributes::ObjectAttributesBuilder;
-use crate::utils::Tpm2BPublicBuilder;
+use crate::{attributes::ObjectAttributesBuilder, structures::PublicBuilder};
 
 /// KeyCustomizaion allows to adjust how a key is going to be created
 pub trait KeyCustomization {
@@ -18,7 +17,7 @@ pub trait KeyCustomization {
     }
 
     /// Alter the key template used on key creation
-    fn template(&self, template_builder: Tpm2BPublicBuilder) -> Tpm2BPublicBuilder {
+    fn template(&self, template_builder: PublicBuilder) -> PublicBuilder {
         template_builder
     }
 }

--- a/tss-esapi/src/attributes/object.rs
+++ b/tss-esapi/src/attributes/object.rs
@@ -60,6 +60,18 @@ impl ObjectAttributes {
     }
 }
 
+impl From<ObjectAttributes> for TPMA_OBJECT {
+    fn from(object_attributes: ObjectAttributes) -> Self {
+        object_attributes.0
+    }
+}
+
+impl From<TPMA_OBJECT> for ObjectAttributes {
+    fn from(tpma_object: TPMA_OBJECT) -> Self {
+        ObjectAttributes(tpma_object)
+    }
+}
+
 /// A builder for [ObjectAttributes]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ObjectAttributesBuilder {

--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     handles::KeyHandle,
-    structures::{Data, PcrSelectionList},
+    structures::{Data, PcrSelectionList, Signature},
     tss2_esys::*,
-    utils::Signature,
     Context, Error, Result,
 };
 use log::error;
 use mbox::MBox;
+use std::convert::TryFrom;
 use std::ptr::null_mut;
 
 impl Context {
@@ -47,7 +47,7 @@ impl Context {
         if ret.is_success() {
             let quoted = unsafe { MBox::<TPM2B_ATTEST>::from_raw(quoted) };
             let signature = unsafe { MBox::from_raw(signature) };
-            Ok((*quoted, unsafe { Signature::try_from(*signature)? }))
+            Ok((*quoted, Signature::try_from(*signature)?))
         } else {
             error!("Error in quoting PCR: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/capability_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/capability_commands.rs
@@ -1,12 +1,14 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    constants::CapabilityType, structures::CapabilityData, tss2_esys::*, utils::PublicParmsUnion,
+    constants::CapabilityType,
+    structures::{CapabilityData, PublicParameters},
+    tss2_esys::*,
     Context, Error, Result, WrapperErrorKind as ErrorKind,
 };
 use log::{error, warn};
 use mbox::MBox;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::ptr::null_mut;
 
 impl Context {
@@ -57,18 +59,14 @@ impl Context {
     /// # Errors
     /// * if any of the public parameters is not compatible with the TPM,
     /// an `Err` containing the specific unmarshalling error will be returned.
-    pub fn test_parms(&mut self, parms: PublicParmsUnion) -> Result<()> {
-        let public_parms = TPMT_PUBLIC_PARMS {
-            type_: parms.object_type(),
-            parameters: parms.try_into()?,
-        };
+    pub fn test_parms(&mut self, public_parmeters: PublicParameters) -> Result<()> {
         let ret = unsafe {
             Esys_TestParms(
                 self.mut_context(),
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &public_parms,
+                &public_parmeters.into(),
             )
         };
 

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -66,22 +66,26 @@ impl Context {
     ///
     /// ```rust
     /// # use tss_esapi::{
-    /// #     Context, Tcti, structures::Auth,
+    /// #     Context, tcti_ldr::TctiNameConf, structures::Auth,
     /// #     constants::{
     /// #         tss::{TPMA_SESSION_DECRYPT, TPMA_SESSION_ENCRYPT},
     /// #         SessionType,
     /// #     },
-    /// #     interface_types::{resource_handles::Hierarchy, algorithm::HashingAlgorithm},
-    /// #     utils::{create_unrestricted_signing_rsa_public, AsymSchemeUnion},
+    /// #     interface_types::{
+    /// #         resource_handles::Hierarchy,
+    /// #         algorithm::{HashingAlgorithm, RsaSchemeAlgorithm},
+    /// #         key_bits::RsaKeyBits,
+    /// #     },
+    /// #     utils::create_unrestricted_signing_rsa_public,
     /// #     attributes::SessionAttributesBuilder,
-    /// #     structures::SymmetricDefinition,
+    /// #     structures::{SymmetricDefinition, RsaExponent, RsaScheme},
     /// # };
     /// # use std::convert::TryFrom;
     /// # use std::str::FromStr;
     /// # // Create context
     /// # let mut context =
     /// #     Context::new(
-    /// #         Tcti::from_environment_variable().expect("Failed to get TCTI"),
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
     /// #     ).expect("Failed to create Context");
     ///
     /// // Create session for a key
@@ -105,9 +109,10 @@ impl Context {
     ///
     /// // Create public area for a rsa key
     /// let public_area = create_unrestricted_signing_rsa_public(
-    ///         AsymSchemeUnion::RSASSA(HashingAlgorithm::Sha256),
-    ///         2048,
-    ///         0,
+    ///         RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
+    ///             .expect("Failed to create RSA scheme"),
+    ///         RsaKeyBits::Rsa2048,
+    ///         RsaExponent::default(),
     ///     )
     ///     .expect("Failed to create rsa public area");
     ///
@@ -177,26 +182,26 @@ impl Context {
     /// Make transient object peristent:
     /// ```rust
     /// # use tss_esapi::{
-    /// #     Context, Tcti, Result,
+    /// #     Context, tcti_ldr::TctiNameConf, Result,
     /// #     constants::{
     /// #         SessionType, CapabilityType,
     /// #         tss::TPM2_PERSISTENT_FIRST,
     /// #     },
     /// #     handles::PcrHandle,
-    /// #     structures::{Digest, CapabilityData, Auth},
+    /// #     structures::{Digest, CapabilityData, Auth, RsaExponent, SymmetricDefinitionObject},
     /// #     interface_types::{
     /// #       resource_handles::Hierarchy,
+    /// #       key_bits::RsaKeyBits,
     /// #     },
     /// #     handles::{ObjectHandle, TpmHandle, PersistentTpmHandle},
     /// #     utils::create_restricted_decryption_rsa_public,
     /// #     tss2_esys::TPM2_HANDLE,
-    /// #     abstraction::cipher::Cipher,
     /// # };
     /// # use std::{env, str::FromStr, convert::TryFrom};
     /// # // Create context
     /// # let mut context =
     /// #     Context::new(
-    /// #         Tcti::from_environment_variable().expect("Failed to get TCTI"),
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
     /// #     ).expect("Failed to create Context");
     /// # // Create persistent TPM handle with
     /// # let persistent_tpm_handle =
@@ -240,8 +245,11 @@ impl Context {
     /// #    ctx
     /// #        .create_primary(
     /// #            Hierarchy::Owner,
-    /// #            &create_restricted_decryption_rsa_public(Cipher::aes_256_cfb(), 2048, 0)
-    /// #               .expect("Failed to Public structure for key"),
+    /// #            &create_restricted_decryption_rsa_public(
+    /// #               SymmetricDefinitionObject::AES_256_CFB,
+    /// #               RsaKeyBits::Rsa2048,
+    /// #               RsaExponent::default(),
+    /// #            ).expect("Failed to Public structure for key"),
     /// #            Some(auth_value_primary).as_ref(),
     /// #            None,
     /// #            None,
@@ -293,26 +301,26 @@ impl Context {
     /// Make persistent object transient
     /// ```rust
     /// # use tss_esapi::{
-    /// #     Context, Tcti, Result,
+    /// #     Context, tcti_ldr::TctiNameConf, Result,
     /// #     constants::{
     /// #         SessionType, CapabilityType,
     /// #         tss::TPM2_PERSISTENT_FIRST,
     /// #     },
     /// #     handles::PcrHandle,
-    /// #     structures::{Digest, CapabilityData, Auth},
+    /// #     structures::{Digest, CapabilityData, Auth, RsaExponent, SymmetricDefinitionObject},
     /// #     interface_types::{
     /// #       resource_handles::Hierarchy,
+    /// #       key_bits::RsaKeyBits,
     /// #     },
     /// #     handles::{ObjectHandle, TpmHandle, PersistentTpmHandle},
     /// #     utils::create_restricted_decryption_rsa_public,
     /// #     tss2_esys::TPM2_HANDLE,
-    /// #     abstraction::cipher::Cipher,
     /// # };
     /// # use std::{env, str::FromStr, convert::TryFrom};
     /// # // Create context
     /// # let mut context =
     /// #     Context::new(
-    /// #         Tcti::from_environment_variable().expect("Failed to get TCTI"),
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
     /// #     ).expect("Failed to create Context");
     /// # // Create persistent TPM handle with
     /// # let persistent_tpm_handle =
@@ -356,8 +364,11 @@ impl Context {
     /// #    ctx
     /// #        .create_primary(
     /// #            Hierarchy::Owner,
-    /// #            &create_restricted_decryption_rsa_public(Cipher::aes_256_cfb(), 2048, 0)
-    /// #               .expect("Failed to Public structure for key"),
+    /// #            &create_restricted_decryption_rsa_public(
+    /// #               SymmetricDefinitionObject::AES_256_CFB,
+    /// #               RsaKeyBits::Rsa2048,
+    /// #               RsaExponent::default(),
+    /// #            ).expect("Failed to Public structure for key"),
     /// #            Some(auth_value_primary).as_ref(),
     /// #            None,
     /// #            None,

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -4,10 +4,10 @@ use crate::{
     handles::{AuthHandle, ObjectHandle, SessionHandle},
     interface_types::session_handles::PolicySession,
     structures::{
-        AuthTicket, Digest, DigestList, Name, Nonce, PcrSelectionList, Timeout, VerifiedTicket,
+        AuthTicket, Digest, DigestList, Name, Nonce, PcrSelectionList, Signature, Timeout,
+        VerifiedTicket,
     },
     tss2_esys::*,
-    utils::Signature,
     Context, Error, Result, WrapperErrorKind as ErrorKind,
 };
 use log::error;

--- a/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
+++ b/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     handles::KeyHandle,
-    structures::{Digest, HashcheckTicket, VerifiedTicket},
+    structures::{Digest, HashcheckTicket, Signature, VerifiedTicket},
     tss2_esys::*,
-    utils::Signature,
     Context, Error, Result,
 };
 use log::error;
@@ -73,7 +72,7 @@ impl Context {
 
         if ret.is_success() {
             let signature = unsafe { MBox::from_raw(signature) };
-            Ok(unsafe { Signature::try_from(*signature)? })
+            Ok(Signature::try_from(*signature)?)
         } else {
             error!("Error when signing: {}", ret);
             Err(ret)

--- a/tss-esapi/src/interface_types/algorithm.rs
+++ b/tss-esapi/src/interface_types/algorithm.rs
@@ -3,7 +3,8 @@
 use crate::{
     constants::AlgorithmIdentifier,
     tss2_esys::{
-        TPMI_ALG_ASYM, TPMI_ALG_HASH, TPMI_ALG_KDF, TPMI_ALG_KEYEDHASH_SCHEME, TPMI_ALG_SIG_SCHEME,
+        TPMI_ALG_ASYM, TPMI_ALG_ECC_SCHEME, TPMI_ALG_HASH, TPMI_ALG_KDF, TPMI_ALG_KEYEDHASH_SCHEME,
+        TPMI_ALG_PUBLIC, TPMI_ALG_RSA_DECRYPT, TPMI_ALG_RSA_SCHEME, TPMI_ALG_SIG_SCHEME,
         TPMI_ALG_SYM, TPMI_ALG_SYM_MODE, TPMI_ALG_SYM_OBJECT,
     },
     Error, Result, WrapperErrorKind,
@@ -131,7 +132,8 @@ pub enum KeyDerivationFunction {
     Kdf1Sp800_56a,
     Kdf2,
     Kdf1Sp800_108,
-    EcMqv,
+    Mgf1,
+    Null,
 }
 
 impl From<KeyDerivationFunction> for AlgorithmIdentifier {
@@ -140,7 +142,8 @@ impl From<KeyDerivationFunction> for AlgorithmIdentifier {
             KeyDerivationFunction::Kdf1Sp800_56a => AlgorithmIdentifier::Kdf1Sp800_56a,
             KeyDerivationFunction::Kdf2 => AlgorithmIdentifier::Kdf2,
             KeyDerivationFunction::Kdf1Sp800_108 => AlgorithmIdentifier::Kdf1Sp800_108,
-            KeyDerivationFunction::EcMqv => AlgorithmIdentifier::EcMqv,
+            KeyDerivationFunction::Mgf1 => AlgorithmIdentifier::Mgf1,
+            KeyDerivationFunction::Null => AlgorithmIdentifier::Null,
         }
     }
 }
@@ -153,7 +156,8 @@ impl TryFrom<AlgorithmIdentifier> for KeyDerivationFunction {
             AlgorithmIdentifier::Kdf1Sp800_56a => Ok(KeyDerivationFunction::Kdf1Sp800_56a),
             AlgorithmIdentifier::Kdf2 => Ok(KeyDerivationFunction::Kdf2),
             AlgorithmIdentifier::Kdf1Sp800_108 => Ok(KeyDerivationFunction::Kdf1Sp800_108),
-            AlgorithmIdentifier::EcMqv => Ok(KeyDerivationFunction::EcMqv),
+            AlgorithmIdentifier::Mgf1 => Ok(KeyDerivationFunction::Mgf1),
+            AlgorithmIdentifier::Null => Ok(KeyDerivationFunction::Null),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
@@ -336,7 +340,7 @@ impl TryFrom<TPMI_ALG_ASYM> for AsymmetricAlgorithm {
 /// # Details
 /// This corresponds to TPMI_ALG_SIG_SCHEME
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum SignatureScheme {
+pub enum SignatureSchemeAlgorithm {
     RsaSsa,
     RsaPss,
     EcDsa,
@@ -347,63 +351,63 @@ pub enum SignatureScheme {
     Null,
 }
 
-impl From<SignatureScheme> for AlgorithmIdentifier {
-    fn from(signature_scheme: SignatureScheme) -> Self {
-        match signature_scheme {
-            SignatureScheme::RsaSsa => AlgorithmIdentifier::RsaSsa,
-            SignatureScheme::RsaPss => AlgorithmIdentifier::RsaPss,
-            SignatureScheme::EcDsa => AlgorithmIdentifier::EcDsa,
-            SignatureScheme::EcDaa => AlgorithmIdentifier::EcDaa,
-            SignatureScheme::Sm2 => AlgorithmIdentifier::Sm2,
-            SignatureScheme::EcSchnorr => AlgorithmIdentifier::EcSchnorr,
-            SignatureScheme::Hmac => AlgorithmIdentifier::Hmac,
-            SignatureScheme::Null => AlgorithmIdentifier::Null,
+impl From<SignatureSchemeAlgorithm> for AlgorithmIdentifier {
+    fn from(signature_scheme_algorithm: SignatureSchemeAlgorithm) -> Self {
+        match signature_scheme_algorithm {
+            SignatureSchemeAlgorithm::RsaSsa => AlgorithmIdentifier::RsaSsa,
+            SignatureSchemeAlgorithm::RsaPss => AlgorithmIdentifier::RsaPss,
+            SignatureSchemeAlgorithm::EcDsa => AlgorithmIdentifier::EcDsa,
+            SignatureSchemeAlgorithm::EcDaa => AlgorithmIdentifier::EcDaa,
+            SignatureSchemeAlgorithm::Sm2 => AlgorithmIdentifier::Sm2,
+            SignatureSchemeAlgorithm::EcSchnorr => AlgorithmIdentifier::EcSchnorr,
+            SignatureSchemeAlgorithm::Hmac => AlgorithmIdentifier::Hmac,
+            SignatureSchemeAlgorithm::Null => AlgorithmIdentifier::Null,
         }
     }
 }
 
-impl TryFrom<AlgorithmIdentifier> for SignatureScheme {
+impl TryFrom<AlgorithmIdentifier> for SignatureSchemeAlgorithm {
     type Error = Error;
     fn try_from(algorithm_identifier: AlgorithmIdentifier) -> Result<Self> {
         match algorithm_identifier {
-            AlgorithmIdentifier::RsaSsa => Ok(SignatureScheme::RsaSsa),
-            AlgorithmIdentifier::RsaPss => Ok(SignatureScheme::RsaPss),
-            AlgorithmIdentifier::EcDsa => Ok(SignatureScheme::EcDsa),
-            AlgorithmIdentifier::EcDaa => Ok(SignatureScheme::EcDaa),
-            AlgorithmIdentifier::Sm2 => Ok(SignatureScheme::Sm2),
-            AlgorithmIdentifier::EcSchnorr => Ok(SignatureScheme::EcSchnorr),
-            AlgorithmIdentifier::Hmac => Ok(SignatureScheme::Hmac),
-            AlgorithmIdentifier::Null => Ok(SignatureScheme::Null),
+            AlgorithmIdentifier::RsaSsa => Ok(SignatureSchemeAlgorithm::RsaSsa),
+            AlgorithmIdentifier::RsaPss => Ok(SignatureSchemeAlgorithm::RsaPss),
+            AlgorithmIdentifier::EcDsa => Ok(SignatureSchemeAlgorithm::EcDsa),
+            AlgorithmIdentifier::EcDaa => Ok(SignatureSchemeAlgorithm::EcDaa),
+            AlgorithmIdentifier::Sm2 => Ok(SignatureSchemeAlgorithm::Sm2),
+            AlgorithmIdentifier::EcSchnorr => Ok(SignatureSchemeAlgorithm::EcSchnorr),
+            AlgorithmIdentifier::Hmac => Ok(SignatureSchemeAlgorithm::Hmac),
+            AlgorithmIdentifier::Null => Ok(SignatureSchemeAlgorithm::Null),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }
 }
 
-impl From<SignatureScheme> for TPMI_ALG_SIG_SCHEME {
-    fn from(signature_scheme: SignatureScheme) -> Self {
-        AlgorithmIdentifier::from(signature_scheme).into()
+impl From<SignatureSchemeAlgorithm> for TPMI_ALG_SIG_SCHEME {
+    fn from(signature_scheme_algorithm: SignatureSchemeAlgorithm) -> Self {
+        AlgorithmIdentifier::from(signature_scheme_algorithm).into()
     }
 }
 
-impl TryFrom<TPMI_ALG_SIG_SCHEME> for SignatureScheme {
+impl TryFrom<TPMI_ALG_SIG_SCHEME> for SignatureSchemeAlgorithm {
     type Error = Error;
     fn try_from(tpmi_alg_sym_scheme: TPMI_ALG_SIG_SCHEME) -> Result<Self> {
-        SignatureScheme::try_from(AlgorithmIdentifier::try_from(tpmi_alg_sym_scheme)?)
+        SignatureSchemeAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_alg_sym_scheme)?)
     }
 }
 
 // A convinience conversion into AsymmetricAlgorithm
 // that is associated with the signature scheme.
-impl TryFrom<SignatureScheme> for AsymmetricAlgorithm {
+impl TryFrom<SignatureSchemeAlgorithm> for AsymmetricAlgorithm {
     type Error = Error;
-    fn try_from(signature_scheme: SignatureScheme) -> Result<Self> {
+    fn try_from(signature_scheme: SignatureSchemeAlgorithm) -> Result<Self> {
         match signature_scheme {
-            SignatureScheme::RsaSsa => Ok(AsymmetricAlgorithm::Rsa),
-            SignatureScheme::RsaPss => Ok(AsymmetricAlgorithm::Rsa),
-            SignatureScheme::EcDsa => Ok(AsymmetricAlgorithm::Ecc),
-            SignatureScheme::EcDaa => Ok(AsymmetricAlgorithm::Ecc),
-            SignatureScheme::Sm2 => Ok(AsymmetricAlgorithm::Ecc),
-            SignatureScheme::EcSchnorr => Ok(AsymmetricAlgorithm::Ecc),
+            SignatureSchemeAlgorithm::RsaSsa => Ok(AsymmetricAlgorithm::Rsa),
+            SignatureSchemeAlgorithm::RsaPss => Ok(AsymmetricAlgorithm::Rsa),
+            SignatureSchemeAlgorithm::EcDsa => Ok(AsymmetricAlgorithm::Ecc),
+            SignatureSchemeAlgorithm::EcDaa => Ok(AsymmetricAlgorithm::Ecc),
+            SignatureSchemeAlgorithm::Sm2 => Ok(AsymmetricAlgorithm::Ecc),
+            SignatureSchemeAlgorithm::EcSchnorr => Ok(AsymmetricAlgorithm::Ecc),
             _ => {
                 // HMAC is for symmetric algorithms
                 //
@@ -465,5 +469,217 @@ impl TryFrom<TPMI_ALG_SYM_OBJECT> for SymmetricObject {
 
     fn try_from(tpmi_alg_sym_object: TPMI_ALG_SYM_OBJECT) -> Result<Self> {
         SymmetricObject::try_from(AlgorithmIdentifier::try_from(tpmi_alg_sym_object)?)
+    }
+}
+
+/// Enum repsenting the public interface type
+///
+/// # Details
+/// This corresponds to TPMI_ALG_PUBLIC
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PublicAlgorithm {
+    Rsa,
+    KeyedHash,
+    Ecc,
+    SymCipher,
+}
+
+impl From<PublicAlgorithm> for AlgorithmIdentifier {
+    fn from(public_algorithm: PublicAlgorithm) -> Self {
+        match public_algorithm {
+            PublicAlgorithm::Rsa => AlgorithmIdentifier::Rsa,
+            PublicAlgorithm::KeyedHash => AlgorithmIdentifier::KeyedHash,
+            PublicAlgorithm::Ecc => AlgorithmIdentifier::Ecc,
+            PublicAlgorithm::SymCipher => AlgorithmIdentifier::SymCipher,
+        }
+    }
+}
+
+impl TryFrom<AlgorithmIdentifier> for PublicAlgorithm {
+    type Error = Error;
+    fn try_from(algorithm_identifier: AlgorithmIdentifier) -> Result<Self> {
+        match algorithm_identifier {
+            AlgorithmIdentifier::Rsa => Ok(PublicAlgorithm::Rsa),
+            AlgorithmIdentifier::KeyedHash => Ok(PublicAlgorithm::KeyedHash),
+            AlgorithmIdentifier::Ecc => Ok(PublicAlgorithm::Ecc),
+            AlgorithmIdentifier::SymCipher => Ok(PublicAlgorithm::SymCipher),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+impl From<PublicAlgorithm> for TPMI_ALG_PUBLIC {
+    fn from(public_algorithm: PublicAlgorithm) -> Self {
+        AlgorithmIdentifier::from(public_algorithm).into()
+    }
+}
+
+impl TryFrom<TPMI_ALG_PUBLIC> for PublicAlgorithm {
+    type Error = Error;
+
+    fn try_from(tpmi_alg_public: TPMI_ALG_PUBLIC) -> Result<Self> {
+        PublicAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_alg_public)?)
+    }
+}
+
+/// Enum repsenting the rsa scheme interface type
+///
+/// # Details
+/// This corresponds to TPMI_ALG_RSA_SCHEME
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum RsaSchemeAlgorithm {
+    RsaSsa,
+    RsaEs,
+    RsaPss,
+    Oaep,
+    Null,
+}
+
+impl From<RsaSchemeAlgorithm> for AlgorithmIdentifier {
+    fn from(rsa_scheme_algorithm: RsaSchemeAlgorithm) -> Self {
+        match rsa_scheme_algorithm {
+            RsaSchemeAlgorithm::RsaSsa => AlgorithmIdentifier::RsaSsa,
+            RsaSchemeAlgorithm::RsaEs => AlgorithmIdentifier::RsaEs,
+            RsaSchemeAlgorithm::RsaPss => AlgorithmIdentifier::RsaPss,
+            RsaSchemeAlgorithm::Oaep => AlgorithmIdentifier::Oaep,
+            RsaSchemeAlgorithm::Null => AlgorithmIdentifier::Null,
+        }
+    }
+}
+
+impl TryFrom<AlgorithmIdentifier> for RsaSchemeAlgorithm {
+    type Error = Error;
+
+    fn try_from(algorithm_identifier: AlgorithmIdentifier) -> Result<Self> {
+        match algorithm_identifier {
+            AlgorithmIdentifier::RsaSsa => Ok(RsaSchemeAlgorithm::RsaSsa),
+            AlgorithmIdentifier::RsaEs => Ok(RsaSchemeAlgorithm::RsaEs),
+            AlgorithmIdentifier::RsaPss => Ok(RsaSchemeAlgorithm::RsaPss),
+            AlgorithmIdentifier::Oaep => Ok(RsaSchemeAlgorithm::Oaep),
+            AlgorithmIdentifier::Null => Ok(RsaSchemeAlgorithm::Null),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+impl From<RsaSchemeAlgorithm> for TPMI_ALG_RSA_SCHEME {
+    fn from(rsa_scheme_algorithm: RsaSchemeAlgorithm) -> Self {
+        AlgorithmIdentifier::from(rsa_scheme_algorithm).into()
+    }
+}
+
+impl TryFrom<TPMI_ALG_RSA_SCHEME> for RsaSchemeAlgorithm {
+    type Error = Error;
+
+    fn try_from(tpmi_alg_rsa_scheme: TPMI_ALG_RSA_SCHEME) -> Result<Self> {
+        RsaSchemeAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_alg_rsa_scheme)?)
+    }
+}
+
+/// Enum repsenting the rsa scheme interface type
+///
+/// # Details
+/// This corresponds to TPMI_ALG_ECC_SCHEME
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum EccSchemeAlgorithm {
+    EcDsa,
+    EcDh,
+    EcDaa,
+    Sm2,
+    EcSchnorr,
+    EcMqv,
+    Null,
+}
+
+impl From<EccSchemeAlgorithm> for AlgorithmIdentifier {
+    fn from(ecc_scheme_algorithm: EccSchemeAlgorithm) -> Self {
+        match ecc_scheme_algorithm {
+            EccSchemeAlgorithm::EcDsa => AlgorithmIdentifier::EcDsa,
+            EccSchemeAlgorithm::EcDh => AlgorithmIdentifier::EcDh,
+            EccSchemeAlgorithm::EcDaa => AlgorithmIdentifier::EcDaa,
+            EccSchemeAlgorithm::Sm2 => AlgorithmIdentifier::Sm2,
+            EccSchemeAlgorithm::EcSchnorr => AlgorithmIdentifier::EcSchnorr,
+            EccSchemeAlgorithm::EcMqv => AlgorithmIdentifier::EcMqv,
+            EccSchemeAlgorithm::Null => AlgorithmIdentifier::Null,
+        }
+    }
+}
+
+impl TryFrom<AlgorithmIdentifier> for EccSchemeAlgorithm {
+    type Error = Error;
+
+    fn try_from(algorithm_identifier: AlgorithmIdentifier) -> Result<Self> {
+        match algorithm_identifier {
+            AlgorithmIdentifier::EcDsa => Ok(EccSchemeAlgorithm::EcDsa),
+            AlgorithmIdentifier::EcDh => Ok(EccSchemeAlgorithm::EcDh),
+            AlgorithmIdentifier::EcDaa => Ok(EccSchemeAlgorithm::EcDaa),
+            AlgorithmIdentifier::Sm2 => Ok(EccSchemeAlgorithm::Sm2),
+            AlgorithmIdentifier::EcSchnorr => Ok(EccSchemeAlgorithm::EcSchnorr),
+            AlgorithmIdentifier::EcMqv => Ok(EccSchemeAlgorithm::EcMqv),
+            AlgorithmIdentifier::Null => Ok(EccSchemeAlgorithm::Null),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+impl From<EccSchemeAlgorithm> for TPMI_ALG_ECC_SCHEME {
+    fn from(ecc_scheme_algorithm: EccSchemeAlgorithm) -> Self {
+        AlgorithmIdentifier::from(ecc_scheme_algorithm).into()
+    }
+}
+
+impl TryFrom<TPMI_ALG_ECC_SCHEME> for EccSchemeAlgorithm {
+    type Error = Error;
+
+    fn try_from(tpmi_alg_ecc_scheme: TPMI_ALG_ECC_SCHEME) -> Result<Self> {
+        EccSchemeAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_alg_ecc_scheme)?)
+    }
+}
+
+/// Enum repsenting the rsa decryption interface type
+///
+/// # Details
+/// This corresponds to TPMI_ALG_RSA_DECRYPT
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum RsaDecryptAlgorithm {
+    RsaEs,
+    Oaep,
+    Null,
+}
+
+impl From<RsaDecryptAlgorithm> for AlgorithmIdentifier {
+    fn from(rsa_decrypt_algorithm: RsaDecryptAlgorithm) -> Self {
+        match rsa_decrypt_algorithm {
+            RsaDecryptAlgorithm::RsaEs => AlgorithmIdentifier::RsaEs,
+            RsaDecryptAlgorithm::Oaep => AlgorithmIdentifier::Oaep,
+            RsaDecryptAlgorithm::Null => AlgorithmIdentifier::Null,
+        }
+    }
+}
+
+impl TryFrom<AlgorithmIdentifier> for RsaDecryptAlgorithm {
+    type Error = Error;
+
+    fn try_from(algorithm_identifier: AlgorithmIdentifier) -> Result<Self> {
+        match algorithm_identifier {
+            AlgorithmIdentifier::RsaEs => Ok(RsaDecryptAlgorithm::RsaEs),
+            AlgorithmIdentifier::Oaep => Ok(RsaDecryptAlgorithm::Oaep),
+            AlgorithmIdentifier::Null => Ok(RsaDecryptAlgorithm::Null),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+impl From<RsaDecryptAlgorithm> for TPMI_ALG_RSA_DECRYPT {
+    fn from(rsa_decrypt_algorithm: RsaDecryptAlgorithm) -> Self {
+        AlgorithmIdentifier::from(rsa_decrypt_algorithm).into()
+    }
+}
+
+impl TryFrom<TPMI_ALG_RSA_DECRYPT> for RsaDecryptAlgorithm {
+    type Error = Error;
+
+    fn try_from(tpmi_alg_rsa_decrypt: TPMI_ALG_RSA_DECRYPT) -> Result<Self> {
+        RsaDecryptAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_alg_rsa_decrypt)?)
     }
 }

--- a/tss-esapi/src/interface_types/key_bits.rs
+++ b/tss-esapi/src/interface_types/key_bits.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    tss2_esys::{TPM2_KEY_BITS, TPMI_AES_KEY_BITS, TPMI_SM4_KEY_BITS},
+    tss2_esys::{TPM2_KEY_BITS, TPMI_AES_KEY_BITS, TPMI_RSA_KEY_BITS, TPMI_SM4_KEY_BITS},
     Error, Result, WrapperErrorKind,
 };
 use std::convert::TryFrom;
@@ -100,6 +100,43 @@ impl TryFrom<TPM2_KEY_BITS> for CamelliaKeyBits {
             128 => Ok(CamelliaKeyBits::Camellia128),
             192 => Ok(CamelliaKeyBits::Camellia192),
             256 => Ok(CamelliaKeyBits::Camellia256),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+/// RSA key bits interface type
+///
+/// # Details
+/// This corresponds to TPMI_RSA_KEY_BITS
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum RsaKeyBits {
+    Rsa1024,
+    Rsa2048,
+    Rsa3072,
+    Rsa4096,
+}
+
+impl From<RsaKeyBits> for TPMI_RSA_KEY_BITS {
+    fn from(rsa_key_bits: RsaKeyBits) -> TPMI_RSA_KEY_BITS {
+        match rsa_key_bits {
+            RsaKeyBits::Rsa1024 => 1024,
+            RsaKeyBits::Rsa2048 => 2048,
+            RsaKeyBits::Rsa3072 => 3072,
+            RsaKeyBits::Rsa4096 => 4096,
+        }
+    }
+}
+
+impl TryFrom<TPMI_RSA_KEY_BITS> for RsaKeyBits {
+    type Error = Error;
+
+    fn try_from(tpmi_rsa_key_bits: TPMI_RSA_KEY_BITS) -> Result<RsaKeyBits> {
+        match tpmi_rsa_key_bits {
+            1024 => Ok(RsaKeyBits::Rsa1024),
+            2048 => Ok(RsaKeyBits::Rsa2048),
+            3072 => Ok(RsaKeyBits::Rsa3072),
+            4096 => Ok(RsaKeyBits::Rsa4096),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         }
     }

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -91,6 +91,8 @@ macro_rules! buffer_type {
     };
 }
 
+pub mod public;
+
 pub mod auth {
     buffer_type!(Auth, 64, TPM2B_AUTH);
 }
@@ -199,7 +201,79 @@ pub mod nonce {
 }
 
 pub mod public_key_rsa {
-    buffer_type!(PublicKeyRSA, 512, TPM2B_PUBLIC_KEY_RSA);
+    use crate::{interface_types::key_bits::RsaKeyBits, tss2_esys::TPM2_MAX_RSA_KEY_BYTES};
+    buffer_type!(
+        PublicKeyRsa,
+        TPM2_MAX_RSA_KEY_BYTES as usize,
+        TPM2B_PUBLIC_KEY_RSA
+    );
+
+    impl PublicKeyRsa {
+        pub fn new_empty_with_size(rsa_key_bits: RsaKeyBits) -> Self {
+            match rsa_key_bits {
+                RsaKeyBits::Rsa1024 => PublicKeyRsa(vec![0u8; 128].into()),
+                RsaKeyBits::Rsa2048 => PublicKeyRsa(vec![0u8; 256].into()),
+                RsaKeyBits::Rsa3072 => PublicKeyRsa(vec![0u8; 384].into()),
+                RsaKeyBits::Rsa4096 => PublicKeyRsa(vec![0u8; 512].into()),
+            }
+        }
+    }
+
+    impl TryFrom<PublicKeyRsa> for [u8; 128] {
+        type Error = Error;
+
+        fn try_from(public_key_rsa: PublicKeyRsa) -> Result<Self> {
+            if public_key_rsa.value().len() > 128 {
+                return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+            }
+
+            let mut value = [0u8; 128];
+            value.copy_from_slice(public_key_rsa.value());
+            Ok(value)
+        }
+    }
+
+    impl TryFrom<PublicKeyRsa> for [u8; 256] {
+        type Error = Error;
+
+        fn try_from(public_key_rsa: PublicKeyRsa) -> Result<Self> {
+            if public_key_rsa.value().len() > 256 {
+                return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+            }
+
+            let mut value = [0u8; 256];
+            value.copy_from_slice(public_key_rsa.value());
+            Ok(value)
+        }
+    }
+
+    impl TryFrom<PublicKeyRsa> for [u8; 384] {
+        type Error = Error;
+
+        fn try_from(public_key_rsa: PublicKeyRsa) -> Result<Self> {
+            if public_key_rsa.value().len() > 384 {
+                return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+            }
+
+            let mut value = [0u8; 384];
+            value.copy_from_slice(public_key_rsa.value());
+            Ok(value)
+        }
+    }
+
+    impl TryFrom<PublicKeyRsa> for [u8; 512] {
+        type Error = Error;
+
+        fn try_from(public_key_rsa: PublicKeyRsa) -> Result<Self> {
+            if public_key_rsa.value().len() > 512 {
+                return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+            }
+
+            let mut value = [0u8; 512];
+            value.copy_from_slice(public_key_rsa.value());
+            Ok(value)
+        }
+    }
 }
 
 pub mod timeout {
@@ -211,5 +285,13 @@ pub mod initial_value {
         InitialValue,
         crate::tss2_esys::TPM2_MAX_SYM_BLOCK_SIZE as usize,
         TPM2B_IV
+    );
+}
+
+pub mod ecc_parameter {
+    buffer_type!(
+        EccParameter,
+        crate::tss2_esys::TPM2_MAX_ECC_KEY_BYTES as usize,
+        TPM2B_ECC_PARAMETER
     );
 }

--- a/tss-esapi/src/structures/buffers/public.rs
+++ b/tss-esapi/src/structures/buffers/public.rs
@@ -1,0 +1,501 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+pub mod ecc;
+pub mod keyed_hash;
+pub mod rsa;
+
+use crate::{
+    attributes::ObjectAttributes,
+    interface_types::algorithm::{HashingAlgorithm, PublicAlgorithm},
+    structures::{Digest, EccPoint, PublicKeyRsa, SymmetricCipherParameters},
+    tss2_esys::{TPM2B_PUBLIC, TPMT_PUBLIC},
+    Error, Result, WrapperErrorKind,
+};
+
+use ecc::PublicEccParameters;
+use keyed_hash::PublicKeyedHashParameters;
+use rsa::PublicRsaParameters;
+
+use log::error;
+use std::convert::{TryFrom, TryInto};
+use tss_esapi_sys::{TPMU_PUBLIC_ID, TPMU_PUBLIC_PARMS};
+
+/// A builder for the [Public] type.
+#[derive(Debug, Clone)]
+pub struct PublicBuilder {
+    public_algorithm: Option<PublicAlgorithm>,
+    object_attributes: Option<ObjectAttributes>,
+    name_hashing_algorithm: Option<HashingAlgorithm>,
+    auth_policy: Option<Digest>,
+    rsa_parameters: Option<PublicRsaParameters>,
+    rsa_unique_identifier: Option<PublicKeyRsa>,
+    keyed_hash_parameters: Option<PublicKeyedHashParameters>,
+    keyed_hash_unique_identifier: Option<Digest>,
+    ecc_parameters: Option<PublicEccParameters>,
+    ecc_unique_identifier: Option<EccPoint>,
+    symmetric_cipher_parameters: Option<SymmetricCipherParameters>,
+    symmetric_cipher_unique_identifier: Option<Digest>,
+}
+
+impl PublicBuilder {
+    /// Creates a new [PublicBuilder]
+    ///
+    /// # Details
+    /// Builds the [Public] type using the provided parameters. Parameters
+    /// associated with other algorithms then the provided public algorithm
+    /// will be ignored.
+    pub const fn new() -> Self {
+        PublicBuilder {
+            public_algorithm: None,
+            object_attributes: None,
+            name_hashing_algorithm: None,
+            auth_policy: None,
+            rsa_parameters: None,
+            rsa_unique_identifier: None,
+            keyed_hash_parameters: None,
+            keyed_hash_unique_identifier: None,
+            ecc_parameters: None,
+            ecc_unique_identifier: None,
+            symmetric_cipher_parameters: None,
+            symmetric_cipher_unique_identifier: None,
+        }
+    }
+
+    /// Adds the public algorithm for the [Public] structure
+    /// to the builder.
+    pub const fn with_public_algorithm(mut self, public_algorithm: PublicAlgorithm) -> Self {
+        self.public_algorithm = Some(public_algorithm);
+        self
+    }
+
+    /// Adds the attributes of the [Public] structure
+    /// to the builder
+    pub const fn with_object_attributes(mut self, object_attributes: ObjectAttributes) -> Self {
+        self.object_attributes = Some(object_attributes);
+        self
+    }
+
+    /// Adds the name hash algorithm for the [Public] strucutre
+    /// to the builder.
+    pub const fn with_name_hashing_algorithm(
+        mut self,
+        name_hashing_algorithm: HashingAlgorithm,
+    ) -> Self {
+        self.name_hashing_algorithm = Some(name_hashing_algorithm);
+        self
+    }
+
+    /// Adds the auth policy for the [Public] strucutre
+    /// to the builder
+    pub fn with_auth_policy(mut self, auth_policy: &Digest) -> Self {
+        self.auth_policy = Some(auth_policy.clone());
+        self
+    }
+
+    /// Adds the RSA parameters for the [Public] structure
+    /// to the builder.
+    ///
+    /// # Details
+    /// This is required if the public algorithm is set to
+    /// [Rsa][`crate::interface_types::algorithm::PublicAlgorithm::Rsa].
+    pub fn with_rsa_parameters(mut self, rsa_parameters: PublicRsaParameters) -> Self {
+        self.rsa_parameters = Some(rsa_parameters);
+        self
+    }
+
+    /// Adds the RSA unique identifier for the [Public] structure
+    /// to the builder.
+    ///
+    /// # Details
+    /// This is required if the public algorithm is set to
+    /// [Rsa][`crate::interface_types::algorithm::PublicAlgorithm::Rsa].
+    ///
+    /// The unique identifier is the public key.
+    pub fn with_rsa_unique_identifier(mut self, rsa_unique_identifier: &PublicKeyRsa) -> Self {
+        self.rsa_unique_identifier = Some(rsa_unique_identifier.clone());
+        self
+    }
+
+    /// Adds the keyed hash parameters for the [Public] structure
+    /// to the builder.
+    ///
+    /// # Details
+    /// This is required if the public algorithm is set to
+    /// [KeyedHash][`crate::interface_types::algorithm::PublicAlgorithm::KeyedHash].
+    pub fn with_keyed_hash_parameters(
+        mut self,
+        keyed_hash_parameters: PublicKeyedHashParameters,
+    ) -> Self {
+        self.keyed_hash_parameters = Some(keyed_hash_parameters);
+        self
+    }
+
+    /// Adds the keyed hash unique identifier for the [Public] structure
+    /// to the builder.
+    ///
+    /// # Details
+    /// This is required if the public algorithm is set to
+    /// [KeyedHash][`crate::interface_types::algorithm::PublicAlgorithm::KeyedHash].
+    pub fn with_keyed_hash_unique_identifier(
+        mut self,
+        keyed_hash_unique_identifier: &Digest,
+    ) -> Self {
+        self.keyed_hash_unique_identifier = Some(keyed_hash_unique_identifier.clone());
+        self
+    }
+
+    /// Adds the ECC parameters for the [Public] structure
+    /// to the builder.
+    ///
+    /// # Details
+    /// This is required if the public algorithm is set to
+    /// [Ecc][`crate::interface_types::algorithm::PublicAlgorithm::Ecc].
+    pub const fn with_ecc_parameters(mut self, ecc_parameters: PublicEccParameters) -> Self {
+        self.ecc_parameters = Some(ecc_parameters);
+        self
+    }
+
+    /// Adds the ECC unique identifier for the [Public] structure
+    /// to the builder.
+    ///
+    /// # Details
+    /// This is required if the public algorithm is set to
+    /// [Ecc][`crate::interface_types::algorithm::PublicAlgorithm::Ecc].
+    ///
+    /// The unique identifier is a ecc point.
+    pub fn with_ecc_unique_identifier(mut self, ecc_unique_identifier: &EccPoint) -> Self {
+        self.ecc_unique_identifier = Some(ecc_unique_identifier.clone());
+        self
+    }
+
+    /// Adds the symmetric cipher parameters for the [Public] structure
+    /// to the builder.
+    ///
+    /// # Details
+    /// This is required if the public algorithm is set to
+    /// [SymCipher][`crate::interface_types::algorithm::PublicAlgorithm::SymCipher].
+    pub const fn with_symmetric_cipher_parameters(
+        mut self,
+        symmetric_cipher_parameters: SymmetricCipherParameters,
+    ) -> Self {
+        self.symmetric_cipher_parameters = Some(symmetric_cipher_parameters);
+        self
+    }
+
+    /// Adds the symmetric cipher unique identifier for the [Public] structure
+    /// to the builder.
+    ///
+    /// # Details
+    /// This is required if the public algorithm is set to
+    /// [SymCipher][`crate::interface_types::algorithm::PublicAlgorithm::SymCipher].
+    pub fn with_symmetric_cipher_unique_identifier(
+        mut self,
+        symmetric_cipher_unique_identifier: &Digest,
+    ) -> Self {
+        self.symmetric_cipher_unique_identifier = Some(symmetric_cipher_unique_identifier.clone());
+        self
+    }
+
+    /// Builds the [Public] structure.
+    ///
+    /// # Errors
+    /// Will return error if the public algorithm, object attributes or name
+    /// hashing algorithm have not been set or if the parameters and unique identifier
+    /// does not match the selected public algorithm.
+    pub fn build(self) -> Result<Public> {
+        let algorithm = self.public_algorithm.ok_or_else(|| {
+            error!("Algorithm is required and has not been set in the PublicBuilder");
+            Error::local_error(WrapperErrorKind::ParamsMissing)
+        })?;
+
+        let object_attributes = self.object_attributes.ok_or_else(|| {
+            error!("ObjectAttributes is required and has not been set in the PublicBuilder");
+            Error::local_error(WrapperErrorKind::ParamsMissing)
+        })?;
+
+        let name_hashing_algorithm = self.name_hashing_algorithm.ok_or_else(|| {
+            error!(
+                "The name hashing algorithm is required and has not been set in the PublicBuilder"
+            );
+            Error::local_error(WrapperErrorKind::ParamsMissing)
+        })?;
+
+        let auth_policy = self.auth_policy.unwrap_or_default();
+
+        match algorithm {
+            PublicAlgorithm::Rsa => {
+                Ok(Public::Rsa {
+                    object_attributes,
+                    name_hashing_algorithm,
+                    auth_policy,
+                    parameters: self.rsa_parameters.ok_or_else(|| {
+                        error!("RSA parameters have not been set in the PublicBuilder even though the RSA algorithm had been selected.");
+                        Error::local_error(WrapperErrorKind::ParamsMissing)
+                    })?,
+                    unique: self.rsa_unique_identifier.ok_or_else(|| {
+                        error!("RSA unique identifier has not been set in the PublicBuilder even though the RSA algorithm had been selected.");
+                        Error::local_error(WrapperErrorKind::ParamsMissing)
+                    })?,
+                })
+            },
+            PublicAlgorithm::KeyedHash => {
+                Ok(Public::KeyedHash {
+                    object_attributes,
+                    name_hashing_algorithm,
+                    auth_policy,
+                    parameters: self.keyed_hash_parameters.ok_or_else(|| {
+                        error!("Keyed hash parameters have not been set in the Public Builder even though the keyed hash algorithm have been selected");
+                        Error::local_error(WrapperErrorKind::ParamsMissing)
+                    })?,
+                    unique: self.keyed_hash_unique_identifier.ok_or_else(|| {
+                        error!("Keyed hash unique identifier have not been set in the Public Builder even though the keyed hash algorithm have been selected");
+                        Error::local_error(WrapperErrorKind::ParamsMissing)
+                    })?,
+                })
+            },
+            PublicAlgorithm::Ecc => {
+                Ok(Public::Ecc {
+                    object_attributes,
+                    name_hashing_algorithm,
+                    auth_policy,
+                    parameters: self.ecc_parameters.ok_or_else(|| {
+                        error!("ECC parameters have not been set in the Public Builder even though the ECC algorithm have been selected");
+                        Error::local_error(WrapperErrorKind::ParamsMissing)
+                    })?,
+                    unique: self.ecc_unique_identifier.ok_or_else(|| {
+                        error!("ECC unique identifier have not been set in the Public Builder even though the ECC algorithm have been selected");
+                        Error::local_error(WrapperErrorKind::ParamsMissing)
+                    })?,
+                })
+            }
+            PublicAlgorithm::SymCipher => {
+                Ok(Public::SymCipher {
+                    object_attributes,
+                    name_hashing_algorithm,
+                    auth_policy,
+                    parameters: self.symmetric_cipher_parameters.ok_or_else(|| {
+                        error!("Symmetric cipher parameters have not been set in the Public Builder even though the symmetric cipher algorithm have been selected");
+                        Error::local_error(WrapperErrorKind::ParamsMissing)
+                    })?,
+                    unique: self.symmetric_cipher_unique_identifier.ok_or_else(|| {
+                        error!("Symmetric cipher unique identifier have not been set in the Public Builder even though the symmetric cipher algorithm have been selected");
+                        Error::local_error(WrapperErrorKind::ParamsMissing)
+                    })?,
+                })
+            }
+        }
+    }
+}
+
+/// Enum representing the Public structure.
+///
+/// # Details
+/// This corresponds to TPM2B_PUBLIC
+#[derive(Debug, Clone)]
+pub enum Public {
+    Rsa {
+        object_attributes: ObjectAttributes,
+        name_hashing_algorithm: HashingAlgorithm,
+        auth_policy: Digest,
+        parameters: PublicRsaParameters,
+        unique: PublicKeyRsa,
+    },
+    KeyedHash {
+        object_attributes: ObjectAttributes,
+        name_hashing_algorithm: HashingAlgorithm,
+        auth_policy: Digest,
+        parameters: PublicKeyedHashParameters,
+        unique: Digest,
+    },
+    Ecc {
+        object_attributes: ObjectAttributes,
+        name_hashing_algorithm: HashingAlgorithm,
+        auth_policy: Digest,
+        parameters: PublicEccParameters,
+        unique: EccPoint,
+    },
+    SymCipher {
+        object_attributes: ObjectAttributes,
+        name_hashing_algorithm: HashingAlgorithm,
+        auth_policy: Digest,
+        parameters: SymmetricCipherParameters,
+        unique: Digest,
+    },
+}
+
+impl Public {
+    /// Returns the object attributes
+    pub fn object_attributes(&self) -> ObjectAttributes {
+        match self {
+            Public::Rsa {
+                object_attributes, ..
+            } => *object_attributes,
+            Public::KeyedHash {
+                object_attributes, ..
+            } => *object_attributes,
+            Public::Ecc {
+                object_attributes, ..
+            } => *object_attributes,
+            Public::SymCipher {
+                object_attributes, ..
+            } => *object_attributes,
+        }
+    }
+
+    /// Returns the name hashing algorithm
+    pub fn name_hashing_algorithm(&self) -> HashingAlgorithm {
+        match self {
+            Public::Rsa {
+                object_attributes: _,
+                name_hashing_algorithm,
+                ..
+            } => *name_hashing_algorithm,
+            Public::KeyedHash {
+                object_attributes: _,
+                name_hashing_algorithm,
+                ..
+            } => *name_hashing_algorithm,
+            Public::Ecc {
+                object_attributes: _,
+                name_hashing_algorithm,
+                ..
+            } => *name_hashing_algorithm,
+            Public::SymCipher {
+                object_attributes: _,
+                name_hashing_algorithm,
+                ..
+            } => *name_hashing_algorithm,
+        }
+    }
+}
+
+impl From<Public> for TPM2B_PUBLIC {
+    fn from(public: Public) -> Self {
+        match public {
+            Public::Rsa {
+                object_attributes,
+                name_hashing_algorithm,
+                auth_policy,
+                parameters,
+                unique,
+            } => TPM2B_PUBLIC {
+                size: std::mem::size_of::<TPMT_PUBLIC>()
+                    .try_into()
+                    .expect("Failed to convert usize to u16"), // should not fail on valid targets
+                publicArea: TPMT_PUBLIC {
+                    type_: PublicAlgorithm::Rsa.into(),
+                    nameAlg: name_hashing_algorithm.into(),
+                    objectAttributes: object_attributes.into(),
+                    authPolicy: auth_policy.into(),
+                    parameters: TPMU_PUBLIC_PARMS {
+                        rsaDetail: parameters.into(),
+                    },
+                    unique: TPMU_PUBLIC_ID { rsa: unique.into() },
+                },
+            },
+            Public::KeyedHash {
+                object_attributes,
+                name_hashing_algorithm,
+                auth_policy,
+                parameters,
+                unique,
+            } => TPM2B_PUBLIC {
+                size: std::mem::size_of::<TPMT_PUBLIC>()
+                    .try_into()
+                    .expect("Failed to convert usize to u16"), // should not fail on valid targets
+                publicArea: TPMT_PUBLIC {
+                    type_: PublicAlgorithm::KeyedHash.into(),
+                    nameAlg: name_hashing_algorithm.into(),
+                    objectAttributes: object_attributes.into(),
+                    authPolicy: auth_policy.into(),
+                    parameters: TPMU_PUBLIC_PARMS {
+                        keyedHashDetail: parameters.into(),
+                    },
+                    unique: TPMU_PUBLIC_ID {
+                        keyedHash: unique.into(),
+                    },
+                },
+            },
+            Public::Ecc {
+                object_attributes,
+                name_hashing_algorithm,
+                auth_policy,
+                parameters,
+                unique,
+            } => TPM2B_PUBLIC {
+                size: std::mem::size_of::<TPMT_PUBLIC>()
+                    .try_into()
+                    .expect("Failed to convert usize to u16"), // should not fail on valid targets
+                publicArea: TPMT_PUBLIC {
+                    type_: PublicAlgorithm::Ecc.into(),
+                    nameAlg: name_hashing_algorithm.into(),
+                    objectAttributes: object_attributes.into(),
+                    authPolicy: auth_policy.into(),
+                    parameters: TPMU_PUBLIC_PARMS {
+                        eccDetail: parameters.into(),
+                    },
+                    unique: TPMU_PUBLIC_ID { ecc: unique.into() },
+                },
+            },
+            Public::SymCipher {
+                object_attributes,
+                name_hashing_algorithm,
+                auth_policy,
+                parameters,
+                unique,
+            } => TPM2B_PUBLIC {
+                size: std::mem::size_of::<TPMT_PUBLIC>()
+                    .try_into()
+                    .expect("Failed to convert usize to u16"), // should not fail on valid targets
+                publicArea: TPMT_PUBLIC {
+                    type_: PublicAlgorithm::SymCipher.into(),
+                    nameAlg: name_hashing_algorithm.into(),
+                    objectAttributes: object_attributes.into(),
+                    authPolicy: auth_policy.into(),
+                    parameters: TPMU_PUBLIC_PARMS {
+                        symDetail: parameters.into(),
+                    },
+                    unique: TPMU_PUBLIC_ID { sym: unique.into() },
+                },
+            },
+        }
+    }
+}
+
+impl TryFrom<TPM2B_PUBLIC> for Public {
+    type Error = Error;
+
+    fn try_from(tpm2b_public: TPM2B_PUBLIC) -> Result<Self> {
+        match PublicAlgorithm::try_from(tpm2b_public.publicArea.type_)? {
+            PublicAlgorithm::Rsa => Ok(Public::Rsa {
+                object_attributes: tpm2b_public.publicArea.objectAttributes.into(),
+                name_hashing_algorithm: tpm2b_public.publicArea.nameAlg.try_into()?,
+                auth_policy: tpm2b_public.publicArea.authPolicy.try_into()?,
+                parameters: unsafe { tpm2b_public.publicArea.parameters.rsaDetail }.try_into()?,
+                unique: unsafe { tpm2b_public.publicArea.unique.rsa }.try_into()?,
+            }),
+            PublicAlgorithm::KeyedHash => Ok(Public::KeyedHash {
+                object_attributes: tpm2b_public.publicArea.objectAttributes.into(),
+                name_hashing_algorithm: tpm2b_public.publicArea.nameAlg.try_into()?,
+                auth_policy: tpm2b_public.publicArea.authPolicy.try_into()?,
+                parameters: unsafe { tpm2b_public.publicArea.parameters.keyedHashDetail }
+                    .try_into()?,
+                unique: unsafe { tpm2b_public.publicArea.unique.keyedHash }.try_into()?,
+            }),
+            PublicAlgorithm::Ecc => Ok(Public::Ecc {
+                object_attributes: tpm2b_public.publicArea.objectAttributes.into(),
+                name_hashing_algorithm: tpm2b_public.publicArea.nameAlg.try_into()?,
+                auth_policy: tpm2b_public.publicArea.authPolicy.try_into()?,
+                parameters: unsafe { tpm2b_public.publicArea.parameters.eccDetail }.try_into()?,
+                unique: unsafe { tpm2b_public.publicArea.unique.ecc }.try_into()?,
+            }),
+            PublicAlgorithm::SymCipher => Ok(Public::SymCipher {
+                object_attributes: tpm2b_public.publicArea.objectAttributes.into(),
+                name_hashing_algorithm: tpm2b_public.publicArea.nameAlg.try_into()?,
+                auth_policy: tpm2b_public.publicArea.authPolicy.try_into()?,
+                parameters: unsafe { tpm2b_public.publicArea.parameters.symDetail }.try_into()?,
+                unique: unsafe { tpm2b_public.publicArea.unique.sym }.try_into()?,
+            }),
+        }
+    }
+}

--- a/tss-esapi/src/structures/buffers/public/ecc.rs
+++ b/tss-esapi/src/structures/buffers/public/ecc.rs
@@ -1,0 +1,270 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    interface_types::{algorithm::EccSchemeAlgorithm, ecc::EccCurve},
+    structures::{EccScheme, KeyDerivationFunctionScheme, SymmetricDefinitionObject},
+    tss2_esys::TPMS_ECC_PARMS,
+    Error, Result, WrapperErrorKind,
+};
+use log::error;
+use std::convert::{TryFrom, TryInto};
+
+/// Builder for PublicEccParameters.
+#[derive(Copy, Clone, Debug)]
+pub struct PublicEccParametersBuilder {
+    symmetric: Option<SymmetricDefinitionObject>,
+    ecc_scheme: Option<EccScheme>,
+    ecc_curve: Option<EccCurve>,
+    key_derivation_function_scheme: Option<KeyDerivationFunctionScheme>,
+    is_signing_key: bool,
+    is_decryption_key: bool,
+    restricted: bool,
+}
+
+impl PublicEccParametersBuilder {
+    pub const fn new() -> Self {
+        PublicEccParametersBuilder {
+            symmetric: None,
+            ecc_scheme: None,
+            ecc_curve: None,
+            key_derivation_function_scheme: None,
+            is_signing_key: false,
+            is_decryption_key: false,
+            restricted: false,
+        }
+    }
+
+    /// Create parameters for a restricted decryption key (i.e. a storage key)
+    pub fn new_restricted_decryption_key(
+        symmetric: SymmetricDefinitionObject,
+        curve: EccCurve,
+    ) -> Self {
+        PublicEccParametersBuilder {
+            symmetric: Some(symmetric),
+            ecc_scheme: Some(EccScheme::Null),
+            ecc_curve: Some(curve),
+            key_derivation_function_scheme: Some(KeyDerivationFunctionScheme::Null),
+            is_signing_key: false,
+            is_decryption_key: true,
+            restricted: true,
+        }
+    }
+
+    /// Create parameters for an unrestricted signing key
+    pub fn new_unrestricted_signing_key(scheme: EccScheme, curve: EccCurve) -> Self {
+        PublicEccParametersBuilder {
+            symmetric: None,
+            ecc_scheme: Some(scheme),
+            ecc_curve: Some(curve),
+            key_derivation_function_scheme: Some(KeyDerivationFunctionScheme::Null),
+            is_signing_key: true,
+            is_decryption_key: false,
+            restricted: false,
+        }
+    }
+
+    /// Adds a [SymmetricDefinitionObject] to the [PublicEccParametersBuilder].
+    pub const fn with_symmetric(mut self, symmetric: SymmetricDefinitionObject) -> Self {
+        self.symmetric = Some(symmetric);
+        self
+    }
+
+    /// Adds a [EccScheme] to the [PublicEccParametersBuilder].
+    pub const fn with_ecc_scheme(mut self, ecc_scheme: EccScheme) -> Self {
+        self.ecc_scheme = Some(ecc_scheme);
+        self
+    }
+
+    /// Adds [EccCurve] to the [PublicEccParametersBuilder].
+    pub const fn with_curve(mut self, ecc_curve: EccCurve) -> Self {
+        self.ecc_curve = Some(ecc_curve);
+        self
+    }
+
+    /// Adds [KeyDerivationFunctionScheme] to the [PublicEccParametersBuilder].
+    pub const fn with_key_derivation_function_scheme(
+        mut self,
+        key_derivation_function_scheme: KeyDerivationFunctionScheme,
+    ) -> Self {
+        self.key_derivation_function_scheme = Some(key_derivation_function_scheme);
+        self
+    }
+
+    /// Adds a flag that indicates if the key is going to be used
+    /// for signing to the [PublicEccParametersBuilder].
+    ///
+    /// # Arguments
+    /// * `set` - `true` inidcates that the key is going to be used for signing operations.
+    ///           `false` indicates that the key is not going to be used for signing operations.
+    pub const fn with_is_signing_key(mut self, set: bool) -> Self {
+        self.is_signing_key = set;
+        self
+    }
+
+    /// Adds a flag that indicates if the key is going to be used for
+    /// decryption to the [PublicEccParametersBuilder].
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the key is going to be used for decryption operations.
+    ///           `false` indicates that the key is not going to be used for decryption operations.
+    pub const fn with_is_decryption_key(mut self, set: bool) -> Self {
+        self.is_decryption_key = set;
+        self
+    }
+
+    /// Adds a flag that inidcates if the key is going to be restrictied to
+    /// the [PublicEccParametersBuilder].
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that it is going to be a restricted key.
+    ///           `false` indicates that it is going to be a non restricted key.
+    pub const fn with_restricted(mut self, set: bool) -> Self {
+        self.restricted = set;
+        self
+    }
+
+    /// Build an object given the previously provded parameters.
+    ///
+    /// The only mandatory parameters are the asymmetric scheme and the elliptic curve.
+    ///
+    /// # Errors
+    /// * if no asymmetric scheme is set, `ParamsMissing` wrapper error is returned.
+    /// * if the `for_signing`, `for_decryption` and `restricted` parameters are
+    /// inconsistent with the rest of the parameters, `InconsistentParams` wrapper
+    /// error is returned
+    pub fn build(self) -> Result<PublicEccParameters> {
+        let ecc_scheme = self.ecc_scheme.ok_or_else(|| {
+            error!("Scheme is required nad has niot been set in the PublicEccParametersBuilder");
+            Error::local_error(WrapperErrorKind::ParamsMissing)
+        })?;
+
+        let ecc_curve = self.ecc_curve.ok_or_else(|| {
+            error!("Curve is required nad has niot been set in the PublicEccParametersBuilder");
+            Error::local_error(WrapperErrorKind::ParamsMissing)
+        })?;
+
+        let key_derivation_function_scheme = self.key_derivation_function_scheme.ok_or_else(|| {
+            error!("Key derivation function scheme is required nad has niot been set in the PublicEccParametersBuilder");
+            Error::local_error(WrapperErrorKind::ParamsMissing)
+        })?;
+
+        if self.restricted && self.is_decryption_key {
+            if self.symmetric.is_none() {
+                return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
+            }
+        } else if self.symmetric.is_some() {
+            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+        }
+        if self.is_decryption_key && self.is_signing_key {
+            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+        }
+
+        // TODO: Figure out if it actually should be allowed to not provide
+        // these parameters.
+        let symmetric_definition_object = self.symmetric.unwrap_or(SymmetricDefinitionObject::Null);
+
+        if self.is_signing_key
+            && ecc_scheme.algorithm() != EccSchemeAlgorithm::EcDsa
+            && ecc_scheme.algorithm() != EccSchemeAlgorithm::EcDaa
+            && ecc_scheme.algorithm() != EccSchemeAlgorithm::Sm2
+            && ecc_scheme.algorithm() != EccSchemeAlgorithm::EcSchnorr
+        {
+            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+        }
+
+        if self.is_decryption_key
+            && ecc_scheme.algorithm() != EccSchemeAlgorithm::Sm2
+            && ecc_scheme.algorithm() != EccSchemeAlgorithm::EcDh
+            && ecc_scheme.algorithm() != EccSchemeAlgorithm::EcMqv
+            && ecc_scheme.algorithm() != EccSchemeAlgorithm::Null
+        {
+            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+        }
+
+        if (ecc_curve == EccCurve::BnP256 || ecc_curve == EccCurve::BnP638)
+            && ecc_scheme.algorithm() != EccSchemeAlgorithm::EcDaa
+        {
+            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+        }
+
+        Ok(PublicEccParameters {
+            symmetric_definition_object,
+            ecc_scheme,
+            ecc_curve,
+            key_derivation_function_scheme,
+        })
+    }
+}
+
+/// Structure holding the ECC specific parameters.
+///
+/// # Details
+/// This corresponds to TPMS_ECC_PARMS.
+#[derive(Clone, Debug, Copy)]
+pub struct PublicEccParameters {
+    symmetric_definition_object: SymmetricDefinitionObject,
+    ecc_scheme: EccScheme,
+    ecc_curve: EccCurve,
+    key_derivation_function_scheme: KeyDerivationFunctionScheme,
+}
+
+impl PublicEccParameters {
+    /// Creates new EccParameters structure
+    pub const fn new(
+        symmetric_definition_object: SymmetricDefinitionObject,
+        ecc_scheme: EccScheme,
+        ecc_curve: EccCurve,
+        key_derivation_function_scheme: KeyDerivationFunctionScheme,
+    ) -> PublicEccParameters {
+        PublicEccParameters {
+            symmetric_definition_object,
+            ecc_scheme,
+            ecc_curve,
+            key_derivation_function_scheme,
+        }
+    }
+
+    /// Returns the [SymmetricDefinitionObject].
+    pub const fn symmetric_definition_object(&self) -> SymmetricDefinitionObject {
+        self.symmetric_definition_object
+    }
+
+    /// Returns the [EccScheme]
+    pub const fn ecc_scheme(&self) -> EccScheme {
+        self.ecc_scheme
+    }
+
+    /// Returns the [EccCurve]
+    pub const fn ecc_curve(&self) -> EccCurve {
+        self.ecc_curve
+    }
+
+    /// Returns the [KeyDerivationFunctionScheme]
+    pub const fn key_derivation_function_scheme(&self) -> KeyDerivationFunctionScheme {
+        self.key_derivation_function_scheme
+    }
+}
+
+impl From<PublicEccParameters> for TPMS_ECC_PARMS {
+    fn from(public_ecc_parameters: PublicEccParameters) -> Self {
+        TPMS_ECC_PARMS {
+            symmetric: public_ecc_parameters.symmetric_definition_object.into(),
+            scheme: public_ecc_parameters.ecc_scheme.into(),
+            curveID: public_ecc_parameters.ecc_curve.into(),
+            kdf: public_ecc_parameters.key_derivation_function_scheme.into(),
+        }
+    }
+}
+
+impl TryFrom<TPMS_ECC_PARMS> for PublicEccParameters {
+    type Error = Error;
+
+    fn try_from(tpms_ecc_parms: TPMS_ECC_PARMS) -> Result<PublicEccParameters> {
+        Ok(PublicEccParameters {
+            symmetric_definition_object: tpms_ecc_parms.symmetric.try_into()?,
+            ecc_scheme: tpms_ecc_parms.scheme.try_into()?,
+            ecc_curve: tpms_ecc_parms.curveID.try_into()?,
+            key_derivation_function_scheme: tpms_ecc_parms.kdf.try_into()?,
+        })
+    }
+}

--- a/tss-esapi/src/structures/buffers/public/keyed_hash.rs
+++ b/tss-esapi/src/structures/buffers/public/keyed_hash.rs
@@ -1,0 +1,39 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{structures::KeyedHashScheme, tss2_esys::TPMS_KEYEDHASH_PARMS, Error, Result};
+use std::convert::{TryFrom, TryInto};
+
+/// Keyed hash parameters
+///
+/// # Details
+/// Corresponds to TPMS_KEYEDHASH_PARMS
+///
+/// These keyed hash parameters are specific to the [`crate::structures::Public`] type.
+#[derive(Clone, Copy, Debug)]
+pub struct PublicKeyedHashParameters {
+    keyed_hash_scheme: KeyedHashScheme,
+}
+
+impl PublicKeyedHashParameters {
+    pub const fn new(keyed_hash_scheme: KeyedHashScheme) -> PublicKeyedHashParameters {
+        PublicKeyedHashParameters { keyed_hash_scheme }
+    }
+}
+
+impl TryFrom<TPMS_KEYEDHASH_PARMS> for PublicKeyedHashParameters {
+    type Error = Error;
+
+    fn try_from(tpms_keyed_hash_parms: TPMS_KEYEDHASH_PARMS) -> Result<Self> {
+        Ok(PublicKeyedHashParameters {
+            keyed_hash_scheme: tpms_keyed_hash_parms.scheme.try_into()?,
+        })
+    }
+}
+
+impl From<PublicKeyedHashParameters> for TPMS_KEYEDHASH_PARMS {
+    fn from(public_keyed_hash_prams: PublicKeyedHashParameters) -> Self {
+        TPMS_KEYEDHASH_PARMS {
+            scheme: public_keyed_hash_prams.keyed_hash_scheme.into(),
+        }
+    }
+}

--- a/tss-esapi/src/structures/buffers/public/rsa.rs
+++ b/tss-esapi/src/structures/buffers/public/rsa.rs
@@ -1,0 +1,356 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    interface_types::{algorithm::RsaSchemeAlgorithm, key_bits::RsaKeyBits},
+    structures::{RsaScheme, SymmetricDefinitionObject},
+    tss2_esys::{TPMS_RSA_PARMS, UINT32},
+    Error, Result, WrapperErrorKind,
+};
+use log::error;
+use std::convert::{TryFrom, TryInto};
+
+/// Builder for `TPMS_RSA_PARMS` values.
+// Most of the field types are from bindgen which does not implement Debug on them.
+#[allow(missing_debug_implementations)]
+#[derive(Copy, Clone, Default)]
+pub struct PublicRsaParametersBuilder {
+    symmetric: Option<SymmetricDefinitionObject>,
+    rsa_scheme: Option<RsaScheme>,
+    key_bits: Option<RsaKeyBits>,
+    exponent: Option<RsaExponent>,
+    is_signing_key: bool,
+    is_decryption_key: bool,
+    restricted: bool,
+}
+
+impl PublicRsaParametersBuilder {
+    /// Creates a new [PublicRsaParametersBuilder]
+    pub const fn new() -> Self {
+        PublicRsaParametersBuilder {
+            symmetric: None,
+            rsa_scheme: None,
+            key_bits: None,
+            exponent: None,
+            is_signing_key: false,
+            is_decryption_key: false,
+            restricted: false,
+        }
+    }
+
+    /// Creates a [PublicRsaParametersBuilder] that is setup
+    /// to build a restructed decryption key.
+    pub fn new_restricted_decryption_key(
+        symmetric: SymmetricDefinitionObject,
+        key_bits: RsaKeyBits,
+        exponent: RsaExponent,
+    ) -> Self {
+        PublicRsaParametersBuilder {
+            symmetric: Some(symmetric),
+            rsa_scheme: Some(RsaScheme::Null),
+            key_bits: Some(key_bits),
+            exponent: Some(exponent),
+            is_signing_key: false,
+            is_decryption_key: true,
+            restricted: true,
+        }
+    }
+
+    /// Creates a [PublicRsaParametersBuilder] that is setup
+    /// to build an unrestricted signing key.
+    pub const fn new_unrestricted_signing_key(
+        rsa_scheme: RsaScheme,
+        key_bits: RsaKeyBits,
+        exponent: RsaExponent,
+    ) -> Self {
+        PublicRsaParametersBuilder {
+            symmetric: None,
+            rsa_scheme: Some(rsa_scheme),
+            key_bits: Some(key_bits),
+            exponent: Some(exponent),
+            is_signing_key: true,
+            is_decryption_key: false,
+            restricted: false,
+        }
+    }
+
+    /// Adds a [SymmetricDefinitionObject] to the [PublicRsaParametersBuilder].
+    pub const fn with_symmetric(mut self, symmetric: SymmetricDefinitionObject) -> Self {
+        self.symmetric = Some(symmetric);
+        self
+    }
+
+    /// Adds a [RsaScheme] to the [PublicRsaParametersBuilder].
+    pub const fn with_scheme(mut self, rsa_scheme: RsaScheme) -> Self {
+        self.rsa_scheme = Some(rsa_scheme);
+        self
+    }
+
+    /// Adds [RsaKeyBits] to the [PublicRsaParametersBuilder].
+    pub const fn with_key_bits(mut self, key_bits: RsaKeyBits) -> Self {
+        self.key_bits = Some(key_bits);
+        self
+    }
+
+    /// Adds [RsaExponent] to the [PublicRsaParametersBuilder].
+    pub const fn with_exponent(mut self, exponent: RsaExponent) -> Self {
+        self.exponent = Some(exponent);
+        self
+    }
+
+    /// Adds a flag that indicates if the key is going to be used
+    /// for signing to the [PublicRsaParametersBuilder].
+    ///
+    /// # Arguments
+    /// * `set` - `true` inidcates that the key is going to be used for signing operations.
+    ///           `false` indicates that the key is not going to be used for signing operations.
+    pub const fn with_is_signing_key(mut self, set: bool) -> Self {
+        self.is_signing_key = set;
+        self
+    }
+
+    /// Adds a flag that indicates if the key is going to be used for
+    /// decryption to the [PublicRsaParametersBuilder].
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that the key is going to be used for decryption operations.
+    ///           `false` indicates that the key is not going to be used for decryption operations.
+    pub const fn with_is_decryption_key(mut self, set: bool) -> Self {
+        self.is_decryption_key = set;
+        self
+    }
+
+    /// Adds a flag that inidcates if the key is going to be restrictied to
+    /// the [PublicRsaParametersBuilder].
+    ///
+    /// # Arguments
+    /// * `set` - `true` indicates that it is going to be a restricted key.
+    ///           `false` indicates that it is going to be a non restricted key.
+    pub const fn with_restricted(mut self, set: bool) -> Self {
+        self.restricted = set;
+        self
+    }
+
+    /// Build an object given the previously provded parameters.
+    ///
+    /// The only mandatory parameter is the asymmetric scheme.
+    ///
+    /// # Errors
+    /// * if no asymmetric scheme is set, `ParamsMissing` wrapper error is returned.
+    /// * if the `for_signing`, `for_decryption` and `restricted` parameters are
+    /// inconsistent with the rest of the parameters, `InconsistentParams` wrapper
+    /// error is returned
+    pub fn build(self) -> Result<PublicRsaParameters> {
+        let rsa_scheme = self.rsa_scheme.ok_or_else(|| {
+            error!("Scheme parameter is required and has not been set in the PublicRsaParametersBuilder");
+            Error::local_error(WrapperErrorKind::ParamsMissing)
+        })?;
+
+        let key_bits = self.key_bits.ok_or_else(|| {
+            error!("Key bits parameter is required and has not been set in the PublicRsaParametersBuilder");
+            Error::local_error(WrapperErrorKind::ParamsMissing)
+        })?;
+
+        if self.restricted && self.is_decryption_key {
+            if self.symmetric.is_none() {
+                error!("Symmetric parameter has not been provided even though 'restricted' and 'is_decrypt_key' are set to true");
+                return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
+            }
+        } else if self.symmetric.is_some() {
+            error!("Found symmetric parameter, expected it to be None because 'restricted' and 'is_decrypt_key' are set to false");
+            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+        }
+
+        // TODO: Figure out if it actually should be allowed to not provide
+        // these parameters.
+        let symmetric_definition_object = self.symmetric.unwrap_or(SymmetricDefinitionObject::Null);
+        let exponent = self.exponent.unwrap_or_default();
+
+        if self.restricted {
+            if self.is_signing_key
+                && rsa_scheme.algorithm() != RsaSchemeAlgorithm::RsaPss
+                && rsa_scheme.algorithm() != RsaSchemeAlgorithm::RsaSsa
+            {
+                error!("Invalid rsa scheme algorithm provided with 'restricted' and 'is_signing_key' set to true");
+                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+            }
+
+            if self.is_decryption_key && rsa_scheme.algorithm() != RsaSchemeAlgorithm::Null {
+                error!("Invalid rsa scheme algorithm provided with 'restricted' and 'is_decryption_key' set to true");
+                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+            }
+        } else {
+            if self.is_decryption_key
+                && self.is_signing_key
+                && rsa_scheme.algorithm() != RsaSchemeAlgorithm::Null
+            {
+                error!("Invalid rsa scheme algorithm provided with 'restricted' set to false and 'is_decryption_key' and 'is_signing_key' set to true");
+                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+            }
+            if self.is_signing_key
+                && rsa_scheme.algorithm() != RsaSchemeAlgorithm::RsaPss
+                && rsa_scheme.algorithm() != RsaSchemeAlgorithm::RsaSsa
+                && rsa_scheme.algorithm() != RsaSchemeAlgorithm::Null
+            {
+                error!("Invalid rsa scheme algorithm provided with 'restricted' set to false and 'is_signing_key' set to true");
+                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+            }
+
+            if self.is_decryption_key
+                && rsa_scheme.algorithm() != RsaSchemeAlgorithm::RsaEs
+                && rsa_scheme.algorithm() != RsaSchemeAlgorithm::Oaep
+                && rsa_scheme.algorithm() != RsaSchemeAlgorithm::Null
+            {
+                error!("Invalid rsa scheme algorithm provided with 'restricted' set to false and 'is_decryption_key' set to true");
+                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+            }
+        }
+
+        Ok(PublicRsaParameters {
+            symmetric_definition_object,
+            rsa_scheme,
+            key_bits,
+            exponent,
+        })
+    }
+}
+
+/// Strucure used to hold the value of a RSA exponent
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub struct RsaExponent {
+    value: u32,
+}
+
+impl RsaExponent {
+    /// Function for creating a new RsaExponent
+    ///
+    /// # Errors
+    /// Will return an error if the value passed into the function
+    /// is not a valid RSA exponent.
+    pub fn create(value: u32) -> Result<Self> {
+        if !RsaExponent::is_valid(value) {
+            error!(
+                "Received invalid value {} when creating rsa exponent",
+                value,
+            );
+            return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
+        }
+        Ok(RsaExponent { value })
+    }
+
+    /// Method that returns the value of the rsa exponent.
+    pub const fn value(&self) -> u32 {
+        self.value
+    }
+
+    /// Function for checking if a value is valid rsa exponent.
+    pub fn is_valid(value: u32) -> bool {
+        (value > 2 && primal::is_prime(value.into())) || value == 0
+    }
+}
+
+impl Default for RsaExponent {
+    fn default() -> RsaExponent {
+        RsaExponent {
+            value: (1 << 16) + 1,
+        }
+    }
+}
+
+impl From<RsaExponent> for UINT32 {
+    fn from(rsa_exponent: RsaExponent) -> Self {
+        rsa_exponent.value
+    }
+}
+
+impl TryFrom<UINT32> for RsaExponent {
+    type Error = Error;
+
+    fn try_from(tpm_uint32_value: UINT32) -> Result<Self> {
+        if RsaExponent::is_valid(tpm_uint32_value) {
+            Ok(RsaExponent {
+                value: tpm_uint32_value,
+            })
+        } else {
+            error!(
+                "Received invalid rsa exponent value {}, from the TPM",
+                tpm_uint32_value,
+            );
+            Err(Error::WrapperError(WrapperErrorKind::WrongValueFromTpm))
+        }
+    }
+}
+
+/// Structure holding the RSA specific parameters.
+///
+/// # Details
+/// This corresponds to TPMS_RSA_PARMS
+///
+/// These rsa parameters are specific to the [`crate::structures::Public`] type.
+#[derive(Clone, Debug, Copy)]
+pub struct PublicRsaParameters {
+    symmetric_definition_object: SymmetricDefinitionObject,
+    rsa_scheme: RsaScheme,
+    key_bits: RsaKeyBits,
+    exponent: RsaExponent,
+}
+
+impl PublicRsaParameters {
+    /// Function for creating new [PublicRsaParameters] structure
+    pub const fn new(
+        symmetric_definition_object: SymmetricDefinitionObject,
+        rsa_scheme: RsaScheme,
+        key_bits: RsaKeyBits,
+        exponent: RsaExponent,
+    ) -> Self {
+        PublicRsaParameters {
+            symmetric_definition_object,
+            rsa_scheme,
+            key_bits,
+            exponent,
+        }
+    }
+
+    /// Returns the [SymmetricDefinitionObject].
+    pub const fn symmetric_definition_object(&self) -> SymmetricDefinitionObject {
+        self.symmetric_definition_object
+    }
+
+    /// Returns the [RsaScheme]
+    pub const fn rsa_scheme(&self) -> RsaScheme {
+        self.rsa_scheme
+    }
+
+    /// Returns the [RsaKeyBits]
+    pub const fn key_bits(&self) -> RsaKeyBits {
+        self.key_bits
+    }
+
+    /// Returns the exponent in the form of a [RsaExponent]
+    pub const fn exponent(&self) -> RsaExponent {
+        self.exponent
+    }
+}
+
+impl From<PublicRsaParameters> for TPMS_RSA_PARMS {
+    fn from(public_rsa_parameters: PublicRsaParameters) -> Self {
+        TPMS_RSA_PARMS {
+            symmetric: public_rsa_parameters.symmetric_definition_object.into(),
+            scheme: public_rsa_parameters.rsa_scheme.into(),
+            keyBits: public_rsa_parameters.key_bits.into(),
+            exponent: public_rsa_parameters.exponent.into(),
+        }
+    }
+}
+
+impl TryFrom<TPMS_RSA_PARMS> for PublicRsaParameters {
+    type Error = Error;
+
+    fn try_from(tpms_rsa_parms: TPMS_RSA_PARMS) -> Result<Self> {
+        Ok(PublicRsaParameters {
+            symmetric_definition_object: tpms_rsa_parms.symmetric.try_into()?,
+            rsa_scheme: tpms_rsa_parms.scheme.try_into()?,
+            key_bits: tpms_rsa_parms.keyBits.try_into()?,
+            exponent: tpms_rsa_parms.exponent.try_into()?,
+        })
+    }
+}

--- a/tss-esapi/src/structures/ecc/mod.rs
+++ b/tss-esapi/src/structures/ecc/mod.rs
@@ -1,6 +1,3 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-pub mod parameters;
-pub mod schemes;
-pub mod signature;
-pub mod symmetric;
+pub mod point;

--- a/tss-esapi/src/structures/ecc/point.rs
+++ b/tss-esapi/src/structures/ecc/point.rs
@@ -1,0 +1,57 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{structures::EccParameter, tss2_esys::TPMS_ECC_POINT, Error, Result};
+use std::convert::{TryFrom, TryInto};
+
+/// Structure holding ecc point information
+///
+/// # Details
+/// This corresponds to TPMS_ECC_POINT
+#[derive(Debug, Clone)]
+pub struct EccPoint {
+    x: EccParameter,
+    y: EccParameter,
+}
+
+impl EccPoint {
+    /// Creates a new ecc point
+    pub const fn new(x: EccParameter, y: EccParameter) -> Self {
+        EccPoint { x, y }
+    }
+
+    /// Returns x value as an [EccParameter] reference.
+    pub const fn x(&self) -> &EccParameter {
+        &self.x
+    }
+
+    /// Returns y value as an [EccParameter] reference.
+    pub const fn y(&self) -> &EccParameter {
+        &self.y
+    }
+}
+
+impl Default for EccPoint {
+    fn default() -> Self {
+        EccPoint::new(EccParameter::default(), EccParameter::default())
+    }
+}
+
+impl From<EccPoint> for TPMS_ECC_POINT {
+    fn from(ecc_point: EccPoint) -> Self {
+        TPMS_ECC_POINT {
+            x: ecc_point.x.into(),
+            y: ecc_point.y.into(),
+        }
+    }
+}
+
+impl TryFrom<TPMS_ECC_POINT> for EccPoint {
+    type Error = Error;
+
+    fn try_from(tpms_ecc_point: TPMS_ECC_POINT) -> Result<Self> {
+        Ok(EccPoint {
+            x: tpms_ecc_point.x.try_into()?,
+            y: tpms_ecc_point.y.try_into()?,
+        })
+    }
+}

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -34,31 +34,28 @@ pub use result::CreatePrimaryKeyResult;
 /// The sized buffers section
 /////////////////////////////////////////////////////////
 mod buffers;
-pub use self::buffers::auth::Auth;
-
-pub use self::buffers::digest::Digest;
-
-pub use self::buffers::max_buffer::MaxBuffer;
-
-pub use self::buffers::max_nv_buffer::MaxNvBuffer;
-
-pub use self::buffers::data::Data;
-
-pub use self::buffers::id_object::IDObject;
-
-pub use self::buffers::encrypted_secret::EncryptedSecret;
-
-pub use self::buffers::sensitive_data::SensitiveData;
-
-pub use self::buffers::private::Private;
-
-pub use self::buffers::public_key_rsa::PublicKeyRSA;
-
-pub use self::buffers::nonce::Nonce;
-
-pub use self::buffers::timeout::Timeout;
-
-pub use self::buffers::initial_value::InitialValue;
+pub use self::buffers::{
+    auth::Auth,
+    data::Data,
+    digest::Digest,
+    ecc_parameter::EccParameter,
+    encrypted_secret::EncryptedSecret,
+    id_object::IDObject,
+    initial_value::InitialValue,
+    max_buffer::MaxBuffer,
+    max_nv_buffer::MaxNvBuffer,
+    nonce::Nonce,
+    private::Private,
+    public::{
+        ecc::{PublicEccParameters, PublicEccParametersBuilder},
+        keyed_hash::PublicKeyedHashParameters,
+        rsa::{PublicRsaParameters, PublicRsaParametersBuilder, RsaExponent},
+        Public, PublicBuilder,
+    },
+    public_key_rsa::PublicKeyRsa,
+    sensitive_data::SensitiveData,
+    timeout::Timeout,
+};
 /////////////////////////////////////////////////////////
 /// The creation section
 /////////////////////////////////////////////////////////
@@ -107,7 +104,7 @@ pub mod pcr_selection_list {
 /// The parameters section
 /////////////////////////////////////////////////////////
 mod parameters;
-pub use self::parameters::{KeyedHashParameters, SymmetricCipherParameters};
+pub use self::parameters::SymmetricCipherParameters;
 /////////////////////////////////////////////////////////
 /// The tickets section
 /////////////////////////////////////////////////////////
@@ -123,6 +120,20 @@ pub use schemes::{HashScheme, HmacScheme, XorScheme};
 
 mod tagged;
 pub use tagged::{
-    schemes::KeyedHashScheme,
+    parameters::PublicParameters,
+    schemes::{
+        EccScheme, KeyDerivationFunctionScheme, KeyedHashScheme, RsaDecryptionScheme, RsaScheme,
+    },
+    signature::Signature,
     symmetric::{SymmetricDefinition, SymmetricDefinitionObject},
 };
+/////////////////////////////////////////////////////////
+/// ECC structures
+/////////////////////////////////////////////////////////
+mod ecc;
+pub use ecc::point::EccPoint;
+/////////////////////////////////////////////////////////
+/// Signatures structures
+/////////////////////////////////////////////////////////
+mod signatures;
+pub use signatures::{EccSignature, RsaSignature};

--- a/tss-esapi/src/structures/parameters.rs
+++ b/tss-esapi/src/structures/parameters.rs
@@ -2,44 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    structures::{KeyedHashScheme, SymmetricDefinitionObject},
-    tss2_esys::{TPMS_KEYEDHASH_PARMS, TPMS_SYMCIPHER_PARMS},
-    Error, Result,
+    structures::SymmetricDefinitionObject, tss2_esys::TPMS_SYMCIPHER_PARMS, Error, Result,
 };
+
 use std::convert::{TryFrom, TryInto};
-
-/// Keyed hash parameters
-///
-/// # Details
-/// Corresponds to TPMS_KEYEDHASH_PARMS
-#[derive(Clone, Copy, Debug)]
-pub struct KeyedHashParameters {
-    keyed_hash_scheme: KeyedHashScheme,
-}
-
-impl KeyedHashParameters {
-    pub const fn new(keyed_hash_scheme: KeyedHashScheme) -> KeyedHashParameters {
-        KeyedHashParameters { keyed_hash_scheme }
-    }
-}
-
-impl TryFrom<TPMS_KEYEDHASH_PARMS> for KeyedHashParameters {
-    type Error = Error;
-
-    fn try_from(tpms_keyed_hash_parms: TPMS_KEYEDHASH_PARMS) -> Result<Self> {
-        Ok(KeyedHashParameters {
-            keyed_hash_scheme: tpms_keyed_hash_parms.scheme.try_into()?,
-        })
-    }
-}
-
-impl From<KeyedHashParameters> for TPMS_KEYEDHASH_PARMS {
-    fn from(keyed_hash_prams: KeyedHashParameters) -> Self {
-        TPMS_KEYEDHASH_PARMS {
-            scheme: keyed_hash_prams.keyed_hash_scheme.into(),
-        }
-    }
-}
 
 /// Symmetric cipher parameters
 ///

--- a/tss-esapi/src/structures/result.rs
+++ b/tss-esapi/src/structures/result.rs
@@ -3,14 +3,13 @@
 
 use crate::{
     handles::KeyHandle,
-    structures::{CreationData, CreationTicket, Digest, Private},
-    tss2_esys::TPM2B_PUBLIC,
+    structures::{CreationData, CreationTicket, Digest, Private, Public},
 };
 
 #[allow(missing_debug_implementations)]
 pub struct CreateKeyResult {
     pub out_private: Private,
-    pub out_public: TPM2B_PUBLIC,
+    pub out_public: Public,
     pub creation_data: CreationData,
     pub creation_hash: Digest,
     pub creation_ticket: CreationTicket,
@@ -19,7 +18,7 @@ pub struct CreateKeyResult {
 #[allow(missing_debug_implementations)]
 pub struct CreatePrimaryKeyResult {
     pub key_handle: KeyHandle,
-    pub out_public: TPM2B_PUBLIC,
+    pub out_public: Public,
     pub creation_data: CreationData,
     pub creation_hash: Digest,
     pub creation_ticket: CreationTicket,

--- a/tss-esapi/src/structures/schemes.rs
+++ b/tss-esapi/src/structures/schemes.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     interface_types::algorithm::{HashingAlgorithm, KeyDerivationFunction},
-    tss2_esys::{TPMS_SCHEME_HASH, TPMS_SCHEME_HMAC, TPMS_SCHEME_XOR},
+    tss2_esys::{TPMS_SCHEME_ECDAA, TPMS_SCHEME_HASH, TPMS_SCHEME_HMAC, TPMS_SCHEME_XOR},
     Error, Result,
 };
 use std::convert::{TryFrom, TryInto};
@@ -118,5 +118,55 @@ impl From<XorScheme> for TPMS_SCHEME_XOR {
             hashAlg: xor_scheme.hashing_algorithm.into(),
             kdf: xor_scheme.key_derivation_function.into(),
         }
+    }
+}
+
+/// Struct for holding the ECDAA scheme
+///
+/// # Details
+/// This corresponds to the TPMS_SCHEME_ECDAA
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EcDaaScheme {
+    hashing_algorithm: HashingAlgorithm,
+    count: u16,
+}
+
+impl EcDaaScheme {
+    /// Function for creating a new ECDAA scheme
+    pub const fn new(hashing_algorithm: HashingAlgorithm, count: u16) -> Self {
+        EcDaaScheme {
+            hashing_algorithm,
+            count,
+        }
+    }
+
+    /// Returns the hashing algorithm of the ECDAA scheme.
+    pub const fn hashing_algorithm(&self) -> HashingAlgorithm {
+        self.hashing_algorithm
+    }
+
+    /// Returns the count of the ECDAA.
+    pub const fn count(&self) -> u16 {
+        self.count
+    }
+}
+
+impl From<EcDaaScheme> for TPMS_SCHEME_ECDAA {
+    fn from(ec_daa_scheme: EcDaaScheme) -> Self {
+        TPMS_SCHEME_ECDAA {
+            hashAlg: ec_daa_scheme.hashing_algorithm.into(),
+            count: ec_daa_scheme.count,
+        }
+    }
+}
+
+impl TryFrom<TPMS_SCHEME_ECDAA> for EcDaaScheme {
+    type Error = Error;
+
+    fn try_from(tpms_scheme_ecdaa: TPMS_SCHEME_ECDAA) -> Result<Self> {
+        Ok(EcDaaScheme {
+            hashing_algorithm: tpms_scheme_ecdaa.hashAlg.try_into()?,
+            count: tpms_scheme_ecdaa.count,
+        })
     }
 }

--- a/tss-esapi/src/structures/signatures.rs
+++ b/tss-esapi/src/structures/signatures.rs
@@ -1,0 +1,139 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    interface_types::algorithm::HashingAlgorithm,
+    structures::{EccParameter, PublicKeyRsa},
+    tss2_esys::{TPMS_SIGNATURE_ECC, TPMS_SIGNATURE_RSA},
+    Error, Result, WrapperErrorKind,
+};
+use log::error;
+use std::convert::{TryFrom, TryInto};
+
+/// Type holding RSA signature information.
+#[derive(Debug, Clone)]
+pub struct RsaSignature {
+    hashing_algorithm: HashingAlgorithm,
+    signature: PublicKeyRsa,
+}
+
+impl RsaSignature {
+    /// Creates new RSA signature
+    ///
+    /// # Errors
+    /// Using [Null][`HashingAlgorithm::Null`] will cause an error.
+    pub fn create(hashing_algorithm: HashingAlgorithm, signature: PublicKeyRsa) -> Result<Self> {
+        if hashing_algorithm == HashingAlgorithm::Null {
+            error!("Hashing algorithm Null is not allowed in RsaSignature");
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(RsaSignature {
+            hashing_algorithm,
+            signature,
+        })
+    }
+
+    /// Returns the hashing algorithm
+    pub const fn hashing_algorithm(&self) -> HashingAlgorithm {
+        self.hashing_algorithm
+    }
+
+    /// Returns the signature
+    pub const fn signature(&self) -> &PublicKeyRsa {
+        &self.signature
+    }
+}
+
+impl From<RsaSignature> for TPMS_SIGNATURE_RSA {
+    fn from(rsa_signature: RsaSignature) -> Self {
+        TPMS_SIGNATURE_RSA {
+            hash: rsa_signature.hashing_algorithm.into(),
+            sig: rsa_signature.signature.into(),
+        }
+    }
+}
+
+impl TryFrom<TPMS_SIGNATURE_RSA> for RsaSignature {
+    type Error = Error;
+
+    fn try_from(tpms_signature_rsa: TPMS_SIGNATURE_RSA) -> Result<Self> {
+        let hashing_algorithm = tpms_signature_rsa.hash.try_into()?;
+        if hashing_algorithm == HashingAlgorithm::Null {
+            error!("Received invalid hashing algorithm Null from the tpm in the RSA signature.");
+            return Err(Error::local_error(WrapperErrorKind::WrongValueFromTpm));
+        }
+
+        Ok(RsaSignature {
+            hashing_algorithm,
+            signature: tpms_signature_rsa.sig.try_into()?,
+        })
+    }
+}
+
+/// Type holding ECC signature information.
+#[derive(Debug, Clone)]
+pub struct EccSignature {
+    hashing_algorithm: HashingAlgorithm,
+    signature_r: EccParameter,
+    signature_s: EccParameter,
+}
+
+impl EccSignature {
+    /// Creates new ECC signature
+    pub fn create(
+        hashing_algorithm: HashingAlgorithm,
+        signature_r: EccParameter,
+        signature_s: EccParameter,
+    ) -> Result<Self> {
+        if hashing_algorithm == HashingAlgorithm::Null {
+            error!("Hashing algorithm Null is not allowed in RsaSignature");
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(EccSignature {
+            hashing_algorithm,
+            signature_r,
+            signature_s,
+        })
+    }
+
+    /// Returns the hashing algorithm
+    pub const fn hashing_algorithm(&self) -> HashingAlgorithm {
+        self.hashing_algorithm
+    }
+
+    /// Returns signature r
+    pub const fn signature_r(&self) -> &EccParameter {
+        &self.signature_r
+    }
+
+    /// Returns signature s
+    pub const fn signature_s(&self) -> &EccParameter {
+        &self.signature_s
+    }
+}
+
+impl From<EccSignature> for TPMS_SIGNATURE_ECC {
+    fn from(ecc_signature: EccSignature) -> Self {
+        TPMS_SIGNATURE_ECC {
+            hash: ecc_signature.hashing_algorithm.into(),
+            signatureR: ecc_signature.signature_r.into(),
+            signatureS: ecc_signature.signature_s.into(),
+        }
+    }
+}
+
+impl TryFrom<TPMS_SIGNATURE_ECC> for EccSignature {
+    type Error = Error;
+
+    fn try_from(tpms_signature_ecc: TPMS_SIGNATURE_ECC) -> Result<Self> {
+        let hashing_algorithm = tpms_signature_ecc.hash.try_into()?;
+        if hashing_algorithm == HashingAlgorithm::Null {
+            error!("Received invalid hashing algorithm Null from the tpm in the ECC signature.");
+            return Err(Error::local_error(WrapperErrorKind::WrongValueFromTpm));
+        }
+        Ok(EccSignature {
+            hashing_algorithm,
+            signature_r: tpms_signature_ecc.signatureR.try_into()?,
+            signature_s: tpms_signature_ecc.signatureS.try_into()?,
+        })
+    }
+}

--- a/tss-esapi/src/structures/tagged/parameters.rs
+++ b/tss-esapi/src/structures/tagged/parameters.rs
@@ -1,0 +1,88 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    interface_types::algorithm::PublicAlgorithm,
+    structures::{
+        PublicEccParameters, PublicKeyedHashParameters, PublicRsaParameters,
+        SymmetricCipherParameters,
+    },
+    tss2_esys::{TPMT_PUBLIC_PARMS, TPMU_PUBLIC_PARMS},
+    Error, Result,
+};
+use std::convert::{TryFrom, TryInto};
+/// Enum representing the public parameters structure.
+///
+/// # Details
+/// This corresponds to TPMT_PUBLIC_PARMS
+#[derive(Debug, Clone, Copy)]
+pub enum PublicParameters {
+    Rsa(PublicRsaParameters),
+    KeyedHash(PublicKeyedHashParameters),
+    Ecc(PublicEccParameters),
+    SymCipher(SymmetricCipherParameters),
+}
+
+impl PublicParameters {
+    /// Returns the algorithm
+    pub fn algorithm(&self) -> PublicAlgorithm {
+        match self {
+            PublicParameters::Rsa(_) => PublicAlgorithm::Rsa,
+            PublicParameters::KeyedHash(_) => PublicAlgorithm::KeyedHash,
+            PublicParameters::Ecc(_) => PublicAlgorithm::Ecc,
+            PublicParameters::SymCipher(_) => PublicAlgorithm::SymCipher,
+        }
+    }
+}
+
+impl From<PublicParameters> for TPMT_PUBLIC_PARMS {
+    fn from(public_parameters: PublicParameters) -> TPMT_PUBLIC_PARMS {
+        let algorithm = public_parameters.algorithm();
+        match public_parameters {
+            PublicParameters::Rsa(parameters) => TPMT_PUBLIC_PARMS {
+                type_: algorithm.into(),
+                parameters: TPMU_PUBLIC_PARMS {
+                    rsaDetail: parameters.into(),
+                },
+            },
+            PublicParameters::KeyedHash(parameters) => TPMT_PUBLIC_PARMS {
+                type_: algorithm.into(),
+                parameters: TPMU_PUBLIC_PARMS {
+                    keyedHashDetail: parameters.into(),
+                },
+            },
+            PublicParameters::Ecc(parameters) => TPMT_PUBLIC_PARMS {
+                type_: algorithm.into(),
+                parameters: TPMU_PUBLIC_PARMS {
+                    eccDetail: parameters.into(),
+                },
+            },
+            PublicParameters::SymCipher(parameters) => TPMT_PUBLIC_PARMS {
+                type_: algorithm.into(),
+                parameters: TPMU_PUBLIC_PARMS {
+                    symDetail: parameters.into(),
+                },
+            },
+        }
+    }
+}
+
+impl TryFrom<TPMT_PUBLIC_PARMS> for PublicParameters {
+    type Error = Error;
+
+    fn try_from(tpmt_public_parms: TPMT_PUBLIC_PARMS) -> Result<Self> {
+        match PublicAlgorithm::try_from(tpmt_public_parms.type_)? {
+            PublicAlgorithm::Rsa => Ok(PublicParameters::Rsa(
+                unsafe { tpmt_public_parms.parameters.rsaDetail }.try_into()?,
+            )),
+            PublicAlgorithm::KeyedHash => Ok(PublicParameters::KeyedHash(
+                unsafe { tpmt_public_parms.parameters.keyedHashDetail }.try_into()?,
+            )),
+            PublicAlgorithm::Ecc => Ok(PublicParameters::Ecc(
+                unsafe { tpmt_public_parms.parameters.eccDetail }.try_into()?,
+            )),
+            PublicAlgorithm::SymCipher => Ok(PublicParameters::SymCipher(
+                unsafe { tpmt_public_parms.parameters.symDetail }.try_into()?,
+            )),
+        }
+    }
+}

--- a/tss-esapi/src/structures/tagged/schemes.rs
+++ b/tss-esapi/src/structures/tagged/schemes.rs
@@ -1,12 +1,20 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    interface_types::algorithm::{HashingAlgorithm, KeyedHashSchemeAlgorithm},
-    structures::schemes::{HmacScheme, XorScheme},
-    tss2_esys::{TPMT_KEYEDHASH_SCHEME, TPMU_SCHEME_KEYEDHASH},
-    Error, Result,
+    interface_types::algorithm::{
+        EccSchemeAlgorithm, HashingAlgorithm, KeyDerivationFunction, KeyedHashSchemeAlgorithm,
+        RsaDecryptAlgorithm, RsaSchemeAlgorithm,
+    },
+    structures::schemes::{EcDaaScheme, HashScheme, HmacScheme, XorScheme},
+    tss2_esys::{
+        TPMT_ECC_SCHEME, TPMT_KDF_SCHEME, TPMT_KEYEDHASH_SCHEME, TPMT_RSA_DECRYPT, TPMT_RSA_SCHEME,
+        TPMU_ASYM_SCHEME, TPMU_KDF_SCHEME, TPMU_SCHEME_KEYEDHASH,
+    },
+    Error, Result, WrapperErrorKind,
 };
+use log::error;
 use std::convert::{TryFrom, TryInto};
+
 /// Enum representing the keyed hash scheme.
 ///
 /// # Details
@@ -58,6 +66,467 @@ impl TryFrom<TPMT_KEYEDHASH_SCHEME> for KeyedHashScheme {
                 hmac_scheme: unsafe { tpmt_keyedhash_scheme.details.hmac }.try_into()?,
             }),
             KeyedHashSchemeAlgorithm::Null => Ok(KeyedHashScheme::Null),
+        }
+    }
+}
+
+/// Enum representing the rsa scheme
+///
+/// # Details
+/// This corresponds to TPMT_RSA_SCHEME.
+/// This uses a subset of the TPMU_ASYM_SCHEME
+/// that has the TPMI_ALG_RSA_SCHEME as selector.
+#[derive(Clone, Copy, Debug)]
+pub enum RsaScheme {
+    RsaSsa(HashScheme),
+    RsaEs,
+    RsaPss(HashScheme),
+    Oaep(HashScheme),
+    Null,
+}
+
+impl RsaScheme {
+    /// Creates a new RsaScheme
+    ///
+    /// # Errors
+    /// - `InconsistentParams` error will be returned if no hashing algorithm
+    ///   is provided when creating RSA scheme of type RSA SSA, RSA PSS and OAEP
+    ///   or if a hashing algorithm is provided when creating a RSA scheme
+    pub fn create(
+        rsa_scheme_algorithm: RsaSchemeAlgorithm,
+        hashing_algorithm: Option<HashingAlgorithm>,
+    ) -> Result<RsaScheme> {
+        match rsa_scheme_algorithm {
+            RsaSchemeAlgorithm::RsaSsa => Ok(RsaScheme::RsaSsa(HashScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!(
+                        "Hashing algorithm is required when creating RSA scheme of type RSA SSA"
+                    );
+                    Error::local_error(WrapperErrorKind::InconsistentParams)
+                })?,
+            ))),
+            RsaSchemeAlgorithm::RsaEs => {
+                if hashing_algorithm.is_none() {
+                    Ok(RsaScheme::RsaEs)
+                } else {
+                    error!("A hashing algorithm shall not be provided when creating RSA scheme of type RSA ES");
+                    Err(Error::local_error(WrapperErrorKind::InconsistentParams))
+                }
+            }
+            RsaSchemeAlgorithm::RsaPss => Ok(RsaScheme::RsaPss(HashScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!(
+                        "Hashing algorithm is required when creating RSA scheme of type RSA PSS"
+                    );
+                    Error::local_error(WrapperErrorKind::InconsistentParams)
+                })?,
+            ))),
+            RsaSchemeAlgorithm::Oaep => Ok(RsaScheme::Oaep(HashScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!("Hashing algorithm is required when creating RSA scheme of type OAEP");
+                    Error::local_error(WrapperErrorKind::InconsistentParams)
+                })?,
+            ))),
+            RsaSchemeAlgorithm::Null => {
+                if hashing_algorithm.is_none() {
+                    Ok(RsaScheme::Null)
+                } else {
+                    error!("A hashing algorithm shall not be provided when creating RSA scheme of type Null");
+                    Err(Error::local_error(WrapperErrorKind::InconsistentParams))
+                }
+            }
+        }
+    }
+
+    /// Returns the rsa scheme algorithm
+    pub fn algorithm(&self) -> RsaSchemeAlgorithm {
+        match self {
+            RsaScheme::RsaSsa(_) => RsaSchemeAlgorithm::RsaSsa,
+            RsaScheme::RsaEs => RsaSchemeAlgorithm::RsaEs,
+            RsaScheme::RsaPss(_) => RsaSchemeAlgorithm::RsaPss,
+            RsaScheme::Oaep(_) => RsaSchemeAlgorithm::Oaep,
+            RsaScheme::Null => RsaSchemeAlgorithm::Null,
+        }
+    }
+}
+
+impl From<RsaScheme> for TPMT_RSA_SCHEME {
+    fn from(rsa_scheme: RsaScheme) -> Self {
+        match rsa_scheme {
+            RsaScheme::RsaSsa(hash_scheme) => TPMT_RSA_SCHEME {
+                scheme: rsa_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    rsassa: hash_scheme.into(),
+                },
+            },
+            RsaScheme::RsaEs => TPMT_RSA_SCHEME {
+                scheme: rsa_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    rsaes: Default::default(),
+                },
+            },
+            RsaScheme::RsaPss(hash_scheme) => TPMT_RSA_SCHEME {
+                scheme: rsa_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    rsapss: hash_scheme.into(),
+                },
+            },
+            RsaScheme::Oaep(hash_scheme) => TPMT_RSA_SCHEME {
+                scheme: rsa_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    oaep: hash_scheme.into(),
+                },
+            },
+            RsaScheme::Null => TPMT_RSA_SCHEME {
+                scheme: rsa_scheme.algorithm().into(),
+                details: Default::default(),
+            },
+        }
+    }
+}
+
+impl TryFrom<TPMT_RSA_SCHEME> for RsaScheme {
+    type Error = Error;
+
+    fn try_from(tpmt_rsa_scheme: TPMT_RSA_SCHEME) -> Result<Self> {
+        match RsaSchemeAlgorithm::try_from(tpmt_rsa_scheme.scheme)? {
+            RsaSchemeAlgorithm::RsaSsa => Ok(RsaScheme::RsaSsa(
+                unsafe { tpmt_rsa_scheme.details.rsassa }.try_into()?,
+            )),
+            RsaSchemeAlgorithm::RsaEs => Ok(RsaScheme::RsaEs),
+            RsaSchemeAlgorithm::RsaPss => Ok(RsaScheme::RsaPss(
+                unsafe { tpmt_rsa_scheme.details.rsapss }.try_into()?,
+            )),
+            RsaSchemeAlgorithm::Oaep => Ok(RsaScheme::Oaep(
+                unsafe { tpmt_rsa_scheme.details.oaep }.try_into()?,
+            )),
+            RsaSchemeAlgorithm::Null => Ok(RsaScheme::Null),
+        }
+    }
+}
+
+/// Enum representing the ecc scheme
+///
+/// # Details
+/// This corresponds to TPMT_ECC_SCHEME.
+/// This uses a subset of the TPMU_ASYM_SCHEME
+/// that has the TPMI_ALG_ECC_SCHEME as selector.
+#[derive(Clone, Copy, Debug)]
+pub enum EccScheme {
+    EcDsa(HashScheme),
+    EcDh(HashScheme),
+    EcDaa(EcDaaScheme),
+    Sm2(HashScheme),
+    EcSchnorr(HashScheme),
+    EcMqv(HashScheme),
+    Null,
+}
+
+impl EccScheme {
+    pub fn create(
+        ecc_scheme_algorithm: EccSchemeAlgorithm,
+        hashing_algorithm: Option<HashingAlgorithm>,
+        count: Option<u16>,
+    ) -> Result<Self> {
+        match ecc_scheme_algorithm {
+            EccSchemeAlgorithm::EcDsa => Ok(EccScheme::EcDsa(HashScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!("Hashing algorithm is required when creating ECC scheme of type EC DSA");
+                    Error::local_error(WrapperErrorKind::ParamsMissing)
+                })?,
+            ))),
+            EccSchemeAlgorithm::EcDh => Ok(EccScheme::EcDh(HashScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!("Hashing algorithm is required when creating ECC scheme of type EC DH");
+                    Error::local_error(WrapperErrorKind::ParamsMissing)
+                })?,
+            ))),
+            EccSchemeAlgorithm::EcDaa => Ok(EccScheme::EcDaa(EcDaaScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!("Hashing algorithm is required when creating ECC scheme of type EC DAA");
+                    Error::local_error(WrapperErrorKind::ParamsMissing)
+                })?,
+                count.ok_or_else(|| {
+                    error!("Count is required when creating ECC scheme of type EC DAA");
+                    Error::local_error(WrapperErrorKind::ParamsMissing)
+                })?,
+            ))),
+            EccSchemeAlgorithm::Sm2 => Ok(EccScheme::Sm2(HashScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!("Hashing algorithm is required when creating ECC scheme of type EC SM2");
+                    Error::local_error(WrapperErrorKind::ParamsMissing)
+                })?,
+            ))),
+            EccSchemeAlgorithm::EcSchnorr => Ok(EccScheme::EcSchnorr(HashScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!(
+                        "Hashing algorithm is required when creating ECC scheme of type EC SCHNORR"
+                    );
+                    Error::local_error(WrapperErrorKind::ParamsMissing)
+                })?,
+            ))),
+            EccSchemeAlgorithm::EcMqv => Ok(EccScheme::EcMqv(HashScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!("Hashing algorithm is required when creating ECC scheme of type EC MQV");
+                    Error::local_error(WrapperErrorKind::ParamsMissing)
+                })?,
+            ))),
+            EccSchemeAlgorithm::Null => {
+                if hashing_algorithm.is_none() {
+                    Ok(EccScheme::Null)
+                } else {
+                    error!("A hashing algorithm shall not be provided when creating ECC scheme of type Null");
+                    Err(Error::local_error(WrapperErrorKind::InconsistentParams))
+                }
+            }
+        }
+    }
+
+    pub fn algorithm(&self) -> EccSchemeAlgorithm {
+        match self {
+            EccScheme::EcDsa(_) => EccSchemeAlgorithm::EcDsa,
+            EccScheme::EcDh(_) => EccSchemeAlgorithm::EcDh,
+            EccScheme::EcDaa(_) => EccSchemeAlgorithm::EcDaa,
+            EccScheme::Sm2(_) => EccSchemeAlgorithm::Sm2,
+            EccScheme::EcSchnorr(_) => EccSchemeAlgorithm::EcSchnorr,
+            EccScheme::EcMqv(_) => EccSchemeAlgorithm::EcMqv,
+            EccScheme::Null => EccSchemeAlgorithm::Null,
+        }
+    }
+}
+
+impl From<EccScheme> for TPMT_ECC_SCHEME {
+    fn from(ecc_scheme: EccScheme) -> Self {
+        match ecc_scheme {
+            EccScheme::EcDsa(hash_scheme) => TPMT_ECC_SCHEME {
+                scheme: ecc_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    ecdsa: hash_scheme.into(),
+                },
+            },
+            EccScheme::EcDh(hash_scheme) => TPMT_ECC_SCHEME {
+                scheme: ecc_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    ecdh: hash_scheme.into(),
+                },
+            },
+            EccScheme::EcDaa(ec_daa_scheme) => TPMT_ECC_SCHEME {
+                scheme: ecc_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    ecdaa: ec_daa_scheme.into(),
+                },
+            },
+
+            EccScheme::Sm2(hash_scheme) => TPMT_ECC_SCHEME {
+                scheme: ecc_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    sm2: hash_scheme.into(),
+                },
+            },
+            EccScheme::EcSchnorr(hash_scheme) => TPMT_ECC_SCHEME {
+                scheme: ecc_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    ecschnorr: hash_scheme.into(),
+                },
+            },
+            EccScheme::EcMqv(hash_scheme) => TPMT_ECC_SCHEME {
+                scheme: ecc_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    ecmqv: hash_scheme.into(),
+                },
+            },
+            EccScheme::Null => TPMT_ECC_SCHEME {
+                scheme: ecc_scheme.algorithm().into(),
+                details: Default::default(),
+            },
+        }
+    }
+}
+
+impl TryFrom<TPMT_ECC_SCHEME> for EccScheme {
+    type Error = Error;
+
+    fn try_from(tpmt_ecc_scheme: TPMT_ECC_SCHEME) -> Result<Self> {
+        match EccSchemeAlgorithm::try_from(tpmt_ecc_scheme.scheme)? {
+            EccSchemeAlgorithm::EcDsa => Ok(EccScheme::EcDsa(
+                unsafe { tpmt_ecc_scheme.details.ecdsa }.try_into()?,
+            )),
+            EccSchemeAlgorithm::EcDh => Ok(EccScheme::EcDh(
+                unsafe { tpmt_ecc_scheme.details.ecdh }.try_into()?,
+            )),
+            EccSchemeAlgorithm::EcDaa => Ok(EccScheme::EcDaa(
+                unsafe { tpmt_ecc_scheme.details.ecdaa }.try_into()?,
+            )),
+            EccSchemeAlgorithm::Sm2 => Ok(EccScheme::Sm2(
+                unsafe { tpmt_ecc_scheme.details.sm2 }.try_into()?,
+            )),
+            EccSchemeAlgorithm::EcSchnorr => Ok(EccScheme::EcSchnorr(
+                unsafe { tpmt_ecc_scheme.details.ecschnorr }.try_into()?,
+            )),
+            EccSchemeAlgorithm::EcMqv => Ok(EccScheme::EcMqv(
+                unsafe { tpmt_ecc_scheme.details.ecmqv }.try_into()?,
+            )),
+            EccSchemeAlgorithm::Null => Ok(EccScheme::Null),
+        }
+    }
+}
+
+/// Enum representing the kdf scheme
+///
+/// # Details
+/// This corresponds to TPMT_KDF_SCHEME.
+#[derive(Clone, Copy, Debug)]
+pub enum KeyDerivationFunctionScheme {
+    Kdf1Sp800_56a(HashScheme),
+    Kdf2(HashScheme),
+    Kdf1Sp800_108(HashScheme),
+    Mgf1(HashScheme),
+    Null,
+}
+
+impl From<KeyDerivationFunctionScheme> for TPMT_KDF_SCHEME {
+    fn from(key_derivation_function_scheme: KeyDerivationFunctionScheme) -> Self {
+        match key_derivation_function_scheme {
+            KeyDerivationFunctionScheme::Kdf1Sp800_56a(hash_scheme) => TPMT_KDF_SCHEME {
+                scheme: KeyDerivationFunction::Kdf1Sp800_56a.into(),
+                details: TPMU_KDF_SCHEME {
+                    kdf1_sp800_56a: hash_scheme.into(),
+                },
+            },
+            KeyDerivationFunctionScheme::Kdf2(hash_scheme) => TPMT_KDF_SCHEME {
+                scheme: KeyDerivationFunction::Kdf2.into(),
+                details: TPMU_KDF_SCHEME {
+                    kdf2: hash_scheme.into(),
+                },
+            },
+            KeyDerivationFunctionScheme::Kdf1Sp800_108(hash_scheme) => TPMT_KDF_SCHEME {
+                scheme: KeyDerivationFunction::Kdf1Sp800_108.into(),
+                details: TPMU_KDF_SCHEME {
+                    kdf1_sp800_108: hash_scheme.into(),
+                },
+            },
+            KeyDerivationFunctionScheme::Mgf1(hash_scheme) => TPMT_KDF_SCHEME {
+                scheme: KeyDerivationFunction::Mgf1.into(),
+                details: TPMU_KDF_SCHEME {
+                    mgf1: hash_scheme.into(),
+                },
+            },
+            KeyDerivationFunctionScheme::Null => TPMT_KDF_SCHEME {
+                scheme: KeyDerivationFunction::Null.into(),
+                details: Default::default(),
+            },
+        }
+    }
+}
+
+impl TryFrom<TPMT_KDF_SCHEME> for KeyDerivationFunctionScheme {
+    type Error = Error;
+
+    fn try_from(tpmt_kdf_scheme: TPMT_KDF_SCHEME) -> Result<Self> {
+        match KeyDerivationFunction::try_from(tpmt_kdf_scheme.scheme)? {
+            KeyDerivationFunction::Kdf1Sp800_56a => Ok(KeyDerivationFunctionScheme::Kdf1Sp800_56a(
+                unsafe { tpmt_kdf_scheme.details.kdf1_sp800_56a }.try_into()?,
+            )),
+            KeyDerivationFunction::Kdf2 => Ok(KeyDerivationFunctionScheme::Kdf2(
+                unsafe { tpmt_kdf_scheme.details.kdf2 }.try_into()?,
+            )),
+            KeyDerivationFunction::Kdf1Sp800_108 => Ok(KeyDerivationFunctionScheme::Kdf1Sp800_108(
+                unsafe { tpmt_kdf_scheme.details.kdf1_sp800_108 }.try_into()?,
+            )),
+            KeyDerivationFunction::Mgf1 => Ok(KeyDerivationFunctionScheme::Mgf1(
+                unsafe { tpmt_kdf_scheme.details.mgf1 }.try_into()?,
+            )),
+            KeyDerivationFunction::Null => Ok(KeyDerivationFunctionScheme::Null),
+        }
+    }
+}
+
+/// Enum representing the rsa decryption scheme
+///
+/// # Details
+/// This corresponds to TPMT_RSA_DECRYPT.
+#[derive(Clone, Copy, Debug)]
+pub enum RsaDecryptionScheme {
+    RsaEs,
+    Oaep(HashScheme),
+    Null,
+}
+
+impl RsaDecryptionScheme {
+    /// Creates a new rsa decrypt scheme
+    pub fn create(
+        rsa_decrypt_algorithm: RsaDecryptAlgorithm,
+        hashing_algorithm: Option<HashingAlgorithm>,
+    ) -> Result<RsaDecryptionScheme> {
+        match rsa_decrypt_algorithm {
+            RsaDecryptAlgorithm::RsaEs => {
+                if hashing_algorithm.is_none() {
+                    Ok(RsaDecryptionScheme::RsaEs)
+                } else {
+                    error!("A hashing algorithm shall not be provided when creating RSA decryption scheme of type RSA ES");
+                    Err(Error::local_error(WrapperErrorKind::InconsistentParams))
+                }
+            },
+            RsaDecryptAlgorithm::Oaep => Ok(RsaDecryptionScheme::Oaep(HashScheme::new(
+                hashing_algorithm.ok_or_else(|| {
+                    error!("Hashing algorithm is required when creating RSA decrypt scheme of type OEAP");
+                    Error::local_error(WrapperErrorKind::ParamsMissing)
+                })?,
+            ))),
+            RsaDecryptAlgorithm::Null => {
+                if hashing_algorithm.is_none() {
+                    Ok(RsaDecryptionScheme::Null)
+                } else {
+                    error!("A hashing algorithm shall not be provided when creating RSA decryption scheme of type Null");
+                    Err(Error::local_error(WrapperErrorKind::InconsistentParams))
+                }
+            }
+        }
+    }
+
+    /// Returns the rsa decrypt scheme algorithm
+    pub fn algorithm(&self) -> RsaDecryptAlgorithm {
+        match self {
+            RsaDecryptionScheme::RsaEs => RsaDecryptAlgorithm::RsaEs,
+            RsaDecryptionScheme::Oaep(_) => RsaDecryptAlgorithm::Oaep,
+            RsaDecryptionScheme::Null => RsaDecryptAlgorithm::Null,
+        }
+    }
+}
+
+impl From<RsaDecryptionScheme> for TPMT_RSA_DECRYPT {
+    fn from(rsa_decryption_scheme: RsaDecryptionScheme) -> Self {
+        match rsa_decryption_scheme {
+            RsaDecryptionScheme::RsaEs => TPMT_RSA_DECRYPT {
+                scheme: rsa_decryption_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    rsaes: Default::default(),
+                },
+            },
+            RsaDecryptionScheme::Oaep(hash_scheme) => TPMT_RSA_DECRYPT {
+                scheme: rsa_decryption_scheme.algorithm().into(),
+                details: TPMU_ASYM_SCHEME {
+                    oaep: hash_scheme.into(),
+                },
+            },
+            RsaDecryptionScheme::Null => TPMT_RSA_DECRYPT {
+                scheme: rsa_decryption_scheme.algorithm().into(),
+                details: Default::default(),
+            },
+        }
+    }
+}
+
+impl TryFrom<TPMT_RSA_DECRYPT> for RsaDecryptionScheme {
+    type Error = Error;
+
+    fn try_from(tpmt_rsa_decrypt: TPMT_RSA_DECRYPT) -> Result<Self> {
+        match RsaDecryptAlgorithm::try_from(tpmt_rsa_decrypt.scheme)? {
+            RsaDecryptAlgorithm::RsaEs => Ok(RsaDecryptionScheme::RsaEs),
+            RsaDecryptAlgorithm::Oaep => Ok(RsaDecryptionScheme::Oaep(
+                unsafe { tpmt_rsa_decrypt.details.oaep }.try_into()?,
+            )),
+            RsaDecryptAlgorithm::Null => Ok(RsaDecryptionScheme::Null),
         }
     }
 }

--- a/tss-esapi/src/structures/tagged/signature.rs
+++ b/tss-esapi/src/structures/tagged/signature.rs
@@ -1,0 +1,127 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    interface_types::algorithm::SignatureSchemeAlgorithm,
+    structures::{EccSignature, HashAgile, RsaSignature},
+    tss2_esys::{TPMT_SIGNATURE, TPMU_SIGNATURE},
+    Error, Result,
+};
+use std::convert::{TryFrom, TryInto};
+
+/// Enum representing a Signature
+///
+/// # Details
+/// This corresponds TPMT_SIGNATURE
+#[derive(Debug, Clone)]
+pub enum Signature {
+    RsaSsa(RsaSignature),
+    RsaPss(RsaSignature),
+    EcDsa(EccSignature),
+    EcDaa(EccSignature),
+    Sm2(EccSignature),
+    EcSchnorr(EccSignature),
+    Hmac(HashAgile),
+    Null,
+}
+
+impl Signature {
+    pub fn algorithm(&self) -> SignatureSchemeAlgorithm {
+        match self {
+            Signature::RsaSsa(_) => SignatureSchemeAlgorithm::RsaSsa,
+            Signature::RsaPss(_) => SignatureSchemeAlgorithm::RsaPss,
+            Signature::EcDsa(_) => SignatureSchemeAlgorithm::EcDsa,
+            Signature::EcDaa(_) => SignatureSchemeAlgorithm::EcDaa,
+            Signature::Sm2(_) => SignatureSchemeAlgorithm::Sm2,
+            Signature::EcSchnorr(_) => SignatureSchemeAlgorithm::EcSchnorr,
+            Signature::Hmac(_) => SignatureSchemeAlgorithm::Hmac,
+            Signature::Null => SignatureSchemeAlgorithm::Null,
+        }
+    }
+}
+
+impl TryFrom<Signature> for TPMT_SIGNATURE {
+    type Error = Error;
+
+    fn try_from(signature: Signature) -> Result<Self> {
+        let signature_algorithm = signature.algorithm().into();
+        match signature {
+            Signature::RsaSsa(rsa_signature) => Ok(TPMT_SIGNATURE {
+                sigAlg: signature_algorithm,
+                signature: TPMU_SIGNATURE {
+                    rsassa: rsa_signature.into(),
+                },
+            }),
+            Signature::RsaPss(rsa_signature) => Ok(TPMT_SIGNATURE {
+                sigAlg: signature_algorithm,
+                signature: TPMU_SIGNATURE {
+                    rsapss: rsa_signature.into(),
+                },
+            }),
+            Signature::EcDsa(ecc_signature) => Ok(TPMT_SIGNATURE {
+                sigAlg: signature_algorithm,
+                signature: TPMU_SIGNATURE {
+                    ecdsa: ecc_signature.into(),
+                },
+            }),
+            Signature::EcDaa(ecc_signature) => Ok(TPMT_SIGNATURE {
+                sigAlg: signature_algorithm,
+                signature: TPMU_SIGNATURE {
+                    ecdaa: ecc_signature.into(),
+                },
+            }),
+            Signature::Sm2(ecc_signature) => Ok(TPMT_SIGNATURE {
+                sigAlg: signature_algorithm,
+                signature: TPMU_SIGNATURE {
+                    sm2: ecc_signature.into(),
+                },
+            }),
+            Signature::EcSchnorr(ecc_signature) => Ok(TPMT_SIGNATURE {
+                sigAlg: signature_algorithm,
+                signature: TPMU_SIGNATURE {
+                    ecschnorr: ecc_signature.into(),
+                },
+            }),
+            Signature::Hmac(hash_agile) => Ok(TPMT_SIGNATURE {
+                sigAlg: signature_algorithm,
+                signature: TPMU_SIGNATURE {
+                    hmac: hash_agile.try_into()?,
+                },
+            }),
+            Signature::Null => Ok(TPMT_SIGNATURE {
+                sigAlg: signature_algorithm,
+                signature: Default::default(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<TPMT_SIGNATURE> for Signature {
+    type Error = Error;
+
+    fn try_from(tpmt_signature: TPMT_SIGNATURE) -> Result<Self> {
+        match SignatureSchemeAlgorithm::try_from(tpmt_signature.sigAlg)? {
+            SignatureSchemeAlgorithm::RsaSsa => Ok(Signature::RsaSsa(
+                unsafe { tpmt_signature.signature.rsassa }.try_into()?,
+            )),
+            SignatureSchemeAlgorithm::RsaPss => Ok(Signature::RsaPss(
+                unsafe { tpmt_signature.signature.rsapss }.try_into()?,
+            )),
+            SignatureSchemeAlgorithm::EcDsa => Ok(Signature::EcDsa(
+                unsafe { tpmt_signature.signature.ecdsa }.try_into()?,
+            )),
+            SignatureSchemeAlgorithm::EcDaa => Ok(Signature::EcDaa(
+                unsafe { tpmt_signature.signature.ecdaa }.try_into()?,
+            )),
+            SignatureSchemeAlgorithm::Sm2 => Ok(Signature::Sm2(
+                unsafe { tpmt_signature.signature.sm2 }.try_into()?,
+            )),
+            SignatureSchemeAlgorithm::EcSchnorr => Ok(Signature::EcSchnorr(
+                unsafe { tpmt_signature.signature.ecschnorr }.try_into()?,
+            )),
+            SignatureSchemeAlgorithm::Hmac => Ok(Signature::Hmac(
+                unsafe { tpmt_signature.signature.hmac }.try_into()?,
+            )),
+            SignatureSchemeAlgorithm::Null => Ok(Signature::Null),
+        }
+    }
+}

--- a/tss-esapi/src/structures/tagged/symmetric.rs
+++ b/tss-esapi/src/structures/tagged/symmetric.rs
@@ -154,6 +154,19 @@ pub enum SymmetricDefinitionObject {
     Null,
 }
 
+impl SymmetricDefinitionObject {
+    /// Constant for the AES 128 bits CFB symmetric definition object
+    pub const AES_128_CFB: SymmetricDefinitionObject = SymmetricDefinitionObject::Aes {
+        key_bits: AesKeyBits::Aes128,
+        mode: SymmetricMode::Cfb,
+    };
+    /// Constant for the AES 256 bits CFB symmetric definition object
+    pub const AES_256_CFB: SymmetricDefinitionObject = SymmetricDefinitionObject::Aes {
+        key_bits: AesKeyBits::Aes256,
+        mode: SymmetricMode::Cfb,
+    };
+}
+
 impl From<SymmetricDefinitionObject> for TPMT_SYM_DEF_OBJECT {
     fn from(symmetric_definition_object: SymmetricDefinitionObject) -> TPMT_SYM_DEF_OBJECT {
         match symmetric_definition_object {

--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -8,11 +8,16 @@
 //! guidelines to them. Structures that are meant to act as builders have `Builder` appended to
 //! type name. Unions are converted to Rust `enum`s by dropping the `TPMU` qualifier and appending
 //! `Union`.
-use crate::attributes::{ObjectAttributes, ObjectAttributesBuilder};
-use crate::constants::{tss::*, PropertyTag};
-use crate::interface_types::{algorithm::HashingAlgorithm, ecc::EccCurve};
+use crate::attributes::ObjectAttributesBuilder;
+use crate::constants::PropertyTag;
+use crate::interface_types::{
+    algorithm::{HashingAlgorithm, PublicAlgorithm},
+    ecc::EccCurve,
+    key_bits::RsaKeyBits,
+};
 use crate::structures::{
-    Digest, KeyedHashParameters, PcrSlot, SymmetricCipherParameters, SymmetricDefinitionObject,
+    Digest, EccPoint, EccScheme, PcrSlot, Public, PublicBuilder, PublicEccParametersBuilder,
+    PublicKeyRsa, PublicRsaParametersBuilder, RsaExponent, RsaScheme, SymmetricDefinitionObject,
 };
 use crate::tss2_esys::*;
 use crate::{Context, Error, Result, WrapperErrorKind};
@@ -23,935 +28,6 @@ use zeroize::Zeroize;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
-/// Helper for building `TPM2B_PUBLIC` values out of its subcomponents.
-///
-/// Currently the implementation is incomplete, focusing on creating objects of RSA type.
-// Most of the field types are from bindgen which does not implement Debug on them.
-#[allow(missing_debug_implementations)]
-pub struct Tpm2BPublicBuilder {
-    type_: Option<TPMI_ALG_PUBLIC>,
-    name_alg: TPMI_ALG_HASH,
-    object_attributes: ObjectAttributes,
-    auth_policy: TPM2B_DIGEST,
-    parameters: Option<PublicParmsUnion>,
-    unique: Option<PublicIdUnion>,
-}
-
-impl Tpm2BPublicBuilder {
-    /// Create a new builder with default (i.e. empty or null) placeholder values.
-    pub fn new() -> Self {
-        Tpm2BPublicBuilder {
-            type_: None,
-            name_alg: TPM2_ALG_NULL,
-            object_attributes: ObjectAttributes(0),
-            auth_policy: Default::default(),
-            parameters: None,
-            unique: None,
-        }
-    }
-
-    /// Set the type of the object to be built.
-    pub fn with_type(mut self, type_: TPMI_ALG_PUBLIC) -> Self {
-        self.type_ = Some(type_);
-        self
-    }
-
-    /// Set the algorithm used to derive the object name.
-    pub fn with_name_alg(mut self, name_alg: TPMI_ALG_HASH) -> Self {
-        self.name_alg = name_alg;
-        self
-    }
-
-    /// Set the object attributes.
-    pub fn with_object_attributes(mut self, obj_attr: ObjectAttributes) -> Self {
-        self.object_attributes = obj_attr;
-        self
-    }
-
-    /// Set the authentication policy hash for the object.
-    pub fn with_auth_policy(mut self, size: u16, buffer: [u8; 64]) -> Self {
-        self.auth_policy = TPM2B_DIGEST { size, buffer };
-        self
-    }
-
-    /// Set the public parameters of the object.
-    pub fn with_parms(mut self, parameters: PublicParmsUnion) -> Self {
-        self.parameters = Some(parameters);
-        self
-    }
-
-    /// Set the unique value for the object.
-    pub fn with_unique(mut self, unique: PublicIdUnion) -> Self {
-        self.unique = Some(unique);
-        self
-    }
-
-    /// Build an object with the previously provided parameters.
-    ///
-    /// The paramters are checked for consistency based on the TSS specifications for the
-    /// `TPM2B_PUBLIC` structure and for the structures nested within it.
-    ///
-    /// Currently only objects of type `TPM2_ALG_RSA` are supported.
-    ///
-    /// # Errors
-    /// * if no public parameters are provided, `ParamsMissing` wrapper error is returned
-    /// * if a public parameter type or public ID type is provided that is incosistent with the
-    /// object type provided, `InconsistentParams` wrapper error is returned
-    ///
-    /// # Panics
-    /// * will panic on unsupported platforms (i.e. on 8 bit processors)
-    pub fn build(self) -> Result<TPM2B_PUBLIC> {
-        match self.type_ {
-            Some(TPM2_ALG_RSA) => {
-                // RSA key
-                let parameters;
-                let unique;
-                if let Some(PublicParmsUnion::RsaDetail(parms)) = self.parameters {
-                    parameters = TPMU_PUBLIC_PARMS { rsaDetail: parms };
-                } else if self.parameters.is_none() {
-                    return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
-                } else {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-
-                if let Some(PublicIdUnion::Rsa(rsa_unique)) = self.unique {
-                    unique = TPMU_PUBLIC_ID { rsa: *rsa_unique };
-                } else if self.unique.is_none() {
-                    unique = Default::default();
-                } else {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-
-                Ok(TPM2B_PUBLIC {
-                    size: std::mem::size_of::<TPMT_PUBLIC>()
-                        .try_into()
-                        .expect("Failed to convert usize to u16"), // should not fail on valid targets
-                    publicArea: TPMT_PUBLIC {
-                        type_: self.type_.unwrap(), // cannot fail given that this is inside a match on `type_`
-                        nameAlg: self.name_alg,
-                        objectAttributes: self.object_attributes.0,
-                        authPolicy: self.auth_policy,
-                        parameters,
-                        unique,
-                    },
-                })
-            }
-            Some(TPM2_ALG_ECC) => {
-                // ECC key
-                let parameters;
-                let unique;
-                if let Some(PublicParmsUnion::EccDetail(parms)) = self.parameters {
-                    parameters = TPMU_PUBLIC_PARMS { eccDetail: parms };
-                } else if self.parameters.is_none() {
-                    return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
-                } else {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-
-                if let Some(PublicIdUnion::Ecc(rsa_unique)) = self.unique {
-                    unique = TPMU_PUBLIC_ID { ecc: *rsa_unique };
-                } else if self.unique.is_none() {
-                    unique = Default::default();
-                } else {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-
-                Ok(TPM2B_PUBLIC {
-                    size: std::mem::size_of::<TPMT_PUBLIC>()
-                        .try_into()
-                        .expect("Failed to convert usize to u16"), // should not fail on valid targets
-                    publicArea: TPMT_PUBLIC {
-                        type_: self.type_.unwrap(), // cannot fail given that this is inside a match on `type_`
-                        nameAlg: self.name_alg,
-                        objectAttributes: self.object_attributes.0,
-                        authPolicy: self.auth_policy,
-                        parameters,
-                        unique,
-                    },
-                })
-            }
-            Some(TPM2_ALG_KEYEDHASH) => {
-                // KeyedHash
-                let parameters;
-                let unique;
-                if let Some(PublicParmsUnion::KeyedHashDetail(parms)) = self.parameters {
-                    parameters = TPMU_PUBLIC_PARMS {
-                        keyedHashDetail: parms.into(),
-                    };
-                } else if self.parameters.is_none() {
-                    return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
-                } else {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-
-                if let Some(PublicIdUnion::KeyedHash(hash_unique)) = self.unique {
-                    unique = TPMU_PUBLIC_ID {
-                        keyedHash: hash_unique,
-                    };
-                } else if self.unique.is_none() {
-                    unique = Default::default();
-                } else {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-
-                Ok(TPM2B_PUBLIC {
-                    size: std::mem::size_of::<TPMT_PUBLIC>()
-                        .try_into()
-                        .expect("Failed to convert usize to u16"), // should not fail on valid targets
-                    publicArea: TPMT_PUBLIC {
-                        type_: self.type_.unwrap(), // cannot fail given that this is inside a match on `type_`
-                        nameAlg: self.name_alg,
-                        objectAttributes: self.object_attributes.0,
-                        authPolicy: self.auth_policy,
-                        parameters,
-                        unique,
-                    },
-                })
-            }
-            Some(TPM2_ALG_SYMCIPHER) => {
-                let parameters = if let Some(PublicParmsUnion::SymDetail(params)) = self.parameters
-                {
-                    TPMU_PUBLIC_PARMS {
-                        symDetail: TPMS_SYMCIPHER_PARMS {
-                            sym: SymmetricDefinitionObject::try_from(params)?.into(),
-                        },
-                    }
-                } else if self.parameters.is_none() {
-                    return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
-                } else {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                };
-
-                let unique = if let Some(PublicIdUnion::Sym(sym_unique)) = self.unique {
-                    TPMU_PUBLIC_ID { sym: sym_unique }
-                } else if self.unique.is_none() {
-                    TPMU_PUBLIC_ID {
-                        sym: Default::default(),
-                    }
-                } else {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                };
-
-                Ok(TPM2B_PUBLIC {
-                    size: std::mem::size_of::<TPMT_PUBLIC>()
-                        .try_into()
-                        .expect("Failed to convert usize to u16"), // should not fail on valid targets
-                    publicArea: TPMT_PUBLIC {
-                        type_: self.type_.unwrap(), // cannot fail given that this is inside a match on `type_`
-                        nameAlg: self.name_alg,
-                        objectAttributes: self.object_attributes.0,
-                        authPolicy: self.auth_policy,
-                        parameters,
-                        unique,
-                    },
-                })
-            }
-            _ => Err(Error::local_error(WrapperErrorKind::UnsupportedParam)),
-        }
-    }
-}
-
-impl Default for Tpm2BPublicBuilder {
-    fn default() -> Self {
-        Tpm2BPublicBuilder::new()
-    }
-}
-
-/// Builder for `TPMS_RSA_PARMS` values.
-// Most of the field types are from bindgen which does not implement Debug on them.
-#[allow(missing_debug_implementations)]
-#[derive(Copy, Clone, Default)]
-pub struct TpmsRsaParmsBuilder {
-    /// Symmetric cipher to be used in conjuction with the key
-    pub symmetric: Option<TPMT_SYM_DEF_OBJECT>,
-    /// Asymmetric scheme to be used for key operations
-    pub scheme: Option<AsymSchemeUnion>,
-    /// Size of key, in bits
-    pub key_bits: TPMI_RSA_KEY_BITS,
-    /// Public exponent of the key. A value of 0 defaults to 2 ^ 16 + 1
-    pub exponent: u32,
-    /// Flag indicating whether the key shall be used for signing
-    pub for_signing: bool,
-    /// Flag indicating whether the key shall be used for decryption
-    pub for_decryption: bool,
-    /// Flag indicating whether the key is restricted
-    pub restricted: bool,
-}
-
-impl TpmsRsaParmsBuilder {
-    /// Create parameters for a restricted decryption key
-    pub fn new_restricted_decryption_key(
-        symmetric: TPMT_SYM_DEF_OBJECT,
-        key_bits: TPMI_RSA_KEY_BITS,
-        exponent: u32,
-    ) -> Self {
-        TpmsRsaParmsBuilder {
-            symmetric: Some(symmetric),
-            scheme: Some(AsymSchemeUnion::AnySig(None)),
-            key_bits,
-            exponent,
-            for_signing: false,
-            for_decryption: true,
-            restricted: true,
-        }
-    }
-
-    /// Create parameters for an unrestricted signing key
-    pub fn new_unrestricted_signing_key(
-        scheme: AsymSchemeUnion,
-        key_bits: TPMI_RSA_KEY_BITS,
-        exponent: u32,
-    ) -> Self {
-        TpmsRsaParmsBuilder {
-            symmetric: None,
-            scheme: Some(scheme),
-            key_bits,
-            exponent,
-            for_signing: true,
-            for_decryption: false,
-            restricted: false,
-        }
-    }
-
-    /// Build an object given the previously provded parameters.
-    ///
-    /// The only mandatory parameter is the asymmetric scheme.
-    ///
-    /// # Errors
-    /// * if no asymmetric scheme is set, `ParamsMissing` wrapper error is returned.
-    /// * if the `for_signing`, `for_decryption` and `restricted` parameters are
-    /// inconsistent with the rest of the parameters, `InconsistentParams` wrapper
-    /// error is returned
-    pub fn build(self) -> Result<TPMS_RSA_PARMS> {
-        if self.restricted && self.for_decryption {
-            if self.symmetric.is_none() {
-                return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
-            }
-        } else if self.symmetric.is_some() {
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
-        let symmetric = self.symmetric.unwrap_or_else(|| TPMT_SYM_DEF_OBJECT {
-            algorithm: TPM2_ALG_NULL,
-            ..Default::default()
-        });
-
-        let scheme = self
-            .scheme
-            .ok_or_else(|| Error::local_error(WrapperErrorKind::ParamsMissing))?
-            .get_rsa_scheme_struct();
-        if self.restricted {
-            if self.for_signing
-                && scheme.scheme != TPM2_ALG_RSAPSS
-                && scheme.scheme != TPM2_ALG_RSASSA
-            {
-                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-            }
-
-            if self.for_decryption && scheme.scheme != TPM2_ALG_NULL {
-                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-            }
-        } else {
-            if self.for_decryption && self.for_signing && scheme.scheme != TPM2_ALG_NULL {
-                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-            }
-            if self.for_signing
-                && scheme.scheme != TPM2_ALG_RSAPSS
-                && scheme.scheme != TPM2_ALG_RSASSA
-                && scheme.scheme != TPM2_ALG_NULL
-            {
-                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-            }
-
-            if self.for_decryption
-                && scheme.scheme != TPM2_ALG_RSAES
-                && scheme.scheme != TPM2_ALG_OAEP
-                && scheme.scheme != TPM2_ALG_NULL
-            {
-                return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-            }
-        }
-        Ok(TPMS_RSA_PARMS {
-            symmetric,
-            scheme,
-            keyBits: self.key_bits,
-            exponent: self.exponent,
-        })
-    }
-}
-
-/// Supported sizes for RSA key modulus
-pub const RSA_KEY_SIZES: [u16; 4] = [1024, 2048, 3072, 4096];
-
-/// Builder for `TPMS_ECC_PARMS` values.
-#[derive(Copy, Clone, Debug)]
-pub struct TpmsEccParmsBuilder {
-    /// Symmetric cipher to be used in conjuction with the key
-    pub symmetric: Option<crate::abstraction::cipher::Cipher>,
-    /// Asymmetric scheme to be used for key operations
-    pub scheme: AsymSchemeUnion,
-    /// Curve to be used with the key
-    pub curve: EccCurve,
-    /// Flag indicating whether the key shall be used for signing
-    pub for_signing: bool,
-    /// Flag indicating whether the key shall be used for decryption
-    pub for_decryption: bool,
-    /// Flag indicating whether the key is restricted
-    pub restricted: bool,
-}
-
-impl TpmsEccParmsBuilder {
-    /// Create parameters for a restricted decryption key (i.e. a storage key)
-    pub fn new_restricted_decryption_key(
-        symmetric: crate::abstraction::cipher::Cipher,
-        curve: EccCurve,
-    ) -> Self {
-        TpmsEccParmsBuilder {
-            symmetric: Some(symmetric),
-            scheme: AsymSchemeUnion::AnySig(None),
-            curve,
-            for_signing: false,
-            for_decryption: true,
-            restricted: true,
-        }
-    }
-
-    /// Create parameters for an unrestricted signing key
-    pub fn new_unrestricted_signing_key(scheme: AsymSchemeUnion, curve: EccCurve) -> Self {
-        TpmsEccParmsBuilder {
-            symmetric: None,
-            scheme,
-            curve,
-            for_signing: true,
-            for_decryption: false,
-            restricted: false,
-        }
-    }
-
-    /// Build an object given the previously provded parameters.
-    ///
-    /// The only mandatory parameters are the asymmetric scheme and the elliptic curve.
-    ///
-    /// # Errors
-    /// * if no asymmetric scheme is set, `ParamsMissing` wrapper error is returned.
-    /// * if the `for_signing`, `for_decryption` and `restricted` parameters are
-    /// inconsistent with the rest of the parameters, `InconsistentParams` wrapper
-    /// error is returned
-    pub fn build(self) -> Result<TPMS_ECC_PARMS> {
-        if self.restricted && self.for_decryption {
-            if self.symmetric.is_none() {
-                return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
-            }
-        } else if self.symmetric.is_some() {
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
-        if self.for_decryption && self.for_signing {
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
-
-        let scheme = self.scheme.get_ecc_scheme_struct();
-        if self.for_signing
-            && scheme.scheme != TPM2_ALG_ECDSA
-            && scheme.scheme != TPM2_ALG_ECDAA
-            && scheme.scheme != TPM2_ALG_SM2
-            && scheme.scheme != TPM2_ALG_ECSCHNORR
-        {
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
-
-        if self.for_decryption
-            && scheme.scheme != TPM2_ALG_SM2
-            && scheme.scheme != TPM2_ALG_ECDH
-            && scheme.scheme != TPM2_ALG_ECMQV
-            && scheme.scheme != TPM2_ALG_NULL
-        {
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
-
-        if (self.curve == EccCurve::BnP256 || self.curve == EccCurve::BnP638)
-            && scheme.scheme != TPM2_ALG_ECDAA
-        {
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
-
-        let symmetric = match self.symmetric {
-            Some(symmetric) => symmetric.try_into()?,
-            None => SymmetricDefinitionObject::Null,
-        };
-
-        Ok(TPMS_ECC_PARMS {
-            symmetric: symmetric.into(),
-            scheme,
-            curveID: self.curve.into(),
-            kdf: TPMT_KDF_SCHEME {
-                scheme: TPM2_ALG_NULL,
-                details: Default::default(),
-            },
-        })
-    }
-}
-
-/// Rust enum representation of `TPMU_PUBLIC_ID`.
-// Most of the field types are from bindgen which does not implement Debug on them.
-#[allow(missing_debug_implementations)]
-pub enum PublicIdUnion {
-    KeyedHash(TPM2B_DIGEST),
-    Sym(TPM2B_DIGEST),
-    Rsa(Box<TPM2B_PUBLIC_KEY_RSA>),
-    Ecc(Box<TPMS_ECC_POINT>),
-}
-
-impl PublicIdUnion {
-    /// Extract a `PublicIdUnion` from a `TPM2B_PUBLIC` object.
-    ///
-    /// # Constraints
-    /// * the value of `public.publicArea.type_` *MUST* be consistent with the union field used in
-    /// `public.publicArea.unique`.
-    ///
-    /// # Safety
-    ///
-    /// Check "Notes on code safety" section in the crate-level documentation.
-    pub unsafe fn from_public(public: &TPM2B_PUBLIC) -> Result<Self> {
-        match public.publicArea.type_ {
-            TPM2_ALG_RSA => Ok(PublicIdUnion::Rsa(Box::from(public.publicArea.unique.rsa))),
-            TPM2_ALG_ECC => Ok(PublicIdUnion::Ecc(Box::from(public.publicArea.unique.ecc))),
-            TPM2_ALG_SYMCIPHER => Err(Error::local_error(WrapperErrorKind::UnsupportedParam)),
-            TPM2_ALG_KEYEDHASH => Err(Error::local_error(WrapperErrorKind::UnsupportedParam)),
-            _ => Err(Error::local_error(WrapperErrorKind::UnsupportedParam)),
-        }
-    }
-}
-
-/// Rust enum representation of `TPMU_PUBLIC_PARMS`.
-// Most of the field types are from bindgen which does not implement Debug on them.
-#[allow(missing_debug_implementations)]
-#[derive(Copy, Clone)]
-pub enum PublicParmsUnion {
-    KeyedHashDetail(KeyedHashParameters),
-    SymDetail(crate::abstraction::cipher::Cipher),
-    RsaDetail(TPMS_RSA_PARMS),
-    EccDetail(TPMS_ECC_PARMS),
-    AsymDetail(TPMS_ASYM_PARMS),
-}
-
-impl PublicParmsUnion {
-    /// Get the object type corresponding to the value's variant.
-    pub fn object_type(&self) -> TPMI_ALG_PUBLIC {
-        match self {
-            PublicParmsUnion::AsymDetail(..) => TPM2_ALG_NULL,
-            PublicParmsUnion::EccDetail(..) => TPM2_ALG_ECC,
-            PublicParmsUnion::RsaDetail(..) => TPM2_ALG_RSA,
-            PublicParmsUnion::SymDetail(..) => TPM2_ALG_SYMCIPHER,
-            PublicParmsUnion::KeyedHashDetail(..) => TPM2_ALG_KEYEDHASH,
-        }
-    }
-}
-
-impl TryFrom<PublicParmsUnion> for TPMU_PUBLIC_PARMS {
-    type Error = Error;
-    fn try_from(parms: PublicParmsUnion) -> Result<Self> {
-        match parms {
-            PublicParmsUnion::AsymDetail(tss_parms) => Ok(TPMU_PUBLIC_PARMS {
-                asymDetail: tss_parms,
-            }),
-            PublicParmsUnion::EccDetail(tss_parms) => Ok(TPMU_PUBLIC_PARMS {
-                eccDetail: tss_parms,
-            }),
-            PublicParmsUnion::RsaDetail(tss_parms) => Ok(TPMU_PUBLIC_PARMS {
-                rsaDetail: tss_parms,
-            }),
-            PublicParmsUnion::SymDetail(cipher) => Ok(TPMU_PUBLIC_PARMS {
-                symDetail: SymmetricCipherParameters::try_from(cipher)?.into(),
-            }),
-            PublicParmsUnion::KeyedHashDetail(tss_parms) => Ok(TPMU_PUBLIC_PARMS {
-                keyedHashDetail: tss_parms.into(),
-            }),
-        }
-    }
-}
-
-/// Rust enum representation of `TPMU_ASYM_SCHEME`.
-#[derive(Copy, Clone, Debug)]
-pub enum AsymSchemeUnion {
-    ECDH(HashingAlgorithm),
-    ECMQV(HashingAlgorithm),
-    RSASSA(HashingAlgorithm),
-    RSAPSS(HashingAlgorithm),
-    ECDSA(HashingAlgorithm),
-    ECDAA(HashingAlgorithm, u16),
-    SM2(HashingAlgorithm),
-    ECSchnorr(HashingAlgorithm),
-    RSAES,
-    RSAOAEP(HashingAlgorithm),
-    AnySig(Option<HashingAlgorithm>),
-}
-
-impl AsymSchemeUnion {
-    /// Get scheme ID.
-    pub fn scheme_id(self) -> TPM2_ALG_ID {
-        match self {
-            AsymSchemeUnion::ECDH(_) => TPM2_ALG_ECDH,
-            AsymSchemeUnion::ECMQV(_) => TPM2_ALG_ECMQV,
-            AsymSchemeUnion::RSASSA(_) => TPM2_ALG_RSASSA,
-            AsymSchemeUnion::RSAPSS(_) => TPM2_ALG_RSAPSS,
-            AsymSchemeUnion::ECDSA(_) => TPM2_ALG_ECDSA,
-            AsymSchemeUnion::ECDAA(_, _) => TPM2_ALG_ECDAA,
-            AsymSchemeUnion::SM2(_) => TPM2_ALG_SM2,
-            AsymSchemeUnion::ECSchnorr(_) => TPM2_ALG_ECSCHNORR,
-            AsymSchemeUnion::RSAES => TPM2_ALG_RSAES,
-            AsymSchemeUnion::RSAOAEP(_) => TPM2_ALG_OAEP,
-            AsymSchemeUnion::AnySig(_) => TPM2_ALG_NULL,
-        }
-    }
-
-    fn get_details(self) -> TPMU_ASYM_SCHEME {
-        match self {
-            AsymSchemeUnion::ECDH(hash_alg) => TPMU_ASYM_SCHEME {
-                ecdh: TPMS_SCHEME_HASH {
-                    hashAlg: hash_alg.into(),
-                },
-            },
-            AsymSchemeUnion::ECMQV(hash_alg) => TPMU_ASYM_SCHEME {
-                ecmqv: TPMS_SCHEME_HASH {
-                    hashAlg: hash_alg.into(),
-                },
-            },
-            AsymSchemeUnion::RSASSA(hash_alg) => TPMU_ASYM_SCHEME {
-                rsassa: TPMS_SCHEME_HASH {
-                    hashAlg: hash_alg.into(),
-                },
-            },
-            AsymSchemeUnion::RSAPSS(hash_alg) => TPMU_ASYM_SCHEME {
-                rsapss: TPMS_SCHEME_HASH {
-                    hashAlg: hash_alg.into(),
-                },
-            },
-            AsymSchemeUnion::ECDSA(hash_alg) => TPMU_ASYM_SCHEME {
-                ecdsa: TPMS_SCHEME_HASH {
-                    hashAlg: hash_alg.into(),
-                },
-            },
-            AsymSchemeUnion::ECDAA(hash_alg, count) => TPMU_ASYM_SCHEME {
-                ecdaa: TPMS_SCHEME_ECDAA {
-                    hashAlg: hash_alg.into(),
-                    count,
-                },
-            },
-            AsymSchemeUnion::SM2(hash_alg) => TPMU_ASYM_SCHEME {
-                sm2: TPMS_SCHEME_HASH {
-                    hashAlg: hash_alg.into(),
-                },
-            },
-            AsymSchemeUnion::ECSchnorr(hash_alg) => TPMU_ASYM_SCHEME {
-                ecschnorr: TPMS_SCHEME_HASH {
-                    hashAlg: hash_alg.into(),
-                },
-            },
-            AsymSchemeUnion::RSAES => TPMU_ASYM_SCHEME {
-                rsaes: Default::default(),
-            },
-            AsymSchemeUnion::RSAOAEP(hash_alg) => TPMU_ASYM_SCHEME {
-                oaep: TPMS_SCHEME_HASH {
-                    hashAlg: hash_alg.into(),
-                },
-            },
-            AsymSchemeUnion::AnySig(hash_alg) => TPMU_ASYM_SCHEME {
-                anySig: TPMS_SCHEME_HASH {
-                    hashAlg: hash_alg.map(u16::from).or(Some(TPM2_ALG_NULL)).unwrap(),
-                },
-            },
-        }
-    }
-
-    /// Convert scheme object to `TPMT_RSA_SCHEME`.
-    fn get_rsa_scheme_struct(self) -> TPMT_RSA_SCHEME {
-        let scheme = self.scheme_id();
-        let details = self.get_details();
-
-        TPMT_RSA_SCHEME { scheme, details }
-    }
-
-    /// Convert scheme object to `TPMT_RSA_DECRYPT`.
-    pub fn get_rsa_decrypt_struct(self) -> TPMT_RSA_DECRYPT {
-        let scheme = self.scheme_id();
-        let details = self.get_details();
-
-        TPMT_RSA_DECRYPT { scheme, details }
-    }
-
-    /// Convert scheme object to `TPMT_ECC_SCHEME`.
-    fn get_ecc_scheme_struct(self) -> TPMT_ECC_SCHEME {
-        let scheme = self.scheme_id();
-        let details = self.get_details();
-
-        TPMT_ECC_SCHEME { scheme, details }
-    }
-
-    pub fn is_signing(self) -> bool {
-        match self {
-            AsymSchemeUnion::ECDH(_)
-            | AsymSchemeUnion::ECMQV(_)
-            | AsymSchemeUnion::RSAOAEP(_)
-            | AsymSchemeUnion::RSAES => false,
-            AsymSchemeUnion::RSASSA(_)
-            | AsymSchemeUnion::RSAPSS(_)
-            | AsymSchemeUnion::ECDSA(_)
-            | AsymSchemeUnion::ECDAA(_, _)
-            | AsymSchemeUnion::SM2(_)
-            | AsymSchemeUnion::ECSchnorr(_)
-            | AsymSchemeUnion::AnySig(_) => true,
-        }
-    }
-
-    pub fn is_decryption(self) -> bool {
-        match self {
-            AsymSchemeUnion::ECDH(_)
-            | AsymSchemeUnion::ECMQV(_)
-            | AsymSchemeUnion::RSAOAEP(_)
-            | AsymSchemeUnion::RSAES => true,
-            AsymSchemeUnion::RSASSA(_)
-            | AsymSchemeUnion::RSAPSS(_)
-            | AsymSchemeUnion::ECDSA(_)
-            | AsymSchemeUnion::ECDAA(_, _)
-            | AsymSchemeUnion::SM2(_)
-            | AsymSchemeUnion::ECSchnorr(_)
-            | AsymSchemeUnion::AnySig(_) => false,
-        }
-    }
-
-    pub fn is_rsa(self) -> bool {
-        match self {
-            AsymSchemeUnion::RSASSA(_)
-            | AsymSchemeUnion::RSAOAEP(_)
-            | AsymSchemeUnion::RSAPSS(_)
-            | AsymSchemeUnion::AnySig(_)
-            | AsymSchemeUnion::RSAES => true,
-            AsymSchemeUnion::ECDH(_)
-            | AsymSchemeUnion::ECMQV(_)
-            | AsymSchemeUnion::ECDSA(_)
-            | AsymSchemeUnion::ECDAA(_, _)
-            | AsymSchemeUnion::SM2(_)
-            | AsymSchemeUnion::ECSchnorr(_) => false,
-        }
-    }
-
-    pub fn is_ecc(self) -> bool {
-        match self {
-            AsymSchemeUnion::RSASSA(_)
-            | AsymSchemeUnion::RSAOAEP(_)
-            | AsymSchemeUnion::RSAPSS(_)
-            | AsymSchemeUnion::AnySig(_)
-            | AsymSchemeUnion::RSAES => false,
-            AsymSchemeUnion::ECDH(_)
-            | AsymSchemeUnion::ECMQV(_)
-            | AsymSchemeUnion::ECDSA(_)
-            | AsymSchemeUnion::ECDAA(_, _)
-            | AsymSchemeUnion::SM2(_)
-            | AsymSchemeUnion::ECSchnorr(_) => true,
-        }
-    }
-}
-
-/// Rust native representation of an asymmetric signature.
-///
-/// The structure contains the signature as a byte vector and the scheme with which the signature
-/// was created.
-#[derive(Debug)]
-pub struct Signature {
-    pub scheme: AsymSchemeUnion,
-    pub signature: SignatureData,
-}
-
-#[derive(Debug, PartialEq, Zeroize)]
-#[zeroize(drop)]
-pub enum SignatureData {
-    RsaSignature(Vec<u8>),
-    EcdsaSignature { r: Vec<u8>, s: Vec<u8> },
-}
-
-impl Signature {
-    /// Attempt to parse a signature from a `TPMT_SIGNATURE` object.
-    ///
-    /// # Constraints
-    /// * the value of `tss_signature.sigAlg` *MUST* be consistent with the union field used in
-    /// `tss_signature.signature`
-    ///
-    /// # Safety
-    ///
-    /// Check "Notes on code safety" section in the crate-level documentation.
-    pub unsafe fn try_from(tss_signature: TPMT_SIGNATURE) -> Result<Self> {
-        match tss_signature.sigAlg {
-            TPM2_ALG_RSASSA => {
-                let hash_alg = tss_signature.signature.rsassa.hash;
-                let scheme = AsymSchemeUnion::RSASSA(hash_alg.try_into()?);
-                let signature_buf = tss_signature.signature.rsassa.sig;
-                let mut signature = signature_buf.buffer.to_vec();
-                let buf_size = signature_buf.size.into();
-                if buf_size > signature.len() {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-                signature.truncate(buf_size);
-
-                Ok(Signature {
-                    scheme,
-                    signature: SignatureData::RsaSignature(signature),
-                })
-            }
-            TPM2_ALG_RSAPSS => {
-                let hash_alg = tss_signature.signature.rsapss.hash;
-                let scheme = AsymSchemeUnion::RSAPSS(hash_alg.try_into()?);
-                let signature_buf = tss_signature.signature.rsassa.sig;
-                let mut signature = signature_buf.buffer.to_vec();
-                let buf_size = signature_buf.size.into();
-                if buf_size > signature.len() {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-                signature.truncate(buf_size);
-
-                Ok(Signature {
-                    scheme,
-                    signature: SignatureData::RsaSignature(signature),
-                })
-            }
-            TPM2_ALG_ECDSA => {
-                let hash_alg = tss_signature.signature.ecdsa.hash;
-                let scheme = AsymSchemeUnion::ECDSA(hash_alg.try_into()?);
-                let buf = tss_signature.signature.ecdsa.signatureR;
-                let mut r = buf.buffer.to_vec();
-                let buf_size = buf.size.into();
-                if buf_size > r.len() {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-                r.truncate(buf_size);
-
-                let buf = tss_signature.signature.ecdsa.signatureS;
-                let mut s = buf.buffer.to_vec();
-                let buf_size = buf.size.into();
-                if buf_size > s.len() {
-                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-                }
-                s.truncate(buf_size);
-
-                Ok(Signature {
-                    scheme,
-                    signature: SignatureData::EcdsaSignature { r, s },
-                })
-            }
-            TPM2_ALG_SM2 | TPM2_ALG_ECSCHNORR | TPM2_ALG_ECDAA => {
-                Err(Error::local_error(WrapperErrorKind::UnsupportedParam))
-            }
-            _ => Err(Error::local_error(WrapperErrorKind::InconsistentParams)),
-        }
-    }
-}
-
-impl TryFrom<Signature> for TPMT_SIGNATURE {
-    type Error = Error;
-    fn try_from(sig: Signature) -> Result<Self> {
-        if sig.scheme.is_decryption() {
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
-        match sig.scheme {
-            AsymSchemeUnion::RSASSA(hash_alg) => {
-                let signature = match sig.signature {
-                    SignatureData::RsaSignature(signature) => signature,
-                    SignatureData::EcdsaSignature { .. } => {
-                        return Err(Error::local_error(WrapperErrorKind::InconsistentParams))
-                    }
-                };
-
-                let len = signature.len();
-                if len > 512 {
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
-
-                let mut buffer = [0_u8; 512];
-                buffer[..len].clone_from_slice(&signature[..len]);
-                Ok(TPMT_SIGNATURE {
-                    sigAlg: TPM2_ALG_RSASSA,
-                    signature: TPMU_SIGNATURE {
-                        rsassa: TPMS_SIGNATURE_RSA {
-                            hash: hash_alg.into(),
-                            sig: TPM2B_PUBLIC_KEY_RSA {
-                                size: len.try_into().expect("Failed to convert length to u16"), // Should never panic as per the check above
-                                buffer,
-                            },
-                        },
-                    },
-                })
-            }
-            AsymSchemeUnion::RSAPSS(hash_alg) => {
-                let signature = match sig.signature {
-                    SignatureData::RsaSignature(signature) => signature,
-                    SignatureData::EcdsaSignature { .. } => {
-                        return Err(Error::local_error(WrapperErrorKind::InconsistentParams))
-                    }
-                };
-
-                let len = signature.len();
-                if len > 512 {
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
-
-                let mut buffer = [0_u8; 512];
-                buffer[..len].clone_from_slice(&signature[..len]);
-                Ok(TPMT_SIGNATURE {
-                    sigAlg: TPM2_ALG_RSAPSS,
-                    signature: TPMU_SIGNATURE {
-                        rsapss: TPMS_SIGNATURE_RSA {
-                            hash: hash_alg.into(),
-                            sig: TPM2B_PUBLIC_KEY_RSA {
-                                size: len.try_into().expect("Failed to convert length to u16"), // Should never panic as per the check above
-                                buffer,
-                            },
-                        },
-                    },
-                })
-            }
-            AsymSchemeUnion::ECDSA(hash_alg) => {
-                let signature = match sig.signature {
-                    SignatureData::EcdsaSignature { r, s } => (r, s),
-                    SignatureData::RsaSignature(_) => {
-                        return Err(Error::local_error(WrapperErrorKind::InconsistentParams))
-                    }
-                };
-
-                let r_len = signature.0.len();
-                if r_len > 128 {
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
-
-                let mut r_buffer = [0_u8; 128];
-                r_buffer[..r_len].clone_from_slice(&signature.0[..r_len]);
-
-                let s_len = signature.1.len();
-                if s_len > 128 {
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
-
-                let mut s_buffer = [0_u8; 128];
-                s_buffer[..s_len].clone_from_slice(&signature.1[..s_len]);
-
-                Ok(TPMT_SIGNATURE {
-                    sigAlg: TPM2_ALG_ECDSA,
-                    signature: TPMU_SIGNATURE {
-                        ecdsa: TPMS_SIGNATURE_ECDSA {
-                            hash: hash_alg.into(),
-                            signatureR: TPM2B_ECC_PARAMETER {
-                                size: r_len.try_into().expect("Failed to convert length to u16"), // Should never panic as per the check above
-                                buffer: r_buffer,
-                            },
-                            signatureS: TPM2B_ECC_PARAMETER {
-                                size: s_len.try_into().expect("Failed to convert length to u16"), // Should never panic as per the check above
-                                buffer: s_buffer,
-                            },
-                        },
-                    },
-                })
-            }
-            _ => Err(Error::local_error(WrapperErrorKind::UnsupportedParam)),
-        }
-    }
-}
 
 /// Rust native wrapper for `TPMS_CONTEXT` objects.
 ///
@@ -1016,23 +92,16 @@ impl TryFrom<TpmsContext> for TPMS_CONTEXT {
     }
 }
 
-/// Create the TPM2B_PUBLIC structure for a restricted decryption key.
+/// Create the [Public] structure for a restricted decryption key.
 ///
 /// * `symmetric` - Cipher to be used for decrypting children of the key
 /// * `key_bits` - Size in bits of the decryption key
 /// * `pub_exponent` - Public exponent of the RSA key. A value of 0 defaults to 2^16 + 1
 pub fn create_restricted_decryption_rsa_public(
-    symmetric: crate::abstraction::cipher::Cipher,
-    key_bits: u16,
-    pub_exponent: u32,
-) -> Result<TPM2B_PUBLIC> {
-    let rsa_parms = TpmsRsaParmsBuilder::new_restricted_decryption_key(
-        SymmetricDefinitionObject::try_from(symmetric)?.into(),
-        key_bits,
-        pub_exponent,
-    )
-    .build()?;
-
+    symmetric: SymmetricDefinitionObject,
+    rsa_key_bits: RsaKeyBits,
+    rsa_pub_exponent: RsaExponent,
+) -> Result<Public> {
     let object_attributes = ObjectAttributesBuilder::new()
         .with_fixed_tpm(true)
         .with_fixed_parent(true)
@@ -1043,35 +112,31 @@ pub fn create_restricted_decryption_rsa_public(
         .with_restricted(true)
         .build()?;
 
-    Tpm2BPublicBuilder::new()
-        .with_type(TPM2_ALG_RSA)
-        .with_name_alg(TPM2_ALG_SHA256)
+    PublicBuilder::new()
+        .with_public_algorithm(PublicAlgorithm::Rsa)
+        .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
         .with_object_attributes(object_attributes)
-        .with_parms(PublicParmsUnion::RsaDetail(rsa_parms))
+        .with_rsa_parameters(
+            PublicRsaParametersBuilder::new_restricted_decryption_key(
+                symmetric,
+                rsa_key_bits,
+                rsa_pub_exponent,
+            )
+            .build()?,
+        )
+        .with_rsa_unique_identifier(&PublicKeyRsa::new_empty_with_size(rsa_key_bits))
         .build()
 }
 
-/// Create the TPM2B_PUBLIC structure for an unrestricted encryption/decryption key.
+/// Create the [Public] structure for an unrestricted encryption/decryption key.
 ///
 /// * `symmetric` - Cipher to be used for decrypting children of the key
 /// * `key_bits` - Size in bits of the decryption key
 /// * `pub_exponent` - Public exponent of the RSA key. A value of 0 defaults to 2^16 + 1
 pub fn create_unrestricted_encryption_decryption_rsa_public(
-    key_bits: u16,
-    pub_exponent: u32,
-) -> Result<TPM2B_PUBLIC> {
-    let rsa_parms = TpmsRsaParmsBuilder {
-        symmetric: None,
-        scheme: Some(AsymSchemeUnion::AnySig(None)),
-        key_bits,
-        exponent: pub_exponent,
-        for_signing: true,
-        for_decryption: true,
-        restricted: false,
-    }
-    .build()
-    .unwrap();
-
+    rsa_key_bits: RsaKeyBits,
+    rsa_pub_exponent: RsaExponent,
+) -> Result<Public> {
     let object_attributes = ObjectAttributesBuilder::new()
         .with_fixed_tpm(true)
         .with_fixed_parent(true)
@@ -1082,28 +147,34 @@ pub fn create_unrestricted_encryption_decryption_rsa_public(
         .with_restricted(false)
         .build()?;
 
-    Tpm2BPublicBuilder::new()
-        .with_type(TPM2_ALG_RSA)
-        .with_name_alg(TPM2_ALG_SHA256)
+    PublicBuilder::new()
+        .with_public_algorithm(PublicAlgorithm::Rsa)
+        .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
         .with_object_attributes(object_attributes)
-        .with_parms(PublicParmsUnion::RsaDetail(rsa_parms))
+        .with_rsa_parameters(
+            PublicRsaParametersBuilder::new()
+                .with_scheme(RsaScheme::Null)
+                .with_key_bits(rsa_key_bits)
+                .with_exponent(rsa_pub_exponent)
+                .with_is_signing_key(true)
+                .with_is_decryption_key(true)
+                .with_restricted(false)
+                .build()?,
+        )
+        .with_rsa_unique_identifier(&PublicKeyRsa::new_empty_with_size(rsa_key_bits))
         .build()
 }
 
-/// Create the TPM2B_PUBLIC structure for an RSA unrestricted signing key.
+/// Create the [Public] structure for an RSA unrestricted signing key.
 ///
-/// * `scheme` - Asymmetric scheme to be used for signing
+/// * `scheme` - RSA scheme to be used for signing
 /// * `key_bits` - Size in bits of the decryption key
 /// * `pub_exponent` - Public exponent of the RSA key. A value of 0 defaults to 2^16 + 1
 pub fn create_unrestricted_signing_rsa_public(
-    scheme: AsymSchemeUnion,
-    key_bits: u16,
-    pub_exponent: u32,
-) -> Result<TPM2B_PUBLIC> {
-    let rsa_parms =
-        TpmsRsaParmsBuilder::new_unrestricted_signing_key(scheme, key_bits, pub_exponent)
-            .build()?;
-
+    scheme: RsaScheme,
+    rsa_key_bits: RsaKeyBits,
+    rsa_pub_exponent: RsaExponent,
+) -> Result<Public> {
     let object_attributes = ObjectAttributesBuilder::new()
         .with_fixed_tpm(true)
         .with_fixed_parent(true)
@@ -1114,24 +185,68 @@ pub fn create_unrestricted_signing_rsa_public(
         .with_restricted(false)
         .build()?;
 
-    Tpm2BPublicBuilder::new()
-        .with_type(TPM2_ALG_RSA)
-        .with_name_alg(TPM2_ALG_SHA256)
+    PublicBuilder::new()
+        .with_public_algorithm(PublicAlgorithm::Rsa)
+        .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
         .with_object_attributes(object_attributes)
-        .with_parms(PublicParmsUnion::RsaDetail(rsa_parms))
+        .with_rsa_parameters(
+            PublicRsaParametersBuilder::new_unrestricted_signing_key(
+                scheme,
+                rsa_key_bits,
+                rsa_pub_exponent,
+            )
+            .build()?,
+        )
+        .with_rsa_unique_identifier(&PublicKeyRsa::new_empty_with_size(rsa_key_bits))
         .build()
 }
 
-/// Create the TPM2B_PUBLIC structure for an ECC unrestricted signing key.
+/// Create the [Public] structure for an RSA unrestricted signing key.
+///
+/// * `scheme` - RSA scheme to be used for signing
+/// * `key_bits` - Size in bits of the decryption key
+/// * `pub_exponent` - Public exponent of the RSA key. A value of 0 defaults to 2^16 + 1
+/// * `rsa_public_key` - The public part of the RSA key that is going to be used as unique identifier.
+pub fn create_unrestricted_signing_rsa_public_with_unique(
+    scheme: RsaScheme,
+    rsa_key_bits: RsaKeyBits,
+    rsa_pub_exponent: RsaExponent,
+    rsa_public_key: &PublicKeyRsa,
+) -> Result<Public> {
+    let object_attributes = ObjectAttributesBuilder::new()
+        .with_fixed_tpm(true)
+        .with_fixed_parent(true)
+        .with_sensitive_data_origin(true)
+        .with_user_with_auth(true)
+        .with_decrypt(false)
+        .with_sign_encrypt(true)
+        .with_restricted(false)
+        .build()?;
+
+    PublicBuilder::new()
+        .with_public_algorithm(PublicAlgorithm::Rsa)
+        .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+        .with_object_attributes(object_attributes)
+        .with_rsa_parameters(
+            PublicRsaParametersBuilder::new_unrestricted_signing_key(
+                scheme,
+                rsa_key_bits,
+                rsa_pub_exponent,
+            )
+            .build()?,
+        )
+        .with_rsa_unique_identifier(rsa_public_key)
+        .build()
+}
+
+/// Create the [Public] structure for an ECC unrestricted signing key.
 ///
 /// * `scheme` - Asymmetric scheme to be used for signing; *must* be an RSA signing scheme
 /// * `curve` - identifier of the precise curve to be used with the key
 pub fn create_unrestricted_signing_ecc_public(
-    scheme: AsymSchemeUnion,
+    scheme: EccScheme,
     curve: EccCurve,
-) -> Result<TPM2B_PUBLIC> {
-    let ecc_parms = TpmsEccParmsBuilder::new_unrestricted_signing_key(scheme, curve).build()?;
-
+) -> Result<Public> {
     let object_attributes = ObjectAttributesBuilder::new()
         .with_fixed_tpm(true)
         .with_fixed_parent(true)
@@ -1142,11 +257,14 @@ pub fn create_unrestricted_signing_ecc_public(
         .with_restricted(false)
         .build()?;
 
-    Tpm2BPublicBuilder::new()
-        .with_type(TPM2_ALG_ECC)
-        .with_name_alg(TPM2_ALG_SHA256)
+    PublicBuilder::new()
+        .with_public_algorithm(PublicAlgorithm::Ecc)
+        .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
         .with_object_attributes(object_attributes)
-        .with_parms(PublicParmsUnion::EccDetail(ecc_parms))
+        .with_ecc_parameters(
+            PublicEccParametersBuilder::new_unrestricted_signing_key(scheme, curve).build()?,
+        )
+        .with_ecc_unique_identifier(&EccPoint::default())
         .build()
 }
 

--- a/tss-esapi/tests/abstraction_ak_tests.rs
+++ b/tss-esapi/tests/abstraction_ak_tests.rs
@@ -9,7 +9,7 @@ use tss_esapi::{
     constants::SessionType,
     handles::AuthHandle,
     interface_types::{
-        algorithm::{AsymmetricAlgorithm, HashingAlgorithm, SignatureScheme},
+        algorithm::{AsymmetricAlgorithm, HashingAlgorithm, SignatureSchemeAlgorithm},
         session_handles::PolicySession,
     },
     structures::{Auth, Digest, SymmetricDefinition},
@@ -27,7 +27,7 @@ fn test_create_ak_rsa_rsa() {
         &mut context,
         ek_rsa,
         HashingAlgorithm::Sha256,
-        SignatureScheme::RsaPss,
+        SignatureSchemeAlgorithm::RsaPss,
         None,
         None,
     )
@@ -43,7 +43,7 @@ fn test_create_ak_rsa_ecc() {
         &mut context,
         ek_rsa,
         HashingAlgorithm::Sha256,
-        SignatureScheme::Sm2,
+        SignatureSchemeAlgorithm::Sm2,
         None,
         None,
     )
@@ -64,7 +64,7 @@ fn test_create_and_use_ak() {
         &mut context,
         ek_rsa,
         HashingAlgorithm::Sha256,
-        SignatureScheme::RsaPss,
+        SignatureSchemeAlgorithm::RsaPss,
         Some(&ak_auth),
         None,
     )
@@ -162,16 +162,15 @@ fn test_create_custom_ak() {
         &mut context,
         ek_rsa,
         HashingAlgorithm::Sha256,
-        SignatureScheme::RsaPss,
+        SignatureSchemeAlgorithm::RsaPss,
         Some(&ak_auth),
         None,
     )
     .unwrap();
 
-    assert_eq!(
-        att_key_without.out_public.publicArea.objectAttributes
-            & tss_esapi::constants::tss::TPMA_OBJECT_STCLEAR,
-        0
+    assert!(
+        !att_key_without.out_public.object_attributes().st_clear(),
+        "ST Clear was set"
     );
 
     // With a customization, we get a new attribute
@@ -179,20 +178,19 @@ fn test_create_custom_ak() {
         &mut context,
         ek_rsa,
         HashingAlgorithm::Sha256,
-        SignatureScheme::RsaPss,
+        SignatureSchemeAlgorithm::RsaPss,
         Some(&ak_auth),
         &StClearKeys,
     )
     .unwrap();
 
     assert_eq!(
-        att_key.out_public.publicArea.objectAttributes
-            & tss_esapi::constants::tss::TPMA_OBJECT_STCLEAR,
+        att_key.out_public.object_attributes().0 & tss_esapi::constants::tss::TPMA_OBJECT_STCLEAR,
         tss_esapi::constants::tss::TPMA_OBJECT_STCLEAR
     );
     assert_eq!(
-        att_key.out_public.publicArea.objectAttributes,
-        att_key_without.out_public.publicArea.objectAttributes
+        att_key.out_public.object_attributes().0,
+        att_key_without.out_public.object_attributes().0
             | tss_esapi::constants::tss::TPMA_OBJECT_STCLEAR
     );
 }

--- a/tss-esapi/tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
+++ b/tss-esapi/tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
@@ -4,9 +4,11 @@ mod test_rsa_encrypt_decrypt {
     use crate::common::{create_ctx_with_session, encryption_decryption_key_pub};
     use std::convert::TryFrom;
     use tss_esapi::{
-        interface_types::{algorithm::HashingAlgorithm, resource_handles::Hierarchy},
-        structures::{Auth, Data, PublicKeyRSA},
-        utils::AsymSchemeUnion,
+        interface_types::{
+            algorithm::{HashingAlgorithm, RsaDecryptAlgorithm},
+            resource_handles::Hierarchy,
+        },
+        structures::{Auth, Data, PublicKeyRsa, RsaDecryptionScheme},
     };
 
     #[test]
@@ -27,11 +29,14 @@ mod test_rsa_encrypt_decrypt {
             .unwrap()
             .key_handle;
 
-        let scheme = AsymSchemeUnion::RSAOAEP(HashingAlgorithm::Sha256);
+        // let scheme = AsymSchemeUnion::RSAOAEP(HashingAlgorithm::Sha256);
+        let scheme =
+            RsaDecryptionScheme::create(RsaDecryptAlgorithm::Oaep, Some(HashingAlgorithm::Sha256))
+                .expect("Failed to create rsa decryption scheme");
 
         let plaintext_bytes: Vec<u8> = vec![0x01, 0x02, 0x03];
 
-        let plaintext = PublicKeyRSA::try_from(plaintext_bytes.clone()).unwrap();
+        let plaintext = PublicKeyRsa::try_from(plaintext_bytes.clone()).unwrap();
 
         let ciphertext = context
             .rsa_encrypt(key_handle, plaintext, scheme, Data::default())

--- a/tss-esapi/tests/context_tests/tpm_commands/context_management_tests.rs
+++ b/tss-esapi/tests/context_tests/tpm_commands/context_management_tests.rs
@@ -55,7 +55,7 @@ mod test_ctx_save {
             .unwrap();
 
         let key_handle = context
-            .load(prim_key_handle, result.out_private, result.out_public)
+            .load(prim_key_handle, result.out_private, &result.out_public)
             .unwrap();
         context.flush_context(prim_key_handle.into()).unwrap();
         let _ = context.context_save(key_handle.into()).unwrap();
@@ -98,7 +98,7 @@ mod test_ctx_load {
             .unwrap();
 
         let key_handle = context
-            .load(prim_key_handle, result.out_private, result.out_public)
+            .load(prim_key_handle, result.out_private, &result.out_public)
             .unwrap();
         context.flush_context(prim_key_handle.into()).unwrap();
         let key_ctx = context.context_save(key_handle.into()).unwrap();
@@ -163,7 +163,7 @@ mod test_flush_context {
             .unwrap();
 
         let key_handle = context
-            .load(prim_key_handle, result.out_private, result.out_public)
+            .load(prim_key_handle, result.out_private, &result.out_public)
             .unwrap();
         context.flush_context(prim_key_handle.into()).unwrap();
         let _ = context.read_public(key_handle).unwrap();

--- a/tss-esapi/tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -13,8 +13,7 @@ mod test_policy_signed {
             algorithm::HashingAlgorithm, resource_handles::Hierarchy,
             session_handles::PolicySession,
         },
-        structures::{Digest, Nonce, SymmetricDefinition},
-        utils::{AsymSchemeUnion, Signature, SignatureData},
+        structures::{Digest, Nonce, PublicKeyRsa, RsaSignature, Signature, SymmetricDefinition},
     };
     #[test]
     fn test_policy_signed() {
@@ -55,10 +54,15 @@ mod test_policy_signed {
         let cp_hash_a =
             Digest::try_from(vec![1, 2, 3]).expect("Failed to convert data into Digest");
         let policy_ref = Nonce::try_from(vec![1, 2, 3]).expect("Failed to convert data into Nonce");
-        let signature = Signature {
-            scheme: AsymSchemeUnion::RSASSA(HashingAlgorithm::Sha256),
-            signature: SignatureData::RsaSignature(vec![0xab; 32]),
-        };
+
+        let signature = Signature::RsaSsa(
+            RsaSignature::create(
+                HashingAlgorithm::Sha256,
+                PublicKeyRsa::try_from(vec![0xab; 32])
+                    .expect("Failed to create Public RSA key strucutre for RSA signature"),
+            )
+            .expect("Failed to create RSA signature"),
+        );
 
         let trial_policy_session = PolicySession::try_from(trial_policy_auth_session)
             .expect("Failed to convert auth session into policy session");

--- a/tss-esapi/tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
+++ b/tss-esapi/tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
@@ -88,7 +88,11 @@ mod test_change_auth {
             )
             .unwrap();
         let loaded_key = context
-            .load(prim_key_handle, keyresult.out_private, keyresult.out_public)
+            .load(
+                prim_key_handle,
+                keyresult.out_private,
+                &keyresult.out_public,
+            )
             .unwrap();
 
         let random_digest = context.get_random(16).unwrap();
@@ -98,7 +102,7 @@ mod test_change_auth {
             .object_change_auth(loaded_key.into(), prim_key_handle.into(), new_key_auth)
             .unwrap();
         context
-            .load(prim_key_handle, new_private, keyresult.out_public)
+            .load(prim_key_handle, new_private, &keyresult.out_public)
             .unwrap();
     }
 

--- a/tss-esapi/tests/interface_types_algorithms_tests.rs
+++ b/tss-esapi/tests/interface_types_algorithms_tests.rs
@@ -76,9 +76,7 @@ mod test_key_derivation_function_interface_type {
     use super::*;
     use tss_esapi::{
         constants::{
-            tss::{
-                TPM2_ALG_ECMQV, TPM2_ALG_KDF1_SP800_108, TPM2_ALG_KDF1_SP800_56A, TPM2_ALG_KDF2,
-            },
+            tss::{TPM2_ALG_KDF1_SP800_108, TPM2_ALG_KDF1_SP800_56A, TPM2_ALG_KDF2, TPM2_ALG_MGF1},
             AlgorithmIdentifier,
         },
         interface_types::algorithm::KeyDerivationFunction,
@@ -94,7 +92,7 @@ mod test_key_derivation_function_interface_type {
             KeyDerivationFunction::Kdf1Sp800_108
         );
         test_conversion!(TPM2_ALG_KDF2, KeyDerivationFunction::Kdf2);
-        test_conversion!(TPM2_ALG_ECMQV, KeyDerivationFunction::EcMqv);
+        test_conversion!(TPM2_ALG_MGF1, KeyDerivationFunction::Mgf1);
     }
 }
 
@@ -169,60 +167,60 @@ mod test_signature_scheme_interface_type {
             },
             AlgorithmIdentifier,
         },
-        interface_types::algorithm::{AsymmetricAlgorithm, SignatureScheme},
+        interface_types::algorithm::{AsymmetricAlgorithm, SignatureSchemeAlgorithm},
     };
     #[test]
     fn test_signature_scheme_conversion() {
-        test_conversion!(TPM2_ALG_RSASSA, SignatureScheme::RsaSsa);
-        test_conversion!(TPM2_ALG_RSAPSS, SignatureScheme::RsaPss);
-        test_conversion!(TPM2_ALG_ECDSA, SignatureScheme::EcDsa);
-        test_conversion!(TPM2_ALG_ECDAA, SignatureScheme::EcDaa);
-        test_conversion!(TPM2_ALG_SM2, SignatureScheme::Sm2);
-        test_conversion!(TPM2_ALG_ECSCHNORR, SignatureScheme::EcSchnorr);
-        test_conversion!(TPM2_ALG_HMAC, SignatureScheme::Hmac);
-        test_conversion!(TPM2_ALG_NULL, SignatureScheme::Null);
+        test_conversion!(TPM2_ALG_RSASSA, SignatureSchemeAlgorithm::RsaSsa);
+        test_conversion!(TPM2_ALG_RSAPSS, SignatureSchemeAlgorithm::RsaPss);
+        test_conversion!(TPM2_ALG_ECDSA, SignatureSchemeAlgorithm::EcDsa);
+        test_conversion!(TPM2_ALG_ECDAA, SignatureSchemeAlgorithm::EcDaa);
+        test_conversion!(TPM2_ALG_SM2, SignatureSchemeAlgorithm::Sm2);
+        test_conversion!(TPM2_ALG_ECSCHNORR, SignatureSchemeAlgorithm::EcSchnorr);
+        test_conversion!(TPM2_ALG_HMAC, SignatureSchemeAlgorithm::Hmac);
+        test_conversion!(TPM2_ALG_NULL, SignatureSchemeAlgorithm::Null);
     }
 
     #[test]
     fn test_special_conversion_into_asymmetric_algorithm() {
         assert_eq!(
             AsymmetricAlgorithm::Rsa,
-            SignatureScheme::RsaSsa
+            SignatureSchemeAlgorithm::RsaSsa
                 .try_into()
                 .expect("Failed to convert RsaSsa into asymmetric algorithm")
         );
         assert_eq!(
             AsymmetricAlgorithm::Rsa,
-            SignatureScheme::RsaPss
+            SignatureSchemeAlgorithm::RsaPss
                 .try_into()
                 .expect("Failed to convert RsaPss into asymmetric algorithm")
         );
         assert_eq!(
             AsymmetricAlgorithm::Ecc,
-            SignatureScheme::EcDsa
+            SignatureSchemeAlgorithm::EcDsa
                 .try_into()
                 .expect("Failed to convert EcDsa into asymmetric algorithm")
         );
         assert_eq!(
             AsymmetricAlgorithm::Ecc,
-            SignatureScheme::EcDaa
+            SignatureSchemeAlgorithm::EcDaa
                 .try_into()
                 .expect("Failed to convert EcDaa into asymmetric algorithm")
         );
         assert_eq!(
             AsymmetricAlgorithm::Ecc,
-            SignatureScheme::Sm2
+            SignatureSchemeAlgorithm::Sm2
                 .try_into()
                 .expect("Failed to convert Sm2 into asymmetric algorithm")
         );
 
-        if AsymmetricAlgorithm::try_from(SignatureScheme::Hmac).is_ok() {
+        if AsymmetricAlgorithm::try_from(SignatureSchemeAlgorithm::Hmac).is_ok() {
             panic!("It should not be possible to convert Hmac into an asymmetric algorithm");
         }
 
         // TODO: Change this if Null should be able to be converted into
         // an asymmetric algorithm
-        if AsymmetricAlgorithm::try_from(SignatureScheme::Null).is_ok() {
+        if AsymmetricAlgorithm::try_from(SignatureSchemeAlgorithm::Null).is_ok() {
             panic!("It should not be possible to convert Null into an asymmetric algorithm");
         }
     }

--- a/tss-esapi/tests/structures_buffers_public_rsa_exponent.rs
+++ b/tss-esapi/tests/structures_buffers_public_rsa_exponent.rs
@@ -1,0 +1,33 @@
+mod rsa_exponent_tests {
+    use tss_esapi::{structures::RsaExponent, Error, WrapperErrorKind};
+    #[test]
+    fn rsa_exponent_create_test() {
+        let expected_error = Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
+        // Valid values for RsaExponent are only 0 or a prime number value larger then 2.
+        assert_eq!(expected_error, RsaExponent::create(1));
+
+        // The specification says that 0 or any prime number larger then 2 should be accepted.
+        let _ = RsaExponent::create(0).expect("Failed to create a RsaExponent from the value 0");
+        let _ = RsaExponent::create(5).expect("Failed to create a RsaExponent from the value 5");
+    }
+
+    #[test]
+    fn rsa_exponent_is_valid_test() {
+        assert!(!RsaExponent::is_valid(1));
+        assert!(RsaExponent::is_valid(17));
+    }
+
+    #[test]
+    fn rsa_exponent_value_test() {
+        let expected_value = 97;
+
+        let rsa_exponent = RsaExponent::create(expected_value).unwrap_or_else(|_| {
+            panic!(
+                "Failed to create a RsaExponent from the value {}",
+                expected_value
+            )
+        });
+
+        assert_eq!(expected_value, rsa_exponent.value());
+    }
+}


### PR DESCRIPTION
- Removes all use of TPM2B_PUBLIC outside of the Context methods.
- Adds new builders and structures in order to be able to Creates
  the new Public object.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>