### PR TITLE
Removes TPMA_LOCALITY from context methods.

### DIFF
--- a/tss-esapi/src/attributes/locality.rs
+++ b/tss-esapi/src/attributes/locality.rs
@@ -97,7 +97,7 @@ impl LocalityAttributesBuilder {
         let mut locality_attributes = LocalityAttributes(0);
         for locality in self.localities {
             if locality_attributes.is_extended() {
-                print!("Failed to add locality {} to locality attributes because a value that requires extended has been added", locality);
+                error!("Locality attribute {new} and locality attribute {prev} cannot be combined because locality attribute {prev} is extended", new=locality, prev=locality_attributes.0);
                 return Err(Error::local_error(WrapperErrorKind::InvalidParam));
             }
             match locality {
@@ -108,14 +108,14 @@ impl LocalityAttributesBuilder {
                 4 => locality_attributes.set_locality_four(true),
                 5..=31 => {
                     error!(
-                        "{} is an invalid locality and cannot be added to locality attributes",
-                        locality
+                        "Locality attribute {new} is invalid and cannot be combined with other locality attributes",
+                        new=locality
                     );
                     return Err(Error::local_error(WrapperErrorKind::InvalidParam));
                 }
                 32.. => {
                     if locality_attributes.0 != 0 {
-                        error!("locality attribute {} requires extended locality attributes and cannot not be combined with other locality attributes", locality);
+                        error!("Locality attribute {new} is extended and cannot be combined with locality attribute(s) {old}", new=locality, old=locality_attributes.0);
                         return Err(Error::local_error(WrapperErrorKind::InvalidParam));
                     }
                     locality_attributes.0 = locality;

--- a/tss-esapi/src/attributes/locality.rs
+++ b/tss-esapi/src/attributes/locality.rs
@@ -1,0 +1,127 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{tss2_esys::TPMA_LOCALITY, Error, Result, WrapperErrorKind};
+use bitfield::bitfield;
+use log::error;
+
+bitfield! {
+    /// Bitfield representing the locality attributes.
+    #[derive(Copy, Clone, Eq, PartialEq)]
+    pub struct LocalityAttributes(TPMA_LOCALITY);
+    impl Debug;
+
+    _, set_locality_zero: 0;
+    pub locality_zero, _: 0;
+    _, set_locality_one: 1;
+    pub locality_one, _: 1;
+    _, set_locality_two: 2;
+    pub locality_two, _: 2;
+    _, set_locality_three: 3;
+    pub locality_three, _: 3;
+    _, set_locality_four: 4;
+    pub locality_four, _: 4;
+    _, set_extended: 7, 5;
+    extended, _: 7, 5;
+}
+
+impl LocalityAttributes {
+    pub const LOCALITY_ZERO: LocalityAttributes = LocalityAttributes(1);
+    pub const LOCALITY_ONE: LocalityAttributes = LocalityAttributes(2);
+    pub const LOCALITY_TWO: LocalityAttributes = LocalityAttributes(4);
+    pub const LOCALITY_THREE: LocalityAttributes = LocalityAttributes(8);
+    pub const LOCALITY_FOUR: LocalityAttributes = LocalityAttributes(16);
+    /// Returns true if the attributes are extended
+    pub fn is_extended(&self) -> bool {
+        self.extended() != 0u8
+    }
+
+    /// Returns the LocalityAttributes as a number.
+    ///
+    /// # Error
+    /// If the attributes are not extended en InvalidParams error
+    /// is returned.
+    pub fn as_extended(&self) -> Result<u8> {
+        if self.is_extended() {
+            Ok(self.0)
+        } else {
+            error!("Cannot retrieve LocalityAttributes as extended when the attributes are not indicated to be extended");
+            Err(Error::local_error(WrapperErrorKind::InvalidParam))
+        }
+    }
+
+    /// Returns the builder used to construct LocalAttributes.
+    pub fn builder() -> LocalityAttributesBuilder {
+        LocalityAttributesBuilder::new()
+    }
+}
+
+impl From<TPMA_LOCALITY> for LocalityAttributes {
+    fn from(tpma_locality: TPMA_LOCALITY) -> Self {
+        LocalityAttributes(tpma_locality)
+    }
+}
+
+impl From<LocalityAttributes> for TPMA_LOCALITY {
+    fn from(locality_attributes: LocalityAttributes) -> Self {
+        locality_attributes.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalityAttributesBuilder {
+    localities: Vec<u8>,
+}
+
+impl LocalityAttributesBuilder {
+    /// Creates a new builder.
+    pub const fn new() -> Self {
+        LocalityAttributesBuilder {
+            localities: Vec::new(),
+        }
+    }
+    /// Adds a locality to the builder
+    pub fn with_locality(mut self, locality: u8) -> Self {
+        self.localities.push(locality);
+        self
+    }
+
+    /// Adds a slice of localities to the builder
+    pub fn with_localities(mut self, localities: &[u8]) -> Self {
+        self.localities.extend_from_slice(localities);
+        self
+    }
+
+    /// Builds the attributes
+    pub fn build(self) -> Result<LocalityAttributes> {
+        let mut locality_attributes = LocalityAttributes(0);
+        for locality in self.localities {
+            if locality_attributes.is_extended() {
+                print!("Failed to add locality {} to locality attributes because a value that requires extended has been added", locality);
+                return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+            }
+            match locality {
+                0 => locality_attributes.set_locality_zero(true),
+                1 => locality_attributes.set_locality_one(true),
+                2 => locality_attributes.set_locality_two(true),
+                3 => locality_attributes.set_locality_three(true),
+                4 => locality_attributes.set_locality_four(true),
+                5..=31 => {
+                    error!(
+                        "{} is an invalid locality and cannot be added to locality attributes",
+                        locality
+                    );
+                    return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+                }
+                32.. => {
+                    if locality_attributes.0 != 0 {
+                        error!("locality attribute {} requires extended locality attributes and cannot not be combined with other locality attributes", locality);
+                        return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+                    }
+                    locality_attributes.0 = locality;
+                }
+            }
+        }
+        Ok(locality_attributes)
+    }
+}

--- a/tss-esapi/src/attributes/mod.rs
+++ b/tss-esapi/src/attributes/mod.rs
@@ -15,6 +15,9 @@ pub mod session;
 /// the specfication.
 pub mod nv_index;
 
+pub mod locality;
+
+pub use locality::{LocalityAttributes, LocalityAttributesBuilder};
 pub use nv_index::{NvIndexAttributes, NvIndexAttributesBuilder};
 pub use object::{ObjectAttributes, ObjectAttributesBuilder};
 pub use session::{SessionAttributes, SessionAttributesBuilder, SessionAttributesMask};

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
+    attributes::LocalityAttributes,
     handles::{AuthHandle, ObjectHandle, SessionHandle},
     interface_types::session_handles::PolicySession,
     structures::{
@@ -204,7 +205,7 @@ impl Context {
     pub fn policy_locality(
         &mut self,
         policy_session: PolicySession,
-        locality: TPMA_LOCALITY,
+        locality: LocalityAttributes,
     ) -> Result<()> {
         let ret = unsafe {
             Esys_PolicyLocality(
@@ -213,7 +214,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                locality,
+                locality.into(),
             )
         };
         let ret = Error::from_tss_rc(ret);

--- a/tss-esapi/src/structures/creation.rs
+++ b/tss-esapi/src/structures/creation.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    attributes::LocalityAttributes,
     constants::AlgorithmIdentifier,
     interface_types::algorithm::HashingAlgorithm,
     structures::{Data, Digest, Name, PcrSelectionList},
-    tss2_esys::{TPM2B_CREATION_DATA, TPMA_LOCALITY, TPMS_CREATION_DATA},
+    tss2_esys::{TPM2B_CREATION_DATA, TPMS_CREATION_DATA},
     Error, Result,
 };
 use std::convert::{TryFrom, TryInto};
@@ -14,7 +15,7 @@ use std::convert::{TryFrom, TryInto};
 pub struct CreationData {
     pcr_select: PcrSelectionList,
     pcr_digest: Digest,
-    locality: TPMA_LOCALITY,
+    locality: LocalityAttributes,
     parent_name_alg: Option<HashingAlgorithm>,
     parent_name: Name,
     parent_qualified_name: Name,
@@ -27,7 +28,7 @@ impl TryFrom<TPMS_CREATION_DATA> for CreationData {
         Ok(CreationData {
             pcr_select: tss_creation_data.pcrSelect.try_into()?,
             pcr_digest: tss_creation_data.pcrDigest.try_into()?,
-            locality: tss_creation_data.locality,
+            locality: tss_creation_data.locality.into(),
             parent_name_alg: match AlgorithmIdentifier::try_from(tss_creation_data.parentNameAlg)? {
                 AlgorithmIdentifier::Null => None,
                 alg => Some(HashingAlgorithm::try_from(alg)?),
@@ -51,7 +52,7 @@ impl From<CreationData> for TPMS_CREATION_DATA {
         TPMS_CREATION_DATA {
             pcrSelect: creation_data.pcr_select.into(),
             pcrDigest: creation_data.pcr_digest.into(),
-            locality: creation_data.locality,
+            locality: creation_data.locality.into(),
             parentNameAlg: match creation_data.parent_name_alg {
                 None => AlgorithmIdentifier::Null.into(),
                 Some(alg) => alg.into(),

--- a/tss-esapi/tests/integration_tests/attributes_tests/locality_attributes_tests.rs
+++ b/tss-esapi/tests/integration_tests/attributes_tests/locality_attributes_tests.rs
@@ -19,7 +19,7 @@ fn test_conversions() {
             1u8.checked_shl(locality.into())
                 .expect("Unable to create locality value"),
             tpma_locality,
-            "Locality did not convert inte expected TPMA_LOCALITY value"
+            "Locality did not convert into expected TPMA_LOCALITY value"
         );
         assert_eq!(
             expected_locality_attributes,
@@ -37,7 +37,7 @@ fn test_conversions() {
         let tpma_locality: TPMA_LOCALITY = expected_locality_attributes.into();
         assert_eq!(
             locality, tpma_locality,
-            "Locality did not convert inte expected TPMA_LOCALITY value"
+            "Locality did not convert into expected TPMA_LOCALITY value"
         );
 
         assert_eq!(
@@ -160,6 +160,28 @@ fn test_invalid_locality() {
                 .build(),
             "Locality builder did not produce expected error when using locality {}",
             locality
+        );
+    }
+}
+
+#[test]
+fn test_invalid_extended_locality() {
+    for locality in 0u8..=4u8 {
+        let locality_attributes = LocalityAttributesBuilder::new()
+            .with_locality(locality)
+            .build()
+            .expect("Failed to get local attributes as extended");
+
+        assert!(
+            !locality_attributes.is_extended(),
+            "The non extended locality {} is unexpectedly indicating that it is extended",
+            locality
+        );
+
+        assert_eq!(
+            Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+            locality_attributes.as_extended(),
+            "Calling as_extended() on locality {} that is not extended, did not result in the expected error", locality,
         );
     }
 }

--- a/tss-esapi/tests/integration_tests/attributes_tests/locality_attributes_tests.rs
+++ b/tss-esapi/tests/integration_tests/attributes_tests/locality_attributes_tests.rs
@@ -1,0 +1,192 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use tss_esapi::{
+    attributes::{LocalityAttributes, LocalityAttributesBuilder},
+    tss2_esys::TPMA_LOCALITY,
+    Error, WrapperErrorKind,
+};
+
+#[test]
+fn test_conversions() {
+    for locality in 0u8..=4u8 {
+        let expected_locality_attributes = LocalityAttributesBuilder::new()
+            .with_locality(locality)
+            .build()
+            .expect("Failed to build locality attributes");
+        let tpma_locality: TPMA_LOCALITY = expected_locality_attributes.into();
+        assert_eq!(
+            1u8.checked_shl(locality.into())
+                .expect("Unable to create locality value"),
+            tpma_locality,
+            "Locality did not convert inte expected TPMA_LOCALITY value"
+        );
+        assert_eq!(
+            expected_locality_attributes,
+            tpma_locality.into(),
+            "The locality attributes converted from TPMA_LOCALITY did not match the expected value"
+        );
+    }
+
+    for locality in 32u8..=u8::MAX {
+        let expected_locality_attributes = LocalityAttributesBuilder::new()
+            .with_locality(locality)
+            .build()
+            .expect("Failed to build locality attributes");
+
+        let tpma_locality: TPMA_LOCALITY = expected_locality_attributes.into();
+        assert_eq!(
+            locality, tpma_locality,
+            "Locality did not convert inte expected TPMA_LOCALITY value"
+        );
+
+        assert_eq!(
+            expected_locality_attributes,
+            tpma_locality.into(),
+            "The locality attributes converted from TPMA_LOCALITY did not match the expected value"
+        );
+    }
+}
+
+#[test]
+fn test_constants() {
+    assert_eq!(
+        LocalityAttributes::LOCALITY_ZERO,
+        LocalityAttributesBuilder::new()
+            .with_locality(0)
+            .build()
+            .expect("Failed to build locality attributes"),
+        "LOCALITY_ZERO constant does not have the correct value"
+    );
+
+    assert_eq!(
+        LocalityAttributes::LOCALITY_ONE,
+        LocalityAttributesBuilder::new()
+            .with_locality(1)
+            .build()
+            .expect("Failed to build locality attributes"),
+        "LOCALITY_ONE constant does not have the correct value"
+    );
+
+    assert_eq!(
+        LocalityAttributes::LOCALITY_TWO,
+        LocalityAttributesBuilder::new()
+            .with_locality(2)
+            .build()
+            .expect("Failed to build locality attributes"),
+        "LOCALITY_TWO constant does not have the correct value"
+    );
+
+    assert_eq!(
+        LocalityAttributes::LOCALITY_THREE,
+        LocalityAttributesBuilder::new()
+            .with_locality(3)
+            .build()
+            .expect("Failed to build locality attributes"),
+        "LOCALITY_THREE constant does not have the correct value"
+    );
+
+    assert_eq!(
+        LocalityAttributes::LOCALITY_FOUR,
+        LocalityAttributesBuilder::new()
+            .with_locality(4)
+            .build()
+            .expect("Failed to build locality attributes"),
+        "LOCALITY_FOUR constant does not have the correct value"
+    );
+}
+
+#[test]
+fn test_builder_valid_non_extended() {
+    let locality_attributes = LocalityAttributesBuilder::new()
+        .with_localities(&[0, 1, 2, 3, 4])
+        .build()
+        .expect("Failed to build locality attributes");
+
+    assert!(
+        locality_attributes.locality_zero(),
+        "Locality ZERO was not properly set"
+    );
+    assert!(
+        locality_attributes.locality_one(),
+        "Locality ONE was not properly set"
+    );
+    assert!(
+        locality_attributes.locality_two(),
+        "Locality TWO was not properly set"
+    );
+    assert!(
+        locality_attributes.locality_three(),
+        "Locality THREE was not properly set"
+    );
+    assert!(
+        locality_attributes.locality_four(),
+        "Locality FOUR was not properly set"
+    );
+    assert!(
+        !locality_attributes.is_extended(),
+        "Locality attributes unexpectedly indicated extended"
+    );
+}
+
+#[test]
+fn test_builder_valid_extended() {
+    for expected_locality in 32u8..=u8::MAX {
+        let locality_attributes = LocalityAttributesBuilder::new()
+            .with_locality(expected_locality)
+            .build()
+            .expect("Failed to build locality attributes");
+        assert!(
+            locality_attributes.is_extended(),
+            "Locality attributes does not indicate to be 'extnded' as expected"
+        );
+        assert_eq!(
+            expected_locality,
+            locality_attributes
+                .as_extended()
+                .expect("Failed to get local attributes as extended"),
+            "The extended value does not match expected value.",
+        );
+    }
+}
+
+#[test]
+fn test_invalid_locality() {
+    for locality in 5u8..=31u8 {
+        assert_eq!(
+            Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+            LocalityAttributesBuilder::new()
+                .with_locality(locality)
+                .build(),
+            "Locality builder did not produce expected error when using locality {}",
+            locality
+        );
+    }
+}
+
+#[test]
+fn test_invalid_locality_combinataions() {
+    for locality in 0u8..=4u8 {
+        assert_eq!(
+            Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+            LocalityAttributesBuilder::new()
+                .with_locality(32)
+                .with_locality(locality)
+                .build(),
+            "Locality builder did not produce expected error when using locality 32 in combination with locality {}",
+            locality,
+        );
+    }
+
+    for locality in 32u8..u8::MAX {
+        assert_eq!(
+            Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+            LocalityAttributesBuilder::new()
+                .with_locality(1)
+                .with_locality(locality)
+                .build(),
+            "Locality builder did not produce expected error when using locality 32 in combination with locality {}",
+            locality,
+        );
+    }
+}

--- a/tss-esapi/tests/integration_tests/attributes_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/attributes_tests/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod locality_attributes_tests;
 mod nv_index_attributes_tests;

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -290,7 +290,7 @@ mod test_policy_locality {
     use crate::common::create_ctx_without_session;
     use std::convert::TryFrom;
     use tss_esapi::{
-        attributes::SessionAttributesBuilder,
+        attributes::{LocalityAttributes, SessionAttributesBuilder},
         constants::SessionType,
         interface_types::{algorithm::HashingAlgorithm, session_handles::PolicySession},
         structures::SymmetricDefinition,
@@ -324,7 +324,9 @@ mod test_policy_locality {
         let trial_policy_session = PolicySession::try_from(trial_policy_auth_session)
             .expect("Failed to convert auth session into policy session");
         // There should be no errors setting an Or for a TRIAL session
-        context.policy_locality(trial_policy_session, 3).unwrap();
+        context
+            .policy_locality(trial_policy_session, LocalityAttributes::LOCALITY_THREE)
+            .unwrap();
     }
 }
 


### PR DESCRIPTION
- Adds the LocalityAttributes type, this corresponds to TPMA_LOCALITY.
- Changes the context methods to use LocalityAttributes instead of TPMA_LOCALITY.
- Changes the CreationData type to use LocalityAttributes internally instead of TPMA_LOCALITY.