### PR TITLE
Added SignatureScheme type.

### DIFF
--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     handles::KeyHandle,
-    structures::{Data, PcrSelectionList, Signature},
+    structures::{Data, PcrSelectionList, Signature, SignatureScheme},
     tss2_esys::*,
     Context, Error, Result,
 };
@@ -23,7 +23,7 @@ impl Context {
         &mut self,
         signing_key_handle: KeyHandle,
         qualifying_data: &Data,
-        signing_scheme: TPMT_SIG_SCHEME,
+        signing_scheme: SignatureScheme,
         pcr_selection_list: PcrSelectionList,
     ) -> Result<(TPM2B_ATTEST, Signature)> {
         let mut quoted = null_mut();
@@ -36,7 +36,7 @@ impl Context {
                 self.optional_session_2(),
                 self.optional_session_3(),
                 &qualifying_data.clone().into(),
-                &signing_scheme,
+                &signing_scheme.into(),
                 &pcr_selection_list.into(),
                 &mut quoted,
                 &mut signature,

--- a/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
+++ b/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     handles::KeyHandle,
-    structures::{Digest, HashcheckTicket, Signature, VerifiedTicket},
+    structures::{Digest, HashcheckTicket, Signature, SignatureScheme, VerifiedTicket},
     tss2_esys::*,
     Context, Error, Result,
 };
@@ -50,7 +50,7 @@ impl Context {
         &mut self,
         key_handle: KeyHandle,
         digest: &Digest,
-        scheme: TPMT_SIG_SCHEME,
+        scheme: SignatureScheme,
         validation: HashcheckTicket,
     ) -> Result<Signature> {
         let mut signature = null_mut();
@@ -63,7 +63,7 @@ impl Context {
                 self.optional_session_2(),
                 self.optional_session_3(),
                 &digest.clone().into(),
-                &scheme,
+                &scheme.into(),
                 &validation,
                 &mut signature,
             )

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -116,13 +116,14 @@ pub use tickets::Ticket;
 pub use tickets::VerifiedTicket;
 
 mod schemes;
-pub use schemes::{HashScheme, HmacScheme, XorScheme};
+pub use schemes::{EcDaaScheme, HashScheme, HmacScheme, XorScheme};
 
 mod tagged;
 pub use tagged::{
     parameters::PublicParameters,
     schemes::{
         EccScheme, KeyDerivationFunctionScheme, KeyedHashScheme, RsaDecryptionScheme, RsaScheme,
+        SignatureScheme,
     },
     signature::Signature,
     symmetric::{SymmetricDefinition, SymmetricDefinitionObject},

--- a/tss-esapi/src/structures/schemes.rs
+++ b/tss-esapi/src/structures/schemes.rs
@@ -17,6 +17,11 @@ impl HashScheme {
     pub const fn new(hashing_algorithm: HashingAlgorithm) -> HashScheme {
         HashScheme { hashing_algorithm }
     }
+
+    /// Returns the hashing algorithm
+    pub const fn hashing_algorithm(&self) -> HashingAlgorithm {
+        self.hashing_algorithm
+    }
 }
 
 impl TryFrom<TPMS_SCHEME_HASH> for HashScheme {

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
@@ -4,10 +4,8 @@ mod test_quote {
     use crate::common::{create_ctx_with_session, signing_key_pub};
     use std::convert::TryFrom;
     use tss_esapi::{
-        constants::tss::TPM2_ALG_NULL,
         interface_types::{algorithm::HashingAlgorithm, resource_handles::Hierarchy},
-        structures::{Data, PcrSelectionListBuilder, PcrSlot},
-        tss2_esys::TPMT_SIG_SCHEME,
+        structures::{Data, PcrSelectionListBuilder, PcrSlot, SignatureScheme},
     };
 
     #[test]
@@ -17,10 +15,6 @@ mod test_quote {
         let pcr_selection_list = PcrSelectionListBuilder::new()
             .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0])
             .build();
-        let scheme = TPMT_SIG_SCHEME {
-            scheme: TPM2_ALG_NULL,
-            details: Default::default(),
-        };
         // No qualifying data
         let qualifying_data = vec![0xff; 16];
 
@@ -33,7 +27,7 @@ mod test_quote {
             .quote(
                 key_handle,
                 &Data::try_from(qualifying_data).unwrap(),
-                scheme,
+                SignatureScheme::Null,
                 pcr_selection_list,
             )
             .expect("Failed to get a quote");

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -522,10 +522,10 @@ mod test_policy_authorize {
     use crate::common::{create_ctx_with_session, get_pcr_policy_digest, signing_key_pub};
     use std::convert::{TryFrom, TryInto};
     use tss_esapi::{
-        constants::tss::{TPM2_ALG_NULL, TPM2_RH_NULL, TPM2_ST_HASHCHECK},
+        constants::tss::{TPM2_RH_NULL, TPM2_ST_HASHCHECK},
         interface_types::{algorithm::HashingAlgorithm, resource_handles::Hierarchy},
-        structures::{Auth, MaxBuffer, Nonce},
-        tss2_esys::{TPM2B_NONCE, TPMT_SIG_SCHEME, TPMT_TK_HASHCHECK},
+        structures::{Auth, MaxBuffer, Nonce, SignatureScheme},
+        tss2_esys::{TPM2B_NONCE, TPMT_TK_HASHCHECK},
     };
     #[test]
     fn test_policy_authorize() {
@@ -559,10 +559,6 @@ mod test_policy_authorize {
             .unwrap()
             .0;
 
-        let scheme = TPMT_SIG_SCHEME {
-            scheme: TPM2_ALG_NULL,
-            details: Default::default(),
-        };
         let validation = TPMT_TK_HASHCHECK {
             tag: TPM2_ST_HASHCHECK,
             hierarchy: TPM2_RH_NULL,
@@ -570,7 +566,12 @@ mod test_policy_authorize {
         };
         // A signature over just the policy_digest, since the policy_ref is empty
         let signature = context
-            .sign(key_handle, &ahash, scheme, validation.try_into().unwrap())
+            .sign(
+                key_handle,
+                &ahash,
+                SignatureScheme::Null,
+                validation.try_into().unwrap(),
+            )
             .unwrap();
         let tkt = context
             .verify_signature(key_handle, &ahash, signature)

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
@@ -4,10 +4,10 @@ mod test_verify_signature {
     use crate::common::{create_ctx_with_session, signing_key_pub, HASH};
     use std::convert::{TryFrom, TryInto};
     use tss_esapi::{
-        constants::tss::{TPM2_ALG_NULL, TPM2_RH_NULL, TPM2_ST_HASHCHECK},
+        constants::tss::{TPM2_RH_NULL, TPM2_ST_HASHCHECK},
         interface_types::{algorithm::HashingAlgorithm, resource_handles::Hierarchy},
-        structures::{Auth, Digest, PublicKeyRsa, RsaSignature, Signature},
-        tss2_esys::{TPMT_SIG_SCHEME, TPMT_TK_HASHCHECK},
+        structures::{Auth, Digest, PublicKeyRsa, RsaSignature, Signature, SignatureScheme},
+        tss2_esys::TPMT_TK_HASHCHECK,
     };
 
     #[test]
@@ -28,10 +28,6 @@ mod test_verify_signature {
             .unwrap()
             .key_handle;
 
-        let scheme = TPMT_SIG_SCHEME {
-            scheme: TPM2_ALG_NULL,
-            details: Default::default(),
-        };
         let validation = TPMT_TK_HASHCHECK {
             tag: TPM2_ST_HASHCHECK,
             hierarchy: TPM2_RH_NULL,
@@ -41,7 +37,7 @@ mod test_verify_signature {
             .sign(
                 key_handle,
                 &Digest::try_from(HASH[..32].to_vec()).unwrap(),
-                scheme,
+                SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )
             .unwrap();
@@ -73,10 +69,6 @@ mod test_verify_signature {
             .unwrap()
             .key_handle;
 
-        let scheme = TPMT_SIG_SCHEME {
-            scheme: TPM2_ALG_NULL,
-            details: Default::default(),
-        };
         let validation = TPMT_TK_HASHCHECK {
             tag: TPM2_ST_HASHCHECK,
             hierarchy: TPM2_RH_NULL,
@@ -86,7 +78,7 @@ mod test_verify_signature {
             .sign(
                 key_handle,
                 &Digest::try_from(HASH[..32].to_vec()).unwrap(),
-                scheme,
+                SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )
             .unwrap();
@@ -186,10 +178,10 @@ mod test_sign {
     use crate::common::{create_ctx_with_session, signing_key_pub, HASH};
     use std::convert::{TryFrom, TryInto};
     use tss_esapi::{
-        constants::tss::{TPM2_ALG_NULL, TPM2_RH_NULL, TPM2_ST_HASHCHECK},
+        constants::tss::{TPM2_RH_NULL, TPM2_ST_HASHCHECK},
         interface_types::resource_handles::Hierarchy,
-        structures::{Auth, Digest},
-        tss2_esys::{TPMT_SIG_SCHEME, TPMT_TK_HASHCHECK},
+        structures::{Auth, Digest, SignatureScheme},
+        tss2_esys::TPMT_TK_HASHCHECK,
     };
 
     #[test]
@@ -210,10 +202,6 @@ mod test_sign {
             .unwrap()
             .key_handle;
 
-        let scheme = TPMT_SIG_SCHEME {
-            scheme: TPM2_ALG_NULL,
-            details: Default::default(),
-        };
         let validation = TPMT_TK_HASHCHECK {
             tag: TPM2_ST_HASHCHECK,
             hierarchy: TPM2_RH_NULL,
@@ -223,7 +211,7 @@ mod test_sign {
             .sign(
                 key_handle,
                 &Digest::try_from(HASH[..32].to_vec()).unwrap(),
-                scheme,
+                SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )
             .unwrap();
@@ -247,10 +235,6 @@ mod test_sign {
             .unwrap()
             .key_handle;
 
-        let scheme = TPMT_SIG_SCHEME {
-            scheme: TPM2_ALG_NULL,
-            details: Default::default(),
-        };
         let validation = TPMT_TK_HASHCHECK {
             tag: TPM2_ST_HASHCHECK,
             hierarchy: TPM2_RH_NULL,
@@ -260,7 +244,7 @@ mod test_sign {
             .sign(
                 key_handle,
                 &Digest::try_from(Vec::<u8>::new()).unwrap(),
-                scheme,
+                SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )
             .unwrap_err();
@@ -284,10 +268,6 @@ mod test_sign {
             .unwrap()
             .key_handle;
 
-        let scheme = TPMT_SIG_SCHEME {
-            scheme: TPM2_ALG_NULL,
-            details: Default::default(),
-        };
         let validation = TPMT_TK_HASHCHECK {
             tag: TPM2_ST_HASHCHECK,
             hierarchy: TPM2_RH_NULL,
@@ -297,7 +277,7 @@ mod test_sign {
             .sign(
                 key_handle,
                 &Digest::try_from([0xbb; 40].to_vec()).unwrap(),
-                scheme,
+                SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )
             .unwrap_err();

--- a/tss-esapi/tests/integration_tests/structures_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/mod.rs
@@ -4,3 +4,4 @@ mod buffers_tests;
 mod capability_data_tests;
 mod lists_tests;
 mod pcr_tests;
+mod tagged_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/mod.rs
@@ -1,0 +1,3 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+mod tagged_signature_scheme_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/tagged_signature_scheme_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/tagged_signature_scheme_tests.rs
@@ -1,0 +1,203 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use tss_esapi::{
+    interface_types::algorithm::{HashingAlgorithm, SignatureSchemeAlgorithm},
+    structures::{EcDaaScheme, HashScheme, HmacScheme, SignatureScheme},
+    tss2_esys::{
+        TPMS_SCHEME_ECDAA, TPMS_SCHEME_HASH, TPMS_SCHEME_HMAC, TPMT_SIG_SCHEME, TPMU_SIG_SCHEME,
+    },
+    Error, WrapperErrorKind,
+};
+
+use std::convert::{TryFrom, TryInto};
+
+fn validate_tss_hash_scheme(
+    left: &TPMS_SCHEME_HASH,
+    right: &TPMS_SCHEME_HASH,
+    union_field_name: &str,
+) {
+    assert_eq!(
+        left.hashAlg, right.hashAlg,
+        "{} in details, hashAlg did not match",
+        union_field_name
+    );
+}
+
+fn validate_tss_ecdaa_scheme(
+    left: &TPMS_SCHEME_ECDAA,
+    right: &TPMS_SCHEME_ECDAA,
+    union_field_name: &str,
+) {
+    assert_eq!(
+        left.hashAlg, right.hashAlg,
+        "{} in details, hashAlg did not match",
+        union_field_name
+    );
+    assert_eq!(
+        left.count, right.count,
+        "{} in details, count did not match",
+        union_field_name
+    );
+}
+
+fn validate_tss_hmac_scheme(
+    left: &TPMS_SCHEME_HMAC,
+    right: &TPMS_SCHEME_HMAC,
+    union_field_name: &str,
+) {
+    assert_eq!(
+        left.hashAlg, right.hashAlg,
+        "{} in details, hashAlg did not match",
+        union_field_name
+    );
+}
+
+macro_rules! test_valid_conversions_generic {
+    (SignatureScheme::$item:ident, $union_field_name:ident, $tss_details_field_validator:expr, $native_scheme_field:ident, $native_scheme:expr) => {
+        let tss_actual: TPMT_SIG_SCHEME = SignatureScheme::$item { $native_scheme_field: $native_scheme }
+        .try_into()
+        .expect(&format!("Failed to convert {} signature scheem into TSS type", stringify!($item)));
+
+
+        let tss_expected = TPMT_SIG_SCHEME {
+            scheme: SignatureSchemeAlgorithm::$item.into(),
+            details: TPMU_SIG_SCHEME {
+                $union_field_name: $native_scheme.into(),
+            },
+        };
+
+        assert_eq!(
+            tss_actual.scheme, tss_expected.scheme,
+            "scheme for Actual converted value did not match expected in TSS types for SignatureScheme {}", stringify!($item),
+        );
+
+        $tss_details_field_validator(
+            &unsafe { tss_actual.details.$union_field_name },
+            &unsafe { tss_expected.details.$union_field_name },
+            stringify!($union_field_name),
+        );
+
+        let native_expected = SignatureScheme::$item { $native_scheme_field: $native_scheme };
+
+        let native_actual = SignatureScheme::try_from(tss_expected)
+            .expect(&format!("Failed to convert TSS type into {}", stringify!($item)));
+
+        assert_eq!(
+            native_actual, native_expected,
+            "The actual SignatureScheme did not match expected",
+        );
+    };
+    // For a selector that has no data
+    (SignatureScheme::$item:ident) => {
+        let tss_actual: TPMT_SIG_SCHEME = SignatureScheme::$item
+        .try_into()
+        .expect(&format!("Failed to convert {} signature scheem into TSS type", stringify!($item)));
+
+        let tss_expected = TPMT_SIG_SCHEME {
+            scheme: SignatureSchemeAlgorithm::$item.into(),
+            details: Default::default(),
+        };
+
+        assert_eq!(
+            tss_actual.scheme, tss_expected.scheme,
+            "scheme for Actual converted value did not match expected in TSS types for SignatureScheme {}", stringify!($item),
+        );
+
+        let native_expected = SignatureScheme::$item;
+        let native_actual = SignatureScheme::try_from(tss_expected)
+            .expect(&format!("Failed to convert TSS type into {}", stringify!($item)));
+
+        assert_eq!(
+            native_actual, native_expected,
+            "The actual SignatureScheme did not match expected",
+        );
+    };
+}
+
+macro_rules! test_valid_conversions {
+    (SignatureScheme::EcDaa, $union_field_name:ident) => {
+        test_valid_conversions_generic!(
+            SignatureScheme::EcDaa,
+            $union_field_name,
+            validate_tss_ecdaa_scheme,
+            ecdaa_scheme,
+            EcDaaScheme::new(HashingAlgorithm::Sha256, 1)
+        );
+    };
+    (SignatureScheme::Hmac, $union_field_name:ident) => {
+        test_valid_conversions_generic!(
+            SignatureScheme::Hmac,
+            $union_field_name,
+            validate_tss_hmac_scheme,
+            hmac_scheme,
+            HmacScheme::new(HashingAlgorithm::Sha256)
+        );
+    };
+    (SignatureScheme::$item:ident, $union_field_name:ident) => {
+        test_valid_conversions_generic!(
+            SignatureScheme::$item,
+            $union_field_name,
+            validate_tss_hash_scheme,
+            hash_scheme,
+            HashScheme::new(HashingAlgorithm::Sha256)
+        );
+    };
+    (SignatureScheme::Null) => {
+        test_valid_conversions_generic!(SignatureScheme::Null);
+    };
+}
+
+#[test]
+fn test_conversions() {
+    test_valid_conversions!(SignatureScheme::RsaSsa, rsassa);
+    test_valid_conversions!(SignatureScheme::RsaPss, rsapss);
+    test_valid_conversions!(SignatureScheme::EcDsa, ecdsa);
+    test_valid_conversions!(SignatureScheme::Sm2, sm2);
+    test_valid_conversions!(SignatureScheme::EcSchnorr, ecschnorr);
+    test_valid_conversions!(SignatureScheme::EcDaa, ecdaa);
+    test_valid_conversions!(SignatureScheme::Hmac, hmac);
+    test_valid_conversions!(SignatureScheme::Null);
+}
+
+#[test]
+fn test_valid_any_sig() {
+    let mut signature_scheme = SignatureScheme::RsaPss {
+        hash_scheme: HashScheme::new(HashingAlgorithm::Sha256),
+    };
+    assert_eq!(
+        HashingAlgorithm::Sha256,
+        signature_scheme
+            .signing_scheme()
+            .expect("Failed to get signing scheme digest"),
+        "The signing scheme method did not return the correct value"
+    );
+
+    signature_scheme
+        .set_signing_scheme(HashingAlgorithm::Sha384)
+        .expect("Failed to change signing scheme digest");
+
+    assert_eq!(
+        HashingAlgorithm::Sha384,
+        signature_scheme
+            .signing_scheme()
+            .expect("Failed to get signing key digest"),
+        "The signing scheme method did not return the correct value after change."
+    );
+}
+
+#[test]
+fn test_invalid_any_sig() {
+    let mut signature_scheme = SignatureScheme::Null;
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+        signature_scheme.signing_scheme(),
+        "Trying to get signing scheme digest from a non signing SignatureScheme did not produce the expected error",
+    );
+
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+        signature_scheme.set_signing_scheme(HashingAlgorithm::Sha256),
+        "Trying to set signing scheme digest on a non signing SignatureScheme did not produce the expected error",
+    )
+}


### PR DESCRIPTION
- Took implementation of SignatureScheme from #221 and created
a separate PR for it in order to remove bindgen type from context
methods and adding conversion test for the type.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>