### PR TITLE
Add property tag variant for MaxCapBuffer

### DIFF
--- a/tss-esapi/src/constants/property_tag.rs
+++ b/tss-esapi/src/constants/property_tag.rs
@@ -56,6 +56,7 @@ pub enum PropertyTag {
     VendorCommands = TPM2_PT_VENDOR_COMMANDS,
     NvBufferMax = TPM2_PT_NV_BUFFER_MAX,
     Modes = TPM2_PT_MODES,
+    MaxCapBuffer = TPM2_PT_MAX_CAP_BUFFER,
     // Variable
     Permanent = TPM2_PT_PERMANENT,
     StartupClear = TPM2_PT_STARTUP_CLEAR,

--- a/tss-esapi/src/constants/tss.rs
+++ b/tss-esapi/src/constants/tss.rs
@@ -423,6 +423,7 @@ pub const TPM2_PT_LIBRARY_COMMANDS: TPM2_PT = TPM2_PT_FIXED + 42; /* number of c
 pub const TPM2_PT_VENDOR_COMMANDS: TPM2_PT = TPM2_PT_FIXED + 43; /* number of vendor commands that are implemented */
 pub const TPM2_PT_NV_BUFFER_MAX: TPM2_PT = TPM2_PT_FIXED + 44; /* the maximum data size in one NV write command */
 pub const TPM2_PT_MODES: TPM2_PT = TPM2_PT_FIXED + 45; /* a TPMA_MODES value indicating that the TPM is designed for these modes. */
+pub const TPM2_PT_MAX_CAP_BUFFER: TPM2_PT = TPM2_PT_FIXED + 46; /* the maximum size of a TPMS_CAPABILITY_DATA structure returned in TPM2_GetCapability(). */
 pub const TPM2_PT_VAR: TPM2_PT = TPM2_PT_GROUP * 2; /* the group of variable properties returned as TPMS_TAGGED_PROPERTY. The properties in this group change because of a Protected Capability other than a firmware update. The values are not necessarily persistent across all power transitions. */
 pub const TPM2_PT_PERMANENT: TPM2_PT = TPM2_PT_VAR + 0; /* TPMA_PERMANENT */
 pub const TPM2_PT_STARTUP_CLEAR: TPM2_PT = TPM2_PT_VAR + 1; /* TPMA_STARTUP_CLEAR */


### PR DESCRIPTION
As per "TCG TSS 2.0 Overview and Common Structures Specification" v0.9
rev 03, and tpm2-tss >= 2.4.0, add a constant for
TPM2_PT_MAX_CAP_BUFFER and a corresponding PropertyTag variant,
MaxCapBuffer.

This avoids an error for "value = 302 did not match any PropertyTag"
that may be seen with some TPM implementations.

Signed-off-by: Rob Shearman <rob@graphiant.com>