### PR TITLE
Add ActivateCredential support for TKC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu
       - name: Run the container
         run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+      - name: Run the cross-compilation script
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/cross-compile.sh
 
   tests-ubuntu-v3:
     name: Ubuntu tests on v3.x.y of tpm2-tss

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,5 +51,3 @@ jobs:
         run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --security-opt seccomp=unconfined ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/coverage.sh
       - name: Collect coverage results
         run: bash <(curl -s https://codecov.io/bash)
-      - name: Run the cross-compilation script
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/cross-compile.sh

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -27,6 +27,7 @@ primal = "0.3.0"
 
 [dev-dependencies]
 env_logger = "0.7.1"
+sha2 = "0.9.8"
 
 [features]
 generate-bindings = ["tss-esapi-sys/generate-bindings"]

--- a/tss-esapi/src/abstraction/ek.rs
+++ b/tss-esapi/src/abstraction/ek.rs
@@ -24,9 +24,11 @@ use std::convert::TryFrom;
 const RSA_2048_EK_CERTIFICATE_NV_INDEX: u32 = 0x01c00002;
 const ECC_P256_EK_CERTIFICATE_NV_INDEX: u32 = 0x01c0000a;
 
-// Source: TCG EK Credential Profile for TPM Family 2.0; Level 0 Version 2.3 Revision 2
-// Appendix B.3.3 and B.3.4
-fn create_ek_public_from_default_template<IKC: IntoKeyCustomization>(
+/// Get the [`Public`] representing a default Endorsement Key
+///
+/// Source: TCG EK Credential Profile for TPM Family 2.0; Level 0 Version 2.3 Revision 2
+/// Appendix B.3.3 and B.3.4
+pub fn create_ek_public_from_default_template<IKC: IntoKeyCustomization>(
     alg: AsymmetricAlgorithm,
     key_customization: IKC,
 ) -> Result<Public> {

--- a/tss-esapi/src/abstraction/transient/key_attestation.rs
+++ b/tss-esapi/src/abstraction/transient/key_attestation.rs
@@ -12,10 +12,10 @@ use crate::{
     structures::{EncryptedSecret, IDObject, SymmetricDefinition},
     tss2_esys::{Tss2_MU_TPMT_PUBLIC_Marshal, TPM2B_PUBLIC, TPMT_PUBLIC},
     utils::PublicKey,
-    Error, Result,
+    Error, Result, WrapperErrorKind,
 };
 use log::error;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 #[derive(Debug)]
 /// Wrapper for the parameters needed by MakeCredential
@@ -62,7 +62,9 @@ impl TransientKeyContext {
             Tss2_MU_TPMT_PUBLIC_Marshal(
                 &public.publicArea,
                 &mut pub_buf as *mut u8,
-                pub_buf.len() as u64,
+                std::mem::size_of::<TPMT_PUBLIC>()
+                    .try_into()
+                    .map_err(|_| Error::local_error(WrapperErrorKind::InternalError))?,
                 &mut offset,
             )
         };

--- a/tss-esapi/src/abstraction/transient/key_attestation.rs
+++ b/tss-esapi/src/abstraction/transient/key_attestation.rs
@@ -19,8 +19,22 @@ use std::convert::{TryFrom, TryInto};
 
 #[derive(Debug)]
 /// Wrapper for the parameters needed by MakeCredential
+///
+/// The 3rd party requesting proof that the key is indeed backed
+/// by a TPM would perform a MakeCredential and would thus require
+/// `name` and `attesting_key_pub` as inputs for that operation.
+///
+/// `public` is not strictly needed, however it is returned as a
+/// convenience block of data. Since the MakeCredential operation
+/// bakes into the encrypted credential the identity of the key to
+/// be attested via its `name`, the correctness of the `name` must
+/// be verifiable by the said 3rd party. `public` bridges this gap:
+///
+/// * it includes all the public parameters of the attested key
+/// * can be hashed (in its marshaled form) with the name hash
+/// (found by unmarshaling it) to obtain `name`
 pub struct MakeCredParams {
-    /// TPM name of the object
+    /// TPM name of the object being attested
     pub name: Vec<u8>,
     /// Encoding of the public parameters of the object whose name
     /// will be included in the credential computations

--- a/tss-esapi/src/abstraction/transient/key_attestation.rs
+++ b/tss-esapi/src/abstraction/transient/key_attestation.rs
@@ -1,0 +1,203 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::{ObjectWrapper, TransientKeyContext};
+use crate::{
+    abstraction::ek,
+    constants::SessionType,
+    handles::{AuthHandle, SessionHandle},
+    interface_types::{
+        algorithm::{AsymmetricAlgorithm, HashingAlgorithm},
+        session_handles::PolicySession,
+    },
+    structures::{EncryptedSecret, IDObject, SymmetricDefinition},
+    tss2_esys::{TPM2B_PUBLIC, TPMT_PUBLIC},
+    utils::PublicKey,
+    Result,
+};
+use std::convert::{TryFrom, TryInto};
+
+#[derive(Debug)]
+/// Wrapper for the parameters needed by MakeCredential
+pub struct MakeCredParams {
+    /// TPM name of the object
+    name: Vec<u8>,
+    /// Encoding of the public parameters of the object whose name
+    /// will be included in the credential computations
+    public: Vec<u8>,
+    /// Public part of the key used to protect the credential
+    attesting_key_pub: PublicKey,
+}
+
+impl MakeCredParams {
+    pub fn name(&self) -> &[u8] {
+        &self.name
+    }
+
+    pub fn public(&self) -> &[u8] {
+        &self.public
+    }
+
+    pub fn attesting_key_pub(&self) -> &PublicKey {
+        &self.attesting_key_pub
+    }
+}
+
+impl TransientKeyContext {
+    /// Get the data required to perform a MakeCredential
+    ///
+    /// # Parameters
+    ///
+    /// * `object` - the object whose TPM name will be included in
+    /// the credential
+    /// * `key` - the key to be used to encrypt the secret that wraps
+    /// the credential
+    ///
+    /// **Note**: If no `key` is given, the default Endorsement Key
+    /// will be used.  
+    pub fn get_make_cred_params(
+        &mut self,
+        object: ObjectWrapper,
+        key: Option<ObjectWrapper>,
+    ) -> Result<MakeCredParams> {
+        let object_handle = self.load_key(object.params, object.material, None)?;
+        let (object_public, object_name, _) =
+            self.context.read_public(object_handle).or_else(|e| {
+                self.context.flush_context(object_handle.into())?;
+                Err(e)
+            })?;
+        self.context.flush_context(object_handle.into())?;
+
+        let public = TPM2B_PUBLIC::from(object_public);
+        let public = unsafe {
+            std::mem::transmute::<TPMT_PUBLIC, [u8; std::mem::size_of::<TPMT_PUBLIC>()]>(
+                public.publicArea,
+            )
+        };
+        let attesting_key_pub = match key {
+            None => {
+                let key_handle =
+                    ek::create_ek_object(&mut self.context, AsymmetricAlgorithm::Rsa, None)?;
+                let (attesting_key_pub, _, _) =
+                    self.context.read_public(key_handle).or_else(|e| {
+                        self.context.flush_context(key_handle.into())?;
+                        Err(e)
+                    })?;
+                self.context.flush_context(key_handle.into())?;
+
+                attesting_key_pub.try_into()?
+            }
+            Some(key) => key.material.public,
+        };
+        Ok(MakeCredParams {
+            name: object_name.value().to_vec(),
+            public: public.to_vec(),
+            attesting_key_pub,
+        })
+    }
+
+    /// Perform an ActivateCredential operation for the given object
+    ///
+    /// # Parameters
+    ///
+    /// * `object` - the object whose TPM name is included in the credential
+    /// * `key` - the key used to encrypt the secret that wraps the credential
+    /// * `credential_blob` - encrypted credential that will be returned by the
+    /// TPM
+    /// * `secret` - encrypted secret that was used to encrypt the credential
+    ///
+    /// **Note**: if no `key` is given, the default Endorsement Key
+    /// will be used. You can find more information about the default Endorsement
+    /// Key in the [ek] module.
+    pub fn activate_credential(
+        &mut self,
+        object: ObjectWrapper,
+        key: Option<ObjectWrapper>,
+        credential_blob: Vec<u8>,
+        secret: Vec<u8>,
+    ) -> Result<Vec<u8>> {
+        let credential_blob = IDObject::try_from(credential_blob)?;
+        let secret = EncryptedSecret::try_from(secret)?;
+        let object_handle = self.load_key(object.params, object.material, object.auth)?;
+        let session_2;
+        let key_handle = match key {
+            None => {
+                // No key was given, use the EK. This requires using a Policy session
+                session_2 = self
+                    .context
+                    .start_auth_session(
+                        None,
+                        None,
+                        None,
+                        SessionType::Policy,
+                        SymmetricDefinition::AES_128_CFB,
+                        HashingAlgorithm::Sha256,
+                    )
+                    .or_else(|e| {
+                        self.context.flush_context(object_handle.into())?;
+                        Err(e)
+                    })?;
+                let _ = self.context.policy_secret(
+                    PolicySession::try_from(session_2.unwrap())
+                        .expect("Failed to convert auth session to policy session"),
+                    AuthHandle::Endorsement,
+                    Default::default(),
+                    Default::default(),
+                    Default::default(),
+                    None,
+                );
+                ek::create_ek_object(&mut self.context, AsymmetricAlgorithm::Rsa, None).or_else(
+                    |e| {
+                        self.context.flush_context(object_handle.into())?;
+                        self.context
+                            .flush_context(SessionHandle::from(session_2).into())?;
+                        Err(e)
+                    },
+                )?
+            }
+            Some(key) => {
+                // Load key and create a HMAC session for it
+                session_2 = self
+                    .context
+                    .start_auth_session(
+                        None,
+                        None,
+                        None,
+                        SessionType::Hmac,
+                        SymmetricDefinition::AES_128_CFB,
+                        HashingAlgorithm::Sha256,
+                    )
+                    .or_else(|e| {
+                        self.context.flush_context(object_handle.into())?;
+                        Err(e)
+                    })?;
+                self.load_key(key.params, key.material, key.auth)
+                    .or_else(|e| {
+                        self.context.flush_context(object_handle.into())?;
+                        self.context
+                            .flush_context(SessionHandle::from(session_2).into())?;
+                        Err(e)
+                    })?
+            }
+        };
+
+        let (session_1, _, _) = self.context.sessions();
+        let credential = self
+            .context
+            .execute_with_sessions((session_1, session_2, None), |ctx| {
+                ctx.activate_credential(object_handle, key_handle, credential_blob, secret)
+            })
+            .or_else(|e| {
+                self.context.flush_context(object_handle.into())?;
+                self.context.flush_context(key_handle.into())?;
+                self.context
+                    .flush_context(SessionHandle::from(session_2).into())?;
+                Err(e)
+            })?;
+
+        self.context.flush_context(object_handle.into())?;
+        self.context.flush_context(key_handle.into())?;
+        self.context
+            .flush_context(SessionHandle::from(session_2).into())?;
+        Ok(credential.value().to_vec())
+    }
+}

--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -42,6 +42,8 @@ use zeroize::Zeroize;
 
 mod key_attestation;
 
+pub use key_attestation::MakeCredParams;
+
 /// Parameters for the kinds of keys supported by the context
 #[derive(Debug, Clone, Copy)]
 pub enum KeyParams {

--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -39,6 +39,8 @@ use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use zeroize::Zeroize;
 
+mod key_attestation;
+
 /// Parameters for the kinds of keys supported by the context
 #[derive(Debug, Clone, Copy)]
 pub enum KeyParams {
@@ -87,6 +89,13 @@ impl KeyMaterial {
     pub fn private(&self) -> &[u8] {
         &self.private
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct ObjectWrapper {
+    pub material: KeyMaterial,
+    pub params: KeyParams,
+    pub auth: Option<Auth>,
 }
 
 /// Structure offering an abstracted programming experience.

--- a/tss-esapi/src/error.rs
+++ b/tss-esapi/src/error.rs
@@ -62,7 +62,7 @@ pub enum WrapperErrorKind {
     InconsistentParams,
     /// Returned when the value of a parameter is not yet supported.
     UnsupportedParam,
-    /// Returend when the value of a parameter is invalid for that type.
+    /// Returned when the value of a parameter is invalid for that type.
     InvalidParam,
     /// Returned when the TPM returns an invalid value from a call.
     WrongValueFromTpm,
@@ -72,6 +72,8 @@ pub enum WrapperErrorKind {
     /// Returned when a handle is required to be in a specific state
     /// (i.g. Open, Flushed, Closed) but it is not.
     InvalidHandleState,
+    /// An unexpected internal error occurred.
+    InternalError,
 }
 
 impl std::fmt::Display for WrapperErrorKind {
@@ -97,6 +99,9 @@ impl std::fmt::Display for WrapperErrorKind {
             WrapperErrorKind::WrongValueFromTpm => write!(f, "the TPM returned an invalid value."),
             WrapperErrorKind::MissingAuthSession => write!(f, "Missing authorization session"),
             WrapperErrorKind::InvalidHandleState => write!(f, "Invalid handle state"),
+            WrapperErrorKind::InternalError => {
+                write!(f, "an unexpected error occurred within the crate")
+            }
         }
     }
 }

--- a/tss-esapi/src/interface_types/resource_handles.rs
+++ b/tss-esapi/src/interface_types/resource_handles.rs
@@ -13,7 +13,7 @@ use std::convert::TryFrom;
 ///
 /// Enum describing the object hierarchies in a TPM 2.0.
 //////////////////////////////////////////////////////////////////////////////////
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Hierarchy {
     Owner,
     Platform,

--- a/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
@@ -644,7 +644,7 @@ fn activate_credential() {
             name_hashing_algorithm,
             auth_policy,
             parameters,
-            unique: if let PublicKey::Rsa(val) = make_cred_params.attesting_key_pub().clone() {
+            unique: if let PublicKey::Rsa(val) = make_cred_params.attesting_key_pub {
                 PublicKeyRsa::try_from(val).unwrap()
             } else {
                 panic!("Wrong public key type");
@@ -664,7 +664,7 @@ fn activate_credential() {
         .make_credential(
             pub_handle,
             credential.clone().try_into().unwrap(),
-            make_cred_params.name().to_vec().try_into().unwrap(),
+            make_cred_params.name.try_into().unwrap(),
         )
         .unwrap();
 

--- a/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
@@ -843,7 +843,11 @@ fn activate_credential_wrong_data() {
         .activate_credential(obj, None, vec![0xaa; 52], vec![0x55; 256])
         .unwrap_err();
     if let Error::Tss2Error(e) = e {
-        assert_eq!(e.kind(), Some(Tss2ResponseCodeKind::Value));
+        // IBM software TPM returns Value, swtpm returns Failure...
+        assert!(matches!(
+            e.kind(),
+            Some(Tss2ResponseCodeKind::Value) | Some(Tss2ResponseCodeKind::Failure)
+        ));
     } else {
         panic!("Got crate error ({}) when expecting an error from TPM.", e);
     }


### PR DESCRIPTION
This commit adds support for two operations, enabling key attestation
via the ActivateCredential call. A test has also been added to verify
attestation using the Endorsement Key.

Intended for https://github.com/parallaxsecond/parsec/issues/539

cc @wiktor-k 