### PR TITLE
Move TransientKeyContext away from contexts

### DIFF
--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -372,7 +372,7 @@ impl Context {
             let out_private = Private::try_from(*out_private)?;
             Ok(out_private)
         } else {
-            error!("Error changing hierarchy auth: {}", ret);
+            error!("Error changing object auth: {}", ret);
             Err(ret)
         }
     }

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -106,7 +106,8 @@ pub mod sensitive_data {
 }
 
 pub mod private {
-    buffer_type!(Private, 256, TPM2B_PRIVATE);
+    use tss_esapi_sys::_PRIVATE;
+    buffer_type!(Private, ::std::mem::size_of::<_PRIVATE>(), TPM2B_PRIVATE);
 }
 
 pub mod encrypted_secret {

--- a/tss-esapi/src/structures/buffers/public/rsa.rs
+++ b/tss-esapi/src/structures/buffers/public/rsa.rs
@@ -221,6 +221,10 @@ pub struct RsaExponent {
 }
 
 impl RsaExponent {
+    /// Empty exponent (internal value is 0), which is treated by TPMs
+    /// as a shorthand for the default value (2^16 + 1).
+    pub const ZERO_EXPONENT: Self = RsaExponent { value: 0 };
+
     /// Function for creating a new RsaExponent
     ///
     /// # Errors

--- a/tss-esapi/src/structures/tagged/schemes.rs
+++ b/tss-esapi/src/structures/tagged/schemes.rs
@@ -530,3 +530,16 @@ impl TryFrom<TPMT_RSA_DECRYPT> for RsaDecryptionScheme {
         }
     }
 }
+
+impl TryFrom<RsaScheme> for RsaDecryptionScheme {
+    type Error = Error;
+
+    fn try_from(rsa_scheme: RsaScheme) -> Result<Self> {
+        match rsa_scheme {
+            RsaScheme::RsaEs => Ok(RsaDecryptionScheme::RsaEs),
+            RsaScheme::Oaep(hash_scheme) => Ok(RsaDecryptionScheme::Oaep(hash_scheme)),
+            RsaScheme::Null => Ok(RsaDecryptionScheme::Null),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}

--- a/tss-esapi/src/structures/tagged/symmetric.rs
+++ b/tss-esapi/src/structures/tagged/symmetric.rs
@@ -202,6 +202,23 @@ impl From<SymmetricDefinitionObject> for TPMT_SYM_DEF_OBJECT {
     }
 }
 
+impl From<SymmetricDefinitionObject> for SymmetricDefinition {
+    fn from(sym_def_obj: SymmetricDefinitionObject) -> Self {
+        match sym_def_obj {
+            SymmetricDefinitionObject::Null => SymmetricDefinition::Null,
+            SymmetricDefinitionObject::Camellia { key_bits, mode } => {
+                SymmetricDefinition::Camellia { key_bits, mode }
+            }
+            SymmetricDefinitionObject::Aes { key_bits, mode } => {
+                SymmetricDefinition::Aes { key_bits, mode }
+            }
+            SymmetricDefinitionObject::Sm4 { key_bits, mode } => {
+                SymmetricDefinition::Sm4 { key_bits, mode }
+            }
+        }
+    }
+}
+
 impl TryFrom<TPMT_SYM_DEF_OBJECT> for SymmetricDefinitionObject {
     type Error = Error;
     fn try_from(tpmt_sym_def_object: TPMT_SYM_DEF_OBJECT) -> Result<SymmetricDefinitionObject> {


### PR DESCRIPTION
This commit moves the TransientKeyContext away from using saved key
contexts. Instead, keys are returned and managed as pairs of public and
(encrypted) private parts which are loaded into the TPM every time an
operation is requested.
A migration mechanism is also implemented to convert from contexts to
the new key material format.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>