### PR TITLE
Add missing key handle session checks

### DIFF
--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -55,7 +55,7 @@ impl Context {
             Esys_RSA_Decrypt(
                 self.mut_context(),
                 key_handle.into(),
-                self.optional_session_1(),
+                self.required_session_1()?,
                 self.optional_session_2(),
                 self.optional_session_3(),
                 &cipher_text.into(),

--- a/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
+++ b/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
@@ -60,7 +60,7 @@ impl Context {
             Esys_Sign(
                 self.mut_context(),
                 key_handle.into(),
-                self.optional_session_1(),
+                self.required_session_1()?,
                 self.optional_session_2(),
                 self.optional_session_3(),
                 &digest.clone().into(),


### PR DESCRIPTION
- Added checks for a key handle session to the context
  methods that according to the specification requires
  it.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>