### PR TITLE
Add ECDH-related functions

### DIFF
--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -321,11 +321,6 @@ impl Context {
     /// ```
     pub fn ecdh_z_gen(&mut self, key_handle: KeyHandle, in_point: EccPoint) -> Result<EccPoint> {
         let mut point = null_mut();
-        let in_point: TPMS_ECC_POINT = in_point.into();
-        let in_point = TPM2B_ECC_POINT {
-            size: in_point.x.size + in_point.y.size,
-            point: in_point,
-        };
         let ret = unsafe {
             Esys_ECDH_ZGen(
                 self.mut_context(),
@@ -333,7 +328,7 @@ impl Context {
                 self.required_session_1()?,
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &in_point,
+                &in_point.into(),
                 &mut point,
             )
         };

--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -3,12 +3,13 @@
 use crate::{
     handles::KeyHandle,
     structures::Data,
-    structures::{PublicKeyRsa, RsaDecryptionScheme},
+    structures::{EccPoint, PublicKeyRsa, RsaDecryptionScheme},
     tss2_esys::*,
     Context, Error, Result,
 };
 use log::error;
 use std::convert::TryFrom;
+use std::convert::TryInto;
 use std::ptr::null_mut;
 
 impl Context {
@@ -78,7 +79,137 @@ impl Context {
         }
     }
 
-    // Missing function: ECDH_KeyGen
+    /// Generate an ephemeral key pair.
+    ///
+    /// # Arguments
+    /// * `key_handle`- A [KeyHandle] of ECC key which curve parameters will be used
+    ///                 to generate the ephemeral key.
+    ///
+    /// # Details
+    /// This command uses the TPM to generate an ephemeral
+    /// key pair. It uses the private ephemeral key and a loaded
+    /// public key to compute the shared secret value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{
+    /// #    Context, TctiNameConf,
+    /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},
+    /// #    constants::SessionType,
+    /// #    interface_types::{
+    /// #        algorithm::{
+    /// #            HashingAlgorithm, PublicAlgorithm, RsaDecryptAlgorithm,
+    /// #        },
+    /// #        ecc::EccCurve,
+    /// #        resource_handles::Hierarchy,
+    /// #   },
+    /// #   structures::{
+    /// #       Auth, Data, EccScheme, PublicBuilder, PublicEccParametersBuilder, PublicKeyRsa, KeyDerivationFunctionScheme, EccPoint,
+    /// #        RsaDecryptionScheme, HashScheme, SymmetricDefinition,
+    /// #    },
+    /// # };
+    /// # use std::{env, str::FromStr, convert::TryFrom};
+    /// # // Create context
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// #
+    /// # let session = context
+    /// #     .start_auth_session(
+    /// #         None,
+    /// #         None,
+    /// #         None,
+    /// #         SessionType::Hmac,
+    /// #         SymmetricDefinition::AES_256_CFB,
+    /// #         tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha256,
+    /// #     )
+    /// #     .expect("Failed to create session")
+    /// #     .expect("Recived invalid handle");
+    /// # let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new()
+    /// #     .with_decrypt(true)
+    /// #     .with_encrypt(true)
+    /// #     .build();
+    /// # context.tr_sess_set_attributes(session, session_attributes, session_attributes_mask)
+    /// #     .expect("Failed to set attributes on session");
+    /// # context.set_sessions((Some(session), None, None));
+    /// # let random_digest = context.get_random(16).unwrap();
+    /// # let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+    /// #
+    /// // Create a key suitable for ECDH key generation
+    /// let ecc_parms = PublicEccParametersBuilder::new()
+    ///     .with_ecc_scheme(
+    ///         EccScheme::EcDh(HashScheme::new(HashingAlgorithm::Sha256)),
+    ///     )
+    ///     .with_curve(EccCurve::NistP256)
+    ///     .with_is_signing_key(false)
+    ///     .with_is_decryption_key(true)
+    ///     .with_restricted(false)
+    ///     .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let object_attributes = ObjectAttributesBuilder::new()
+    ///     .with_fixed_tpm(true)
+    ///     .with_fixed_parent(true)
+    ///     .with_sensitive_data_origin(true)
+    ///     .with_user_with_auth(true)
+    ///     .with_decrypt(true)
+    ///     .with_sign_encrypt(false)
+    ///     .with_restricted(false)
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let public = PublicBuilder::new()
+    ///     .with_public_algorithm(PublicAlgorithm::Ecc)
+    ///     .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+    ///     .with_object_attributes(object_attributes)
+    ///     .with_ecc_parameters(ecc_parms)
+    ///     .with_ecc_unique_identifier(&EccPoint::default())
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let key_handle = context
+    ///     .create_primary(
+    ///         Hierarchy::Owner,
+    ///         &public,
+    ///         Some(&key_auth),
+    ///         None,
+    ///         None,
+    ///         None,
+    ///     )
+    ///     .unwrap()
+    ///     .key_handle;
+    ///
+    /// // Generate ephemeral key pair and a shared secret
+    /// let (z_point, pub_point) = context.ecdh_key_gen(key_handle).unwrap();
+    /// ```
+    pub fn ecdh_key_gen(&mut self, key_handle: KeyHandle) -> Result<(EccPoint, EccPoint)> {
+        let mut z_point = null_mut();
+        let mut pub_point = null_mut();
+        let ret = unsafe {
+            Esys_ECDH_KeyGen(
+                self.mut_context(),
+                key_handle.into(),
+                self.optional_session_1(),
+                self.optional_session_2(),
+                self.optional_session_3(),
+                &mut z_point,
+                &mut pub_point,
+            )
+        };
+
+        let ret = Error::from_tss_rc(ret);
+
+        if ret.is_success() {
+            Ok(unsafe { ((*z_point).point.try_into()?, (*pub_point).point.try_into()?) })
+        } else {
+            error!("Error when generating ECDH keypair: {}", ret);
+            Err(ret)
+        }
+    }
+
     // Missing function: ECDH_ZGen
     // Missing function: ECC_Parameters
     // Missing function: ZGen_2Phase

--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -210,7 +210,143 @@ impl Context {
         }
     }
 
-    // Missing function: ECDH_ZGen
+    /// Recover Z value from a public point and a private key.
+    ///
+    /// # Arguments
+    /// * `key_handle` - A [KeyHandle] of ECC key which curve parameters will be used
+    ///                 to generate the ephemeral key.
+    /// * `in_point` - An [EccPoint] on the curve of the key referenced by `key_handle`
+    ///
+    /// # Details
+    /// This command uses the TPM to recover the Z value from a public point and a private key.
+    /// It will perform the multiplication of the provided `in_point` with the private key and
+    /// return the coordinates of the resultant point.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{
+    /// #    Context, TctiNameConf,
+    /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},
+    /// #    constants::SessionType,
+    /// #    interface_types::{
+    /// #        algorithm::{
+    /// #            HashingAlgorithm, PublicAlgorithm, RsaDecryptAlgorithm,
+    /// #        },
+    /// #        ecc::EccCurve,
+    /// #        resource_handles::Hierarchy,
+    /// #   },
+    /// #   structures::{
+    /// #       Auth, Data, EccScheme, PublicBuilder, PublicEccParametersBuilder, PublicKeyRsa, KeyDerivationFunctionScheme, EccPoint,
+    /// #        RsaDecryptionScheme, HashScheme, SymmetricDefinition,
+    /// #    },
+    /// # };
+    /// # use std::{env, str::FromStr, convert::TryFrom};
+    /// # // Create context
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// #
+    /// # let session = context
+    /// #     .start_auth_session(
+    /// #         None,
+    /// #         None,
+    /// #         None,
+    /// #         SessionType::Hmac,
+    /// #         SymmetricDefinition::AES_256_CFB,
+    /// #         tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha256,
+    /// #     )
+    /// #     .expect("Failed to create session")
+    /// #     .expect("Recived invalid handle");
+    /// # let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new()
+    /// #     .with_decrypt(true)
+    /// #     .with_encrypt(true)
+    /// #     .build();
+    /// # context.tr_sess_set_attributes(session, session_attributes, session_attributes_mask)
+    /// #     .expect("Failed to set attributes on session");
+    /// # context.set_sessions((Some(session), None, None));
+    /// # let random_digest = context.get_random(16).unwrap();
+    /// # let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+    /// #
+    /// // Create a key suitable for ECDH key generation
+    /// let ecc_parms = PublicEccParametersBuilder::new()
+    ///     .with_ecc_scheme(
+    ///         EccScheme::EcDh(HashScheme::new(HashingAlgorithm::Sha256)),
+    ///     )
+    ///     .with_curve(EccCurve::NistP256)
+    ///     .with_is_signing_key(false)
+    ///     .with_is_decryption_key(true)
+    ///     .with_restricted(false)
+    ///     .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let object_attributes = ObjectAttributesBuilder::new()
+    ///     .with_fixed_tpm(true)
+    ///     .with_fixed_parent(true)
+    ///     .with_sensitive_data_origin(true)
+    ///     .with_user_with_auth(true)
+    ///     .with_decrypt(true)
+    ///     .with_sign_encrypt(false)
+    ///     .with_restricted(false)
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let public = PublicBuilder::new()
+    ///     .with_public_algorithm(PublicAlgorithm::Ecc)
+    ///     .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+    ///     .with_object_attributes(object_attributes)
+    ///     .with_ecc_parameters(ecc_parms)
+    ///     .with_ecc_unique_identifier(&EccPoint::default())
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let key_handle = context
+    ///     .create_primary(
+    ///         Hierarchy::Owner,
+    ///         &public,
+    ///         Some(&key_auth),
+    ///         None,
+    ///         None,
+    ///         None,
+    ///     )
+    ///     .unwrap()
+    ///     .key_handle;
+    ///
+    /// // Generate ephemeral key pair and a shared secret
+    /// let (z_point, pub_point) = context.ecdh_key_gen(key_handle).unwrap();
+    /// let z_point_gen = context.ecdh_z_gen(key_handle, pub_point).unwrap();
+    /// assert_eq!(z_point.x().value(), z_point_gen.x().value());
+    /// ```
+    pub fn ecdh_z_gen(&mut self, key_handle: KeyHandle, in_point: EccPoint) -> Result<EccPoint> {
+        let mut point = null_mut();
+        let in_point: TPMS_ECC_POINT = in_point.into();
+        let in_point = TPM2B_ECC_POINT {
+            size: in_point.x.size + in_point.y.size,
+            point: in_point,
+        };
+        let ret = unsafe {
+            Esys_ECDH_ZGen(
+                self.mut_context(),
+                key_handle.into(),
+                self.required_session_1()?,
+                self.optional_session_2(),
+                self.optional_session_3(),
+                &in_point,
+                &mut point,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+
+        if ret.is_success() {
+            Ok(unsafe { (*point).point.try_into()? })
+        } else {
+            error!("Error when performing ECDH ZGen: {}", ret);
+            Err(ret)
+        }
+    }
+
     // Missing function: ECC_Parameters
     // Missing function: ZGen_2Phase
 }

--- a/tss-esapi/src/structures/buffers/public/ecc.rs
+++ b/tss-esapi/src/structures/buffers/public/ecc.rs
@@ -134,17 +134,17 @@ impl PublicEccParametersBuilder {
     /// error is returned
     pub fn build(self) -> Result<PublicEccParameters> {
         let ecc_scheme = self.ecc_scheme.ok_or_else(|| {
-            error!("Scheme is required nad has niot been set in the PublicEccParametersBuilder");
+            error!("Scheme is required nad has not been set in the PublicEccParametersBuilder");
             Error::local_error(WrapperErrorKind::ParamsMissing)
         })?;
 
         let ecc_curve = self.ecc_curve.ok_or_else(|| {
-            error!("Curve is required nad has niot been set in the PublicEccParametersBuilder");
+            error!("Curve is required nad has not been set in the PublicEccParametersBuilder");
             Error::local_error(WrapperErrorKind::ParamsMissing)
         })?;
 
         let key_derivation_function_scheme = self.key_derivation_function_scheme.ok_or_else(|| {
-            error!("Key derivation function scheme is required nad has niot been set in the PublicEccParametersBuilder");
+            error!("Key derivation function scheme is required nad has not been set in the PublicEccParametersBuilder");
             Error::local_error(WrapperErrorKind::ParamsMissing)
         })?;
 

--- a/tss-esapi/src/structures/ecc/point.rs
+++ b/tss-esapi/src/structures/ecc/point.rs
@@ -1,3 +1,5 @@
+use tss_esapi_sys::TPM2B_ECC_POINT;
+
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{structures::EccParameter, tss2_esys::TPMS_ECC_POINT, Error, Result};
@@ -41,6 +43,19 @@ impl From<EccPoint> for TPMS_ECC_POINT {
         TPMS_ECC_POINT {
             x: ecc_point.x.into(),
             y: ecc_point.y.into(),
+        }
+    }
+}
+
+impl From<EccPoint> for TPM2B_ECC_POINT {
+    fn from(ecc_point: EccPoint) -> Self {
+        let size = std::mem::size_of::<u16>()
+            + ecc_point.x().len()
+            + std::mem::size_of::<u16>()
+            + ecc_point.y().len();
+        TPM2B_ECC_POINT {
+            size: size as u16,
+            point: ecc_point.into(),
         }
     }
 }

--- a/tss-esapi/tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
+++ b/tss-esapi/tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
@@ -3,12 +3,17 @@
 mod test_rsa_encrypt_decrypt {
     use crate::common::{create_ctx_with_session, encryption_decryption_key_pub};
     use std::convert::TryFrom;
+    use tss_esapi::attributes::ObjectAttributesBuilder;
     use tss_esapi::{
         interface_types::{
-            algorithm::{HashingAlgorithm, RsaDecryptAlgorithm},
+            algorithm::{HashingAlgorithm, PublicAlgorithm, RsaDecryptAlgorithm},
+            ecc::EccCurve,
             resource_handles::Hierarchy,
         },
-        structures::{Auth, Data, PublicKeyRsa, RsaDecryptionScheme},
+        structures::{
+            Auth, Data, EccPoint, EccScheme, HashScheme, KeyDerivationFunctionScheme,
+            PublicBuilder, PublicEccParametersBuilder, PublicKeyRsa, RsaDecryptionScheme,
+        },
     };
 
     #[test]
@@ -49,5 +54,53 @@ mod test_rsa_encrypt_decrypt {
             .unwrap();
 
         assert_eq!(plaintext_bytes, decrypted.value());
+    }
+
+    #[test]
+    fn test_ecdh() {
+        let mut context = create_ctx_with_session();
+        let random_digest = context.get_random(16).unwrap();
+        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+
+        let ecc_parms = PublicEccParametersBuilder::new()
+            .with_ecc_scheme(EccScheme::EcDh(HashScheme::new(HashingAlgorithm::Sha256)))
+            .with_curve(EccCurve::NistP256)
+            .with_is_signing_key(false)
+            .with_is_decryption_key(true)
+            .with_restricted(false)
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .build()
+            .unwrap();
+
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .with_decrypt(true)
+            .with_sign_encrypt(false)
+            .with_restricted(false)
+            .build()
+            .unwrap();
+
+        let public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_ecc_parameters(ecc_parms)
+            .with_ecc_unique_identifier(&EccPoint::default())
+            .build()
+            .unwrap();
+
+        let key_handle = context
+            .create_primary(Hierarchy::Owner, &public, Some(&key_auth), None, None, None)
+            .unwrap()
+            .key_handle;
+
+        let (z_point, pub_point) = context.ecdh_key_gen(key_handle).unwrap();
+
+        let param = context.ecdh_z_gen(key_handle, pub_point).unwrap();
+
+        assert_eq!(z_point.x().value(), param.x().value());
     }
 }


### PR DESCRIPTION
This PR adds ECDH KeyGen and ZGen functions.

I left the naming similar to their TPM counterparts but if you have better options I'm all ears.

I don't mind if this PR is merged after https://github.com/parallaxsecond/rust-tss-esapi/pull/241 I'll then rebase and fix the raw types to their wrapper types. (OTOH adjusting shouldn't be difficult).

I'm submitting now so that this is tracked as I need the code anyway for my work :)

Have a nice day! :wave: 