### PR TITLE
Add version testing to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ jobs:
       - name: Run the container
         run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
 
+  tests-ubuntu-v3:
+    name: Ubuntu tests on v3.x.y of tpm2-tss
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the container
+        run: docker build -t ubuntucontainer tss-esapi/tests/ --build-arg TPM2_TSS_VERSION=3.0.4 --file tss-esapi/tests/Dockerfile-ubuntu
+      - name: Run the container
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+
   tests-fedora:
     name: Fedora tests
     # We just build a container... GitHub doesn't like Fedora :(

--- a/tss-esapi/tests/Dockerfile-ubuntu
+++ b/tss-esapi/tests/Dockerfile-ubuntu
@@ -1,9 +1,11 @@
 FROM ghcr.io/tpm2-software/ubuntu-18.04:latest
 
+ARG TPM2_TSS_VERSION=2.3.3
+ENV TPM2_TSS_VERSION=$TPM2_TSS_VERSION
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
-# Download and install TSS 2.0
-RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.3
+# Download and install the TSS library
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch $TPM2_TSS_VERSION
 RUN cd tpm2-tss \
 	&& ./bootstrap \
 	&& ./configure \

--- a/tss-esapi/tests/all-ubuntu.sh
+++ b/tss-esapi/tests/all-ubuntu.sh
@@ -10,6 +10,15 @@
 
 set -euf -o pipefail
 
+#################################################
+# Generate bindings for non-"standard" versions #
+#################################################
+if [[ "$TPM2_TSS_VERSION" != "2.3.3" ]]; then
+	FEATURES="--features=generate-bindings"
+else
+	FEATURES=""
+fi
+
 #################################
 # Run the TPM simulation server #
 #################################
@@ -25,9 +34,9 @@ cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::cargo
 ###################
 # Build the crate #
 ###################
-RUST_BACKTRACE=1 cargo build
+RUST_BACKTRACE=1 cargo build $FEATURES
 
 #################
 # Run the tests #
 #################
-TEST_TCTI=mssim: RUST_BACKTRACE=1 RUST_LOG=info cargo test -- --test-threads=1 --nocapture
+TEST_TCTI=mssim: RUST_BACKTRACE=1 RUST_LOG=info cargo test $FEATURES -- --test-threads=1 --nocapture


### PR DESCRIPTION
This commit modifies the Ubuntu CI testing to allow for different
versions of the tpm2-tss library to be used with our crate.

Fixes #269 