### PR TITLE
Implement Send/Sync on TctiContext

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "6.0.0"
+version = "6.1.0"
 authors = ["Parsec Project Contributors"]
 edition = "2018"
 description = "Rust-native wrapper around TSS 2.0 Enhanced System API"

--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -91,7 +91,7 @@ impl Context {
     pub fn new(tcti_name_conf: TctiNameConf) -> Result<Self> {
         let mut esys_context = null_mut();
 
-        let tcti_context = TctiContext::initialize(tcti_name_conf)?;
+        let mut tcti_context = TctiContext::initialize(tcti_name_conf)?;
 
         let ret = unsafe {
             Esys_Initialize(

--- a/tss-esapi/src/tcti_ldr.rs
+++ b/tss-esapi/src/tcti_ldr.rs
@@ -50,7 +50,7 @@ impl TctiContext {
     }
 
     /// Get access to the inner C pointer
-    pub(crate) fn tcti_context_ptr(&self) -> *mut tss_esapi_sys::TSS2_TCTI_CONTEXT {
+    pub(crate) fn tcti_context_ptr(&mut self) -> *mut tss_esapi_sys::TSS2_TCTI_CONTEXT {
         self.tcti_context
     }
 }
@@ -62,6 +62,13 @@ impl Drop for TctiContext {
         }
     }
 }
+
+// `Send` and `Sync` are implemented to allow `TctiContext` to be thread-safe.
+// This is necessary because `*mut TSS2_TCTI_CONTEXT` is not thread-safe by
+// default. We can confirm the safety as the pointer can only be accessed
+// in a thread-safe way (i.e. in methods that require a `&mut self`).
+unsafe impl Send for TctiContext {}
+unsafe impl Sync for TctiContext {}
 
 /// Wrapper around the TSS2_TCTI_INFO structure.
 #[derive(Debug)]


### PR DESCRIPTION
This commit adds Send and Sync implementations on TctiContext which
would allow Context and all structures depending on it to be
thread-safe.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>