### PR TITLE
Fix error comment for ECC decryption keys

### DIFF
--- a/tss-esapi/src/structures/buffers/public/ecc.rs
+++ b/tss-esapi/src/structures/buffers/public/ecc.rs
@@ -154,7 +154,7 @@ impl PublicEccParametersBuilder {
                 return Err(Error::local_error(WrapperErrorKind::ParamsMissing));
             }
         } else if self.symmetric.is_some() {
-            error!("Symmetric should be set for decryption keys");
+            error!("Symmetric should not be set for decryption keys that are not restricted");
             return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
         }
         if self.is_decryption_key && self.is_signing_key {


### PR DESCRIPTION
The error message that I've added with the other PR was reversed. This PR fixes that.