### PR TITLE
Change Name to TPM2B_NAME conversion

### DIFF
--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -429,8 +429,8 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &object_name.try_into()?,
-                &new_parent_name.try_into()?,
+                &object_name.into(),
+                &new_parent_name.into(),
                 if include_object { 1 } else { 0 },
             )
         };

--- a/tss-esapi/src/structures/names/name.rs
+++ b/tss-esapi/src/structures/names/name.rs
@@ -35,7 +35,7 @@ impl TryFrom<Vec<u8>> for Name {
         }
         let size = bytes.len() as u16;
         let mut name = [0; Name::MAX_SIZE];
-        name.copy_from_slice(&bytes);
+        name[..bytes.len()].copy_from_slice(&bytes);
         Ok(Name {
             value: TPM2B_NAME { size, name },
         })


### PR DESCRIPTION
This commit fixes a current issue flagged on the CI where conversion
from Name to its FFI equivalent is not done properly.

cc @wiktor-k 