### PR TITLE
Change default RSA exponent to 0

### DIFF
--- a/tss-esapi/src/structures/buffers/public/rsa.rs
+++ b/tss-esapi/src/structures/buffers/public/rsa.rs
@@ -259,9 +259,7 @@ impl RsaExponent {
 
 impl Default for RsaExponent {
     fn default() -> RsaExponent {
-        RsaExponent {
-            value: (1 << 16) + 1,
-        }
+        RsaExponent { value: 0 }
     }
 }
 


### PR DESCRIPTION
This commit modifies the default value of `RsaExponent` to 0 from (1 <<
16) + 1 as the current value is causing backwards compatibility issues.

Fixes #285 
cc @lkatalin