### PR TITLE
Support Certify context command

### DIFF
--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    handles::KeyHandle,
+    handles::{KeyHandle, ObjectHandle},
     structures::{Attest, AttestBuffer, Data, PcrSelectionList, Signature, SignatureScheme},
     tss2_esys::*,
     Context, Error, Result,
@@ -12,7 +12,148 @@ use std::convert::TryFrom;
 use std::ptr::null_mut;
 
 impl Context {
-    // Missing function: Certify
+    /// Prove that an object is loaded in the TPM
+    ///
+    /// # Arguments
+    /// * `object_handle` - Handle of the object to be certified
+    /// * `signing_key_handle` - Handle of the key used to sign the attestation buffer
+    /// * `qualifying_data` - Qualifying data
+    /// * `signing_scheme` - Signing scheme to use if the scheme for `signing_key_handle` is `Null`.
+    ///
+    /// The object may be any object that is loaded with [Self::load()] or [Self::create_primary()]. An object that
+    /// only has its public area loaded may not be certified.
+    ///
+    /// The `signing_key_handle` must be usable for signing.
+    ///
+    /// If `signing_key_handle` has the Restricted attribute set to `true` then `signing_scheme` must be
+    /// [SignatureScheme::Null].
+    ///
+    /// # Returns
+    /// The command returns a tuple consisting of:
+    /// * `attest_data` - TPM-generated attestation data.
+    /// * `signature` - Signature for the attestation data.
+    ///
+    /// # Errors
+    /// * if the qualifying data provided is too long, a `WrongParamSize` wrapper error will be returned
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use std::convert::TryFrom;
+    /// # use tss_esapi::{
+    /// #     abstraction::cipher::Cipher,
+    /// #     handles::KeyHandle,
+    /// #     interface_types::{
+    /// #         algorithm::{HashingAlgorithm, RsaSchemeAlgorithm, SignatureSchemeAlgorithm},
+    /// #         key_bits::RsaKeyBits,
+    /// #         resource_handles::Hierarchy,
+    /// #     },
+    /// #     structures::{
+    /// #         RsaExponent, RsaScheme, SymmetricDefinition,
+    /// #     },
+    /// #     utils::{create_unrestricted_signing_rsa_public, create_restricted_decryption_rsa_public},
+    /// # };
+    /// use std::convert::TryInto;
+    /// use tss_esapi::{
+    ///     structures::{Data, SignatureScheme},
+    ///     interface_types::session_handles::AuthSession,
+    /// };
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let qualifying_data = vec![0xff; 16];
+    /// # let signing_key_pub = create_unrestricted_signing_rsa_public(
+    /// #         RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
+    /// #         .expect("Failed to create RSA scheme"),
+    /// #     RsaKeyBits::Rsa2048,
+    /// #     RsaExponent::default(),
+    /// # )
+    /// # .expect("Failed to create an unrestricted signing rsa public structure");
+    /// # let sign_key_handle = context
+    /// #     .execute_with_nullauth_session(|ctx| {
+    /// #         ctx.create_primary(Hierarchy::Owner, &signing_key_pub, None, None, None, None)
+    /// #     })
+    /// #     .unwrap()
+    /// #     .key_handle;
+    /// # let decryption_key_pub = create_restricted_decryption_rsa_public(
+    /// #         Cipher::aes_256_cfb()
+    /// #         .try_into()
+    /// #         .expect("Failed to create symmetric object"),
+    /// #     RsaKeyBits::Rsa2048,
+    /// #     RsaExponent::default(),
+    /// # )
+    /// # .expect("Failed to create a restricted decryption rsa public structure");
+    /// # let obj_key_handle = context
+    /// #     .execute_with_nullauth_session(|ctx| {
+    /// #         ctx.create_primary(
+    /// #             Hierarchy::Owner,
+    /// #             &decryption_key_pub,
+    /// #             None,
+    /// #             None,
+    /// #             None,
+    /// #             None,
+    /// #         )
+    /// #     })
+    /// #     .unwrap()
+    /// #     .key_handle;
+    /// let (attest, signature) = context
+    ///     .execute_with_sessions(
+    ///         (
+    ///             Some(AuthSession::Password),
+    ///             Some(AuthSession::Password),
+    ///             None,
+    ///         ),
+    ///         |ctx| {
+    ///             ctx.certify(
+    ///                 obj_key_handle.into(),
+    ///                 sign_key_handle,
+    ///                 &Data::try_from(qualifying_data).unwrap(),
+    ///                 SignatureScheme::Null,
+    ///             )
+    ///         },
+    ///     )
+    ///     .expect("Failed to certify object handle");
+    /// ```
+    pub fn certify(
+        &mut self,
+        object_handle: ObjectHandle,
+        signing_key_handle: KeyHandle,
+        qualifying_data: &Data,
+        signing_scheme: SignatureScheme,
+    ) -> Result<(Attest, Signature)> {
+        let mut certify_info = null_mut();
+        let mut signature = null_mut();
+        let ret = unsafe {
+            Esys_Certify(
+                self.mut_context(),
+                object_handle.into(),
+                signing_key_handle.into(),
+                self.required_session_1()?,
+                self.required_session_2()?,
+                self.optional_session_3(),
+                &qualifying_data.clone().into(),
+                &signing_scheme.into(),
+                &mut certify_info,
+                &mut signature,
+            )
+        };
+        let ret = Error::from_tss_rc(ret);
+
+        if ret.is_success() {
+            let certify_info = unsafe { MBox::<TPM2B_ATTEST>::from_raw(certify_info) };
+            let signature = unsafe { MBox::from_raw(signature) };
+            Ok((
+                Attest::try_from(AttestBuffer::try_from(*certify_info)?)?,
+                Signature::try_from(*signature)?,
+            ))
+        } else {
+            error!("Error in certifying: {}", ret);
+            Err(ret)
+        }
+    }
+
     // Missing function: CertifyCreation
 
     /// Generate a quote on the selected PCRs

--- a/tss-esapi/src/handles/handle.rs
+++ b/tss-esapi/src/handles/handle.rs
@@ -309,6 +309,7 @@ pub mod nv_index {
 /// Key handle module
 pub mod key {
     use super::object::ObjectHandle;
+    use crate::tss2_esys::ESYS_TR_RH_NULL;
     impl_basic_handle!(
         /// Key Handle
         ///
@@ -317,6 +318,7 @@ pub mod key {
         KeyHandle
     );
     impl_handle_conversion!(KeyHandle, ObjectHandle);
+    add_constant_handle!(KeyHandle, Null, ESYS_TR_RH_NULL);
 }
 
 /// Session handle module

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
@@ -1,14 +1,22 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod test_quote {
-    use crate::common::{create_ctx_with_session, signing_key_pub};
+    use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
     use std::convert::TryFrom;
     use tss_esapi::{
+        constants::StructureTag,
+        handles::KeyHandle,
         interface_types::{
-            algorithm::HashingAlgorithm, resource_handles::Hierarchy,
+            algorithm::{HashingAlgorithm, SignatureSchemeAlgorithm},
+            resource_handles::Hierarchy,
+            session_handles::AuthSession,
             structure_tags::AttestationType,
         },
-        structures::{AttestInfo, Data, PcrSelectionListBuilder, PcrSlot, SignatureScheme},
+        structures::{
+            AttestInfo, Data, HashScheme, MaxBuffer, PcrSelectionListBuilder, PcrSlot,
+            SignatureScheme, Ticket,
+        },
+        traits::Marshall,
     };
 
     #[test]
@@ -54,5 +62,107 @@ mod test_quote {
                 panic!("Attested did not contain the expected variant.")
             }
         }
+    }
+
+    #[test]
+    fn certify() {
+        let mut context = create_ctx_with_session();
+        let qualifying_data = vec![0xff; 16];
+
+        let sign_key_handle = context
+            .create_primary(Hierarchy::Owner, &signing_key_pub(), None, None, None, None)
+            .unwrap()
+            .key_handle;
+        let obj_key_handle = context
+            .create_primary(
+                Hierarchy::Owner,
+                &decryption_key_pub(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+            .key_handle;
+
+        let (attest, signature) = context
+            .execute_with_sessions(
+                (
+                    Some(AuthSession::Password),
+                    Some(AuthSession::Password),
+                    None,
+                ),
+                |ctx| {
+                    ctx.certify(
+                        obj_key_handle.into(),
+                        sign_key_handle,
+                        &Data::try_from(qualifying_data.clone()).unwrap(),
+                        SignatureScheme::Null,
+                    )
+                },
+            )
+            .expect("Failed to certify object handle");
+
+        // Verify the signature is valid for the attestation data
+
+        let data = MaxBuffer::try_from(attest.marshall().unwrap())
+            .expect("Failed to get data buffer from attestation data");
+        let (digest, _) = context
+            .hash(&data, HashingAlgorithm::Sha256, Hierarchy::Null)
+            .expect("Failed to hash data");
+
+        let ticket = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.verify_signature(sign_key_handle, &digest, signature)
+            })
+            .expect("Failed to verify signature");
+        assert_eq!(ticket.tag(), StructureTag::Verified);
+
+        // Verify the attestation data is as expected
+
+        assert_eq!(attest.attestation_type(), AttestationType::Certify);
+        assert!(matches!(attest.attested(), AttestInfo::Certify { .. }));
+        assert_eq!(attest.extra_data().value(), qualifying_data);
+    }
+
+    #[test]
+    fn certify_null() {
+        let mut context = create_ctx_with_session();
+        let qualifying_data = vec![0xff; 16];
+        let sign_scheme = SignatureScheme::RsaPss {
+            hash_scheme: HashScheme::new(HashingAlgorithm::Sha256),
+        };
+
+        let obj_key_handle = context
+            .create_primary(
+                Hierarchy::Owner,
+                &decryption_key_pub(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+            .key_handle;
+
+        let (_attest, signature) = context
+            .execute_with_sessions(
+                (
+                    Some(AuthSession::Password),
+                    Some(AuthSession::Password),
+                    None,
+                ),
+                |ctx| {
+                    ctx.certify(
+                        obj_key_handle.into(),
+                        KeyHandle::Null,
+                        &Data::try_from(qualifying_data).unwrap(),
+                        sign_scheme,
+                    )
+                },
+            )
+            .expect("Failed to certify object handle");
+
+        assert_eq!(signature.algorithm(), SignatureSchemeAlgorithm::Null);
     }
 }


### PR DESCRIPTION
Add support for the Certify context command, which is useful for
proving that a TPM posseses an object as part of remote attestation.

Signed-off-by: Rob Shearman <rob@graphiant.com>

I'm happy to wait for #293 and/or #286 to be merged and rebase on top of them.