### PR TITLE
Make Name wrap the raw type directly

### DIFF
--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -352,7 +352,6 @@ impl Context {
         key_sign: &Name,
         check_ticket: VerifiedTicket,
     ) -> Result<()> {
-        let tss_key_sign = TPM2B_NAME::try_from(key_sign.clone())?;
         let check_ticket = TPMT_TK_VERIFIED::try_from(check_ticket)?;
         let ret = unsafe {
             Esys_PolicyAuthorize(
@@ -363,7 +362,7 @@ impl Context {
                 self.optional_session_3(),
                 &approved_policy.clone().into(),
                 &policy_ref.clone().into(),
-                &tss_key_sign,
+                key_sign.as_ref(),
                 &check_ticket,
             )
         };

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -298,7 +298,7 @@ impl Context {
                 self.optional_session_2(),
                 self.optional_session_3(),
                 &credential.into(),
-                &object_name.try_into()?,
+                object_name.as_ref(),
                 &mut out_credential_blob,
                 &mut out_secret,
             )

--- a/tss-esapi/src/structures/creation.rs
+++ b/tss-esapi/src/structures/creation.rs
@@ -57,8 +57,8 @@ impl TryFrom<CreationData> for TPMS_CREATION_DATA {
                 None => AlgorithmIdentifier::Null.into(),
                 Some(alg) => alg.into(),
             },
-            parentName: creation_data.parent_name.try_into()?,
-            parentQualifiedName: creation_data.parent_qualified_name.try_into()?,
+            parentName: *creation_data.parent_name.as_ref(),
+            parentQualifiedName: *creation_data.parent_qualified_name.as_ref(),
             outsideInfo: creation_data.outside_info.into(),
         })
     }

--- a/tss-esapi/src/structures/creation.rs
+++ b/tss-esapi/src/structures/creation.rs
@@ -46,10 +46,9 @@ impl TryFrom<TPM2B_CREATION_DATA> for CreationData {
     }
 }
 
-impl TryFrom<CreationData> for TPMS_CREATION_DATA {
-    type Error = Error;
-    fn try_from(creation_data: CreationData) -> Result<Self> {
-        Ok(TPMS_CREATION_DATA {
+impl From<CreationData> for TPMS_CREATION_DATA {
+    fn from(creation_data: CreationData) -> Self {
+        TPMS_CREATION_DATA {
             pcrSelect: creation_data.pcr_select.into(),
             pcrDigest: creation_data.pcr_digest.into(),
             locality: creation_data.locality,
@@ -57,9 +56,9 @@ impl TryFrom<CreationData> for TPMS_CREATION_DATA {
                 None => AlgorithmIdentifier::Null.into(),
                 Some(alg) => alg.into(),
             },
-            parentName: *creation_data.parent_name.as_ref(),
-            parentQualifiedName: *creation_data.parent_qualified_name.as_ref(),
+            parentName: creation_data.parent_name.into(),
+            parentQualifiedName: creation_data.parent_qualified_name.into(),
             outsideInfo: creation_data.outside_info.into(),
-        })
+        }
     }
 }

--- a/tss-esapi/src/structures/names/name.rs
+++ b/tss-esapi/src/structures/names/name.rs
@@ -54,6 +54,12 @@ impl TryFrom<TPM2B_NAME> for Name {
     }
 }
 
+impl From<Name> for TPM2B_NAME {
+    fn from(name: Name) -> Self {
+        name.value
+    }
+}
+
 impl AsRef<TPM2B_NAME> for Name {
     fn as_ref(&self) -> &TPM2B_NAME {
         &self.value


### PR DESCRIPTION
Hi,

I've noticed that in the `cryptoki` crate most wrapper types just [directly contain the native/raw type](https://github.com/parallaxsecond/rust-cryptoki/blob/main/cryptoki/src/types/slot_token.rs#L90). This makes it very efficient to pass around.

Usually it's the low level function that gives and accepts the raw types and using the wrapper design, without intermediate `Vec<u8>` buffer makes it possible to borrow immutable refs to the inner type (via `AsRef<T>`). This allows reusing one reference thus reducing the number of `clone`s needed.

(Edit: I think some Rust types also use this approach of exposing inner types, e.g. [`Vec<u8>` implements `AsRef<&[u8]>`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.as_ref-1) and [`str` implements `AsRef<[u8]>`](https://doc.rust-lang.org/std/primitive.str.html#impl-AsRef%3C%5Bu8%5D%3E)).

In this example PR I just did that to `Name` but I think more types could benefit from this approach too but since I'm not a super-experienced Rust programmer I'll leave the PR here for discussion on whether this approach is worth to explore.

See you later! :wave: 

CC: @ionut-arm, @Superhepper, @hug-dev.