### PR TITLE
Fix compile error when using zeroize_derive >= 1.2.0

### DIFF
--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -852,7 +852,7 @@ impl TryFrom<Signature> for TPMT_SIGNATURE {
         }
         match sig.scheme {
             AsymSchemeUnion::RSASSA(hash_alg) => {
-                let signature = match sig.signature {
+                let signature = match &sig.signature {
                     SignatureData::RsaSignature(signature) => signature,
                     SignatureData::EcdsaSignature { .. } => {
                         return Err(Error::local_error(WrapperErrorKind::InconsistentParams))
@@ -880,7 +880,7 @@ impl TryFrom<Signature> for TPMT_SIGNATURE {
                 })
             }
             AsymSchemeUnion::RSAPSS(hash_alg) => {
-                let signature = match sig.signature {
+                let signature = match &sig.signature {
                     SignatureData::RsaSignature(signature) => signature,
                     SignatureData::EcdsaSignature { .. } => {
                         return Err(Error::local_error(WrapperErrorKind::InconsistentParams))
@@ -908,7 +908,7 @@ impl TryFrom<Signature> for TPMT_SIGNATURE {
                 })
             }
             AsymSchemeUnion::ECDSA(hash_alg) => {
-                let signature = match sig.signature {
+                let signature = match &sig.signature {
                     SignatureData::EcdsaSignature { r, s } => (r, s),
                     SignatureData::RsaSignature(_) => {
                         return Err(Error::local_error(WrapperErrorKind::InconsistentParams))


### PR DESCRIPTION
Fix "cannot move out of type which implements the Drop trait" compile
errors when using zeroize_derive >= 1.2.0 by matching on a reference
to the signature field contained in the SignatureData type. The code
previously compiled fine when using zeroize_derive <= 1.1.0 as it was
mistakenly not deriving the Drop trait for enum types.

Fixes #260

Signed-off-by: Rob Shearman <rob@graphiant.com>