### PR TITLE
Improved return values of pcr_read.

### DIFF
--- a/tss-esapi/src/abstraction/mod.rs
+++ b/tss-esapi/src/abstraction/mod.rs
@@ -5,6 +5,7 @@ pub mod ak;
 pub mod cipher;
 pub mod ek;
 pub mod nv;
+pub mod pcr;
 pub mod transient;
 
 use crate::{attributes::ObjectAttributesBuilder, structures::PublicBuilder};

--- a/tss-esapi/src/abstraction/pcr.rs
+++ b/tss-esapi/src/abstraction/pcr.rs
@@ -1,0 +1,71 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+mod bank;
+mod data;
+
+use crate::{structures::PcrSelectionList, Context, Result};
+
+pub use bank::PcrBank;
+pub use data::PcrData;
+
+/// Function that reads all the PCRs in a selection list and returns
+/// the result as PCR data.
+///
+/// # Example
+///
+/// ```rust
+/// # use tss_esapi::{Context, TctiNameConf};
+/// # // Create context
+/// # let mut context =
+/// #     Context::new(
+/// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+/// #     ).expect("Failed to create Context");
+/// #
+/// use tss_esapi::{
+///     interface_types::algorithm::HashingAlgorithm,
+///     structures::{PcrSelectionListBuilder, PcrSlot},
+/// };
+/// // Create PCR selection list with slots in a bank
+/// // that is going to be read.
+/// let pcr_selection_list = PcrSelectionListBuilder::new()
+///     .with_selection(HashingAlgorithm::Sha256,
+///         &[
+///             PcrSlot::Slot0,
+///             PcrSlot::Slot1,
+///             PcrSlot::Slot2,
+///             PcrSlot::Slot3,
+///             PcrSlot::Slot4,
+///             PcrSlot::Slot5,
+///             PcrSlot::Slot6,
+///             PcrSlot::Slot7,
+///             PcrSlot::Slot8,
+///             PcrSlot::Slot9,
+///             PcrSlot::Slot10,
+///             PcrSlot::Slot11,
+///             PcrSlot::Slot12,
+///             PcrSlot::Slot13,
+///             PcrSlot::Slot14,
+///             PcrSlot::Slot15,
+///             PcrSlot::Slot16,
+///             PcrSlot::Slot17,
+///             PcrSlot::Slot18,
+///             PcrSlot::Slot19,
+///             PcrSlot::Slot20,
+///             PcrSlot::Slot21,
+///     ])
+///     .build();
+/// let _pcr_data = tss_esapi::abstraction::pcr::read_all(&mut context, pcr_selection_list)
+///     .expect("pcr::read_all failed");
+/// ```
+pub fn read_all(
+    context: &mut Context,
+    mut pcr_selection_list: PcrSelectionList,
+) -> Result<PcrData> {
+    let mut pcr_data = PcrData::new();
+    while !pcr_selection_list.is_empty() {
+        let (_, pcrs_read, pcr_digests) = context.pcr_read(&pcr_selection_list)?;
+        pcr_data.add(&pcrs_read, &pcr_digests)?;
+        pcr_selection_list.subtract(&pcrs_read)?;
+    }
+    Ok(pcr_data)
+}

--- a/tss-esapi/src/abstraction/pcr/bank.rs
+++ b/tss-esapi/src/abstraction/pcr/bank.rs
@@ -1,0 +1,134 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    structures::{Digest, PcrSlot},
+    Error, Result, WrapperErrorKind,
+};
+use log::error;
+use std::collections::BTreeMap;
+
+/// Struct for holding PcrSlots and their
+/// corresponding values.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct PcrBank {
+    bank: BTreeMap<PcrSlot, Digest>,
+}
+
+impl PcrBank {
+    /// Function that creates PcrBank from a vector of pcr slots and
+    /// a vector of pcr digests.
+    ///
+    /// # Details
+    /// The order of pcr slots are assumed to match the order of the Digests.
+    ///
+    /// # Error
+    /// - If number of pcr slots does not match the number of pcr digests
+    ///   InconsistentParams error is returned.
+    ///
+    /// - If the vector of pcr slots contains duplicates then
+    ///   InconsistentParams error is returned.
+    pub fn create(mut pcr_slots: Vec<PcrSlot>, mut digests: Vec<Digest>) -> Result<PcrBank> {
+        if pcr_slots.len() != digests.len() {
+            error!(
+                "Number of PcrSlots does not match the number of PCR digests. ({} != {})",
+                pcr_slots.len(),
+                digests.len()
+            );
+            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+        }
+        pcr_slots
+            .drain(..)
+            .zip(digests.drain(..))
+            .try_fold(BTreeMap::<PcrSlot, Digest>::new(), |mut data, (pcr_slot, digest)| {
+                if data.insert(pcr_slot, digest).is_none() {
+                    Ok(data)
+                } else {
+                    error!("Error trying to insert data into PcrSlot {:?} where data have already been inserted", pcr_slot);
+                    Err(Error::local_error(WrapperErrorKind::InconsistentParams))
+                }
+            })
+            .map(|bank|  PcrBank { bank })
+    }
+
+    /// Retrieves reference to a [Digest] associated with the provided [PcrSlot].
+    ///
+    /// # Details
+    /// Returns a reference to a [Digest] associated with the provided [PcrSlot]
+    /// if one exists else returns None.
+    pub fn get_digest(&self, pcr_slot: PcrSlot) -> Option<&Digest> {
+        self.bank.get(&pcr_slot)
+    }
+
+    /// Returns true if the [PcrBank] contains a digest
+    /// for the provided [PcrSlot].
+    pub fn has_digest(&self, pcr_slot: PcrSlot) -> bool {
+        self.bank.contains_key(&pcr_slot)
+    }
+
+    /// Number of digests in the [PcrBank]
+    pub fn len(&self) -> usize {
+        self.bank.len()
+    }
+
+    /// Returns true if the [PcrBank] is empty
+    pub fn is_empty(&self) -> bool {
+        self.bank.is_empty()
+    }
+
+    /// Removees the [Digest] associated with the [PcrSlot] and
+    /// returns it.
+    ///
+    /// # Details
+    /// Removes the [Digest] associated with the provided [PcrSlot]
+    /// out of the bank and returns it if it exists else returns None.
+    pub fn remove_digest(&mut self, pcr_slot: PcrSlot) -> Option<Digest> {
+        self.bank.remove(&pcr_slot)
+    }
+
+    /// Inserts [Digest] value associated with a [PcrSlot] into the bank.
+    ///
+    /// # Error
+    /// Returns an error if a [Digest] is already associated with the
+    /// provided [PcrSlot].
+    pub fn insert_digest(&mut self, pcr_slot: PcrSlot, digest: Digest) -> Result<()> {
+        self.ensure_non_existing(pcr_slot, "Failed to insert")?;
+        let _ = self.bank.insert(pcr_slot, digest);
+        Ok(())
+    }
+
+    /// Attempts to extend the [PcrBank] with `other`.
+    ///
+    /// # Error
+    /// Returns an error if the a value in `other` already
+    /// exists.
+    pub fn try_extend(&mut self, other: PcrBank) -> Result<()> {
+        other
+            .bank
+            .keys()
+            .try_for_each(|&pcr_slot| self.ensure_non_existing(pcr_slot, "Failed to extend"))?;
+        self.bank.extend(other.bank);
+        Ok(())
+    }
+
+    /// Returns an error if a [Digest] for [PcrSlot] already exists in the bank
+    fn ensure_non_existing(&self, pcr_slot: PcrSlot, error_msg: &str) -> Result<()> {
+        if self.has_digest(pcr_slot) {
+            error!(
+                "{}, a digest already for PcrSlot {:?} exists in the bank",
+                error_msg, pcr_slot
+            );
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(())
+    }
+}
+
+impl<'a> IntoIterator for &'a PcrBank {
+    type Item = (&'a PcrSlot, &'a Digest);
+    type IntoIter = ::std::collections::btree_map::Iter<'a, PcrSlot, Digest>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.bank.iter()
+    }
+}

--- a/tss-esapi/src/abstraction/pcr/data.rs
+++ b/tss-esapi/src/abstraction/pcr/data.rs
@@ -1,0 +1,134 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    abstraction::pcr::PcrBank,
+    interface_types::algorithm::HashingAlgorithm,
+    structures::{Digest, DigestList, PcrSelectionList},
+    tss2_esys::TPML_DIGEST,
+    Error, Result, WrapperErrorKind,
+};
+use log::error;
+/// Struct holding pcr banks and their associated
+/// hashing algorithm
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PcrData {
+    data: Vec<(HashingAlgorithm, PcrBank)>,
+}
+
+impl PcrData {
+    /// Creates new empty PcrData
+    pub const fn new() -> Self {
+        PcrData { data: Vec::new() }
+    }
+
+    /// Function for creating PcrData from a pcr selection list and pcr digests list.
+    pub fn create(
+        pcr_selection_list: &PcrSelectionList,
+        digest_list: &DigestList,
+    ) -> Result<PcrData> {
+        Ok(PcrData {
+            data: Self::create_data(pcr_selection_list, digest_list.value().to_vec())?,
+        })
+    }
+
+    /// Adds data to the PcrData
+    pub fn add(
+        &mut self,
+        pcr_selection_list: &PcrSelectionList,
+        digest_list: &DigestList,
+    ) -> Result<()> {
+        Self::create_data(pcr_selection_list, digest_list.value().to_vec())?
+            .drain(..)
+            .try_for_each(|(hashing_algorithm, pcr_bank)| {
+                if let Some(existing_pcr_bank) = self.pcr_bank_mut(hashing_algorithm) {
+                    existing_pcr_bank.try_extend(pcr_bank)?;
+                } else {
+                    self.data.push((hashing_algorithm, pcr_bank));
+                }
+                Ok(())
+            })
+    }
+
+    /// Function for turning a pcr selection list and pcr digests values
+    /// into the format in which data is stored in PcrData.
+    fn create_data(
+        pcr_selection_list: &PcrSelectionList,
+        mut digests: Vec<Digest>,
+    ) -> Result<Vec<(HashingAlgorithm, PcrBank)>> {
+        pcr_selection_list
+            .get_selections()
+            .iter()
+            .map(|pcr_selection| {
+                let pcr_slots = pcr_selection.selected();
+                if pcr_slots.len() > digests.len() {
+                    error!("More pcr slots in selection then available digests");
+                    return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+                }
+                let digests_in_bank = digests.drain(..pcr_slots.len()).collect();
+                Ok((
+                    pcr_selection.hashing_algorithm(),
+                    PcrBank::create(pcr_slots, digests_in_bank)?,
+                ))
+            })
+            .collect()
+    }
+
+    /// Function for retrieving the first PCR values associated with hashing_algorithm.
+    pub fn pcr_bank(&self, hashing_algorithm: HashingAlgorithm) -> Option<&PcrBank> {
+        self.data
+            .iter()
+            .find(|(alg, _)| *alg == hashing_algorithm)
+            .map(|(_, bank)| bank)
+    }
+
+    /// Function for retrieving the number of banks in the data.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns true if there are no banks in the data.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Private method for finding a PCR bank.
+    fn pcr_bank_mut(&mut self, hashing_algorithm: HashingAlgorithm) -> Option<&mut PcrBank> {
+        self.data
+            .iter_mut()
+            .find(|(alg, _)| *alg == hashing_algorithm)
+            .map(|(_, bank)| bank)
+    }
+}
+
+impl<'a> IntoIterator for PcrData {
+    type Item = (HashingAlgorithm, PcrBank);
+    type IntoIter = ::std::vec::IntoIter<(HashingAlgorithm, PcrBank)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+impl From<PcrData> for Vec<TPML_DIGEST> {
+    fn from(pcr_data: PcrData) -> Self {
+        pcr_data
+            .data
+            .iter()
+            .flat_map(|(_, pcr_bank)| pcr_bank.into_iter())
+            .map(|(_, digest)| digest)
+            .collect::<Vec<&Digest>>()
+            .chunks(DigestList::MAX_SIZE)
+            .map(|digests| {
+                let mut tpml_digest: TPML_DIGEST = Default::default();
+                for (index, digest) in digests.iter().enumerate() {
+                    tpml_digest.count += 1;
+                    tpml_digest.digests[index].size = digest.len() as u16;
+                    tpml_digest.digests[index].buffer[..digest.len()]
+                        .copy_from_slice(digest.value());
+                }
+                tpml_digest
+            })
+            .collect()
+    }
+}

--- a/tss-esapi/src/structures/pcr/select.rs
+++ b/tss-esapi/src/structures/pcr/select.rs
@@ -133,6 +133,11 @@ impl PcrSelect {
     }
 
     /// Returns the size of the select.
+    ///
+    /// NB! This is not the same as how many [PcrSlot]
+    /// there are in the select but rather how many
+    /// octets that are needed to hold the bit field
+    /// that indicate what slots that are selected.
     pub fn size_of_select(&self) -> PcrSelectSize {
         self.size_of_select
     }

--- a/tss-esapi/tests/integration_tests/abstraction_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/mod.rs
@@ -3,4 +3,6 @@
 mod ak_tests;
 mod ek_tests;
 mod nv_tests;
+mod pcr_data_tests;
+mod pcr_tests;
 mod transient_key_context_tests;

--- a/tss-esapi/tests/integration_tests/abstraction_tests/pcr_data_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/pcr_data_tests.rs
@@ -1,0 +1,128 @@
+use tss_esapi::{
+    abstraction::pcr::PcrData,
+    interface_types::algorithm::HashingAlgorithm,
+    structures::{Digest, DigestList, PcrSelectionListBuilder, PcrSlot},
+    tss2_esys::TPML_DIGEST,
+    Error, WrapperErrorKind,
+};
+
+use std::convert::TryFrom;
+
+#[test]
+fn test_valid_to_tpml_digest_conversion() {
+    let pcr_selection_list_1 = PcrSelectionListBuilder::new()
+        .with_selection(
+            HashingAlgorithm::Sha256,
+            &[
+                PcrSlot::Slot0,
+                PcrSlot::Slot1,
+                PcrSlot::Slot2,
+                PcrSlot::Slot3,
+                PcrSlot::Slot4,
+                PcrSlot::Slot5,
+                PcrSlot::Slot6,
+                PcrSlot::Slot7,
+            ],
+        )
+        .build();
+
+    let mut pcr_digest_list_1 = DigestList::new();
+    for i in 0u8..8u8 {
+        let value: [u8; 1] = [i];
+        pcr_digest_list_1
+            .add(Digest::try_from(&value[..]).expect("Failed to create digest value"))
+            .expect("Failed to add value to digest");
+    }
+
+    let pcr_selection_list_2 = PcrSelectionListBuilder::new()
+        .with_selection(
+            HashingAlgorithm::Sha256,
+            &[
+                PcrSlot::Slot8,
+                PcrSlot::Slot9,
+                PcrSlot::Slot10,
+                PcrSlot::Slot11,
+                PcrSlot::Slot12,
+                PcrSlot::Slot13,
+                PcrSlot::Slot14,
+                PcrSlot::Slot15,
+            ],
+        )
+        .build();
+
+    let mut pcr_digest_list_2 = DigestList::new();
+    for i in 8u8..16u8 {
+        let value: [u8; 1] = [i];
+        pcr_digest_list_2
+            .add(Digest::try_from(&value[..]).expect("Failed to create digest value"))
+            .expect("Failed to add value to digest");
+    }
+
+    let mut pcr_data = PcrData::new();
+    pcr_data
+        .add(&pcr_selection_list_1, &pcr_digest_list_1)
+        .expect("Failed to add selection and digests nr1");
+    pcr_data
+        .add(&pcr_selection_list_2, &pcr_digest_list_2)
+        .expect("Failed to add selection and digests nr2");
+
+    let tpml_digests: Vec<TPML_DIGEST> = pcr_data.into();
+    assert_eq!(
+        tpml_digests.len(),
+        2,
+        "PcrData did not convert into 2 TPML_DIGEST items as expected"
+    );
+    for (tpml_digest, count) in tpml_digests.iter().zip(0u8..2u8) {
+        assert_eq!(
+            tpml_digest.count as usize,
+            DigestList::MAX_SIZE,
+            "The converted digest list did not contain expected number of elements"
+        );
+        for (tpm2b_digest, value) in tpml_digest.digests.iter().zip(8 * count..8 * (count + 1)) {
+            assert_eq!(
+                tpm2b_digest.size, 1,
+                "The converted digest did not contain expected number of bytes"
+            );
+            assert_eq!(
+                tpm2b_digest.buffer[0], value,
+                "Thw converted digest did not contain expected values"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_invalid_to_tpml_digest_conversion() {
+    let pcr_selection_list_1 = PcrSelectionListBuilder::new()
+        .with_selection(
+            HashingAlgorithm::Sha256,
+            &[
+                PcrSlot::Slot0,
+                PcrSlot::Slot1,
+                PcrSlot::Slot2,
+                PcrSlot::Slot3,
+                PcrSlot::Slot4,
+                PcrSlot::Slot5,
+                PcrSlot::Slot6,
+                PcrSlot::Slot7,
+            ],
+        )
+        .build();
+
+    let mut pcr_digest_list_1 = DigestList::new();
+    for i in 0u8..7u8 {
+        let value: [u8; 1] = [i];
+        pcr_digest_list_1
+            .add(Digest::try_from(&value[..]).expect("Failed to create digest value"))
+            .expect("Failed to add value to digest");
+    }
+
+    let mut pcr_data = PcrData::new();
+    let pcr_data_add_result = pcr_data.add(&pcr_selection_list_1, &pcr_digest_list_1);
+
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::InconsistentParams)),
+        pcr_data_add_result,
+        "Did not receive expected error"
+    );
+}

--- a/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
@@ -1,0 +1,137 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::common::create_ctx_without_session;
+
+use tss_esapi::{
+    interface_types::algorithm::HashingAlgorithm,
+    structures::{PcrSelectionListBuilder, PcrSlot},
+};
+
+#[test]
+fn test_pcr_read_all() {
+    let mut context = create_ctx_without_session();
+
+    let pcr_selection_list = PcrSelectionListBuilder::new()
+        .with_selection(
+            HashingAlgorithm::Sha256,
+            &[
+                PcrSlot::Slot0,
+                PcrSlot::Slot1,
+                PcrSlot::Slot2,
+                PcrSlot::Slot3,
+                PcrSlot::Slot4,
+                PcrSlot::Slot5,
+                PcrSlot::Slot6,
+                PcrSlot::Slot7,
+                PcrSlot::Slot8,
+                PcrSlot::Slot9,
+                PcrSlot::Slot10,
+                PcrSlot::Slot11,
+                PcrSlot::Slot12,
+                PcrSlot::Slot13,
+                PcrSlot::Slot14,
+                PcrSlot::Slot15,
+                PcrSlot::Slot16,
+                PcrSlot::Slot17,
+                PcrSlot::Slot18,
+                PcrSlot::Slot19,
+                PcrSlot::Slot20,
+                PcrSlot::Slot21,
+                PcrSlot::Slot22,
+                PcrSlot::Slot23,
+            ],
+        )
+        .build();
+
+    let pcr_data = tss_esapi::abstraction::pcr::read_all(&mut context, pcr_selection_list)
+        .expect("Call to pcr_read_all failed");
+
+    assert_eq!(
+        pcr_data
+            .pcr_bank(HashingAlgorithm::Sha256)
+            .expect("PcrData did not conatin expected PcrBank")
+            .len(),
+        24,
+        "PcrData did not contain expected amount of digests"
+    );
+
+    let (_count, _read_pcr_selection_1, read_pcrs_1) = context
+        .pcr_read(
+            &PcrSelectionListBuilder::new()
+                .with_selection(
+                    HashingAlgorithm::Sha256,
+                    &[
+                        PcrSlot::Slot0,
+                        PcrSlot::Slot1,
+                        PcrSlot::Slot2,
+                        PcrSlot::Slot3,
+                        PcrSlot::Slot4,
+                        PcrSlot::Slot5,
+                        PcrSlot::Slot6,
+                        PcrSlot::Slot7,
+                    ],
+                )
+                .build(),
+        )
+        .expect("Call 1 to pcr_read failed");
+
+    let (_count, _read_pcr_selection_2, read_pcrs_2) = context
+        .pcr_read(
+            &PcrSelectionListBuilder::new()
+                .with_selection(
+                    HashingAlgorithm::Sha256,
+                    &[
+                        PcrSlot::Slot8,
+                        PcrSlot::Slot9,
+                        PcrSlot::Slot10,
+                        PcrSlot::Slot11,
+                        PcrSlot::Slot12,
+                        PcrSlot::Slot13,
+                        PcrSlot::Slot14,
+                        PcrSlot::Slot15,
+                    ],
+                )
+                .build(),
+        )
+        .expect("Call 2 to pcr_read failed");
+
+    let (_count, _read_pcr_selection_3, read_pcrs_3) = context
+        .pcr_read(
+            &PcrSelectionListBuilder::new()
+                .with_selection(
+                    HashingAlgorithm::Sha256,
+                    &[
+                        PcrSlot::Slot16,
+                        PcrSlot::Slot17,
+                        PcrSlot::Slot18,
+                        PcrSlot::Slot19,
+                        PcrSlot::Slot20,
+                        PcrSlot::Slot21,
+                        PcrSlot::Slot22,
+                        PcrSlot::Slot23,
+                    ],
+                )
+                .build(),
+        )
+        .expect("Call 2 to pcr_read failed");
+
+    vec![read_pcrs_1, read_pcrs_2, read_pcrs_3]
+        .iter()
+        .enumerate()
+        .for_each(|(idx, dl)| {
+            assert_eq!(dl.len(), 8);
+            let d = pcr_data
+                .pcr_bank(HashingAlgorithm::Sha256)
+                .expect("PcrData did not conatin expected PcrBank")
+                .into_iter()
+                .skip(idx * 8)
+                .take(8);
+            assert_eq!(d.len(), 8);
+            dl.value()
+                .iter()
+                .zip(d)
+                .for_each(|(actual, (_, expected))| {
+                    assert_eq!(actual, expected);
+                })
+        })
+}

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/digest_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/digest_list_tests.rs
@@ -44,34 +44,3 @@ fn test_add_exceeding_max_limit() {
     }
     digest_list.add(digest).unwrap_err();
 }
-
-#[test]
-fn test_conversion_from_tss_digest_list_with_count_below_min() {
-    // These tests might be removed in the future becuase the
-    // min limit only applies when the DigestList is used as
-    // argument to policy_or.
-    let mut tss_digest_list: TPML_DIGEST = Default::default();
-    let mut tss_digest = TPM2B_DIGEST {
-        size: 32,
-        ..Default::default()
-    };
-    tss_digest.buffer[..32].copy_from_slice(&[1; 32]);
-    tss_digest_list.count = 1;
-    tss_digest_list.digests[0] = tss_digest;
-
-    let _ = DigestList::try_from(tss_digest_list).unwrap_err();
-}
-
-#[test]
-fn test_conversion_to_tss_digest_list_with_count_below_min() {
-    // These tests might be removed in the future becuase the
-    // min limit only applies when the DigestList is used as
-    // argument to policy_or.
-    let mut digest_list: DigestList = Default::default();
-    digest_list
-        .add(Digest::try_from(vec![1, 2, 3, 4, 5, 6, 7]).unwrap())
-        .unwrap();
-    if TPML_DIGEST::try_from(digest_list).is_ok() {
-        panic!("No error regarding a digest list that is to small was reported.");
-    }
-}

--- a/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_selection_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_selection_tests.rs
@@ -41,3 +41,40 @@ fn test_conversion_from_tss_pcr_selection() {
     );
     assert_eq!(expected, actual);
 }
+
+#[test]
+fn test_subtract() {
+    let mut pcr_select_1 = PcrSelection::new(
+        HashingAlgorithm::Sha256,
+        PcrSelectSize::TwoBytes,
+        &[PcrSlot::Slot4, PcrSlot::Slot15],
+    );
+
+    let pcr_select_2 = PcrSelection::new(
+        HashingAlgorithm::Sha256,
+        PcrSelectSize::TwoBytes,
+        &[PcrSlot::Slot4],
+    );
+
+    pcr_select_1
+        .subtract(&pcr_select_2)
+        .expect("Failed to subtract pcr_select_2 from pcr_select_1");
+
+    assert_eq!(
+        pcr_select_1.hashing_algorithm(),
+        HashingAlgorithm::Sha256,
+        "The pcr_select_1 did not contain expected HashingAlgorithm after subtract"
+    );
+
+    assert_eq!(
+        pcr_select_1.size_of_select(),
+        PcrSelectSize::TwoBytes,
+        "The pcr_select_1 did not have the expected size of select after subtract"
+    );
+
+    assert_eq!(
+        pcr_select_1.selected(),
+        vec![PcrSlot::Slot15],
+        "The pcr_select_1 did not contain expected PcrSlots after subtract"
+    );
+}


### PR DESCRIPTION
This fixes #277 by doing the following:

- Changed pcr_read to return a DigestList instead of PcrData.

- Moved PcrData to abstractions and made it possible to construct
  PcrData from rust native types.

- Added subtract to PcrSelectionList.

- Added a pcr_read_all functiion to the pcr module
  in abstractions. This function tries to read all the
  values in a PcrSelectionList.

- [x] Crate tests that verifies that the new functionality actually works
- [x] Improve the docuemntation

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>