### PR TITLE
SIgnature and Public marshalling/unmarshalling for remote attestation

### DIFF
--- a/tss-esapi/src/structures/buffers/public.rs
+++ b/tss-esapi/src/structures/buffers/public.rs
@@ -291,7 +291,7 @@ impl PublicBuilder {
 ///
 /// # Details
 /// This corresponds to TPM2B_PUBLIC
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Public {
     Rsa {
         object_attributes: ObjectAttributes,

--- a/tss-esapi/src/structures/buffers/public/ecc.rs
+++ b/tss-esapi/src/structures/buffers/public/ecc.rs
@@ -10,7 +10,7 @@ use log::error;
 use std::convert::{TryFrom, TryInto};
 
 /// Builder for PublicEccParameters.
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct PublicEccParametersBuilder {
     symmetric: Option<SymmetricDefinitionObject>,
     ecc_scheme: Option<EccScheme>,
@@ -214,7 +214,7 @@ impl PublicEccParametersBuilder {
 ///
 /// # Details
 /// This corresponds to TPMS_ECC_PARMS.
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 pub struct PublicEccParameters {
     symmetric_definition_object: SymmetricDefinitionObject,
     ecc_scheme: EccScheme,

--- a/tss-esapi/src/structures/buffers/public/keyed_hash.rs
+++ b/tss-esapi/src/structures/buffers/public/keyed_hash.rs
@@ -9,7 +9,7 @@ use std::convert::{TryFrom, TryInto};
 /// Corresponds to TPMS_KEYEDHASH_PARMS
 ///
 /// These keyed hash parameters are specific to the [`crate::structures::Public`] type.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PublicKeyedHashParameters {
     keyed_hash_scheme: KeyedHashScheme,
 }

--- a/tss-esapi/src/structures/buffers/public/rsa.rs
+++ b/tss-esapi/src/structures/buffers/public/rsa.rs
@@ -287,7 +287,7 @@ impl TryFrom<UINT32> for RsaExponent {
 /// This corresponds to TPMS_RSA_PARMS
 ///
 /// These rsa parameters are specific to the [`crate::structures::Public`] type.
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub struct PublicRsaParameters {
     symmetric_definition_object: SymmetricDefinitionObject,
     rsa_scheme: RsaScheme,

--- a/tss-esapi/src/structures/ecc/point.rs
+++ b/tss-esapi/src/structures/ecc/point.rs
@@ -9,7 +9,7 @@ use std::convert::{TryFrom, TryInto};
 ///
 /// # Details
 /// This corresponds to TPMS_ECC_POINT
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EccPoint {
     x: EccParameter,
     y: EccParameter,

--- a/tss-esapi/src/structures/hash/agile.rs
+++ b/tss-esapi/src/structures/hash/agile.rs
@@ -6,7 +6,7 @@ use crate::tss2_esys::{TPMT_HA, TPMU_HA};
 use crate::{Error, Result, WrapperErrorKind};
 use std::convert::{TryFrom, TryInto};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HashAgile {
     algorithm: HashingAlgorithm,
     digest: Digest,

--- a/tss-esapi/src/structures/parameters.rs
+++ b/tss-esapi/src/structures/parameters.rs
@@ -11,7 +11,7 @@ use std::convert::{TryFrom, TryInto};
 ///
 /// # Details
 /// Corresponds to TPMS_SYMCIPHER_PARMS
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub struct SymmetricCipherParameters {
     symmetric_definition_object: SymmetricDefinitionObject,
 }

--- a/tss-esapi/src/structures/signatures.rs
+++ b/tss-esapi/src/structures/signatures.rs
@@ -10,7 +10,7 @@ use log::error;
 use std::convert::{TryFrom, TryInto};
 
 /// Type holding RSA signature information.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RsaSignature {
     hashing_algorithm: HashingAlgorithm,
     signature: PublicKeyRsa,
@@ -70,7 +70,7 @@ impl TryFrom<TPMS_SIGNATURE_RSA> for RsaSignature {
 }
 
 /// Type holding ECC signature information.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EccSignature {
     hashing_algorithm: HashingAlgorithm,
     signature_r: EccParameter,

--- a/tss-esapi/src/structures/tagged/schemes.rs
+++ b/tss-esapi/src/structures/tagged/schemes.rs
@@ -19,7 +19,7 @@ use std::convert::{TryFrom, TryInto};
 ///
 /// # Details
 /// This corresponds to TPMT_SCHEME_KEYEDHASH.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KeyedHashScheme {
     Xor { xor_scheme: XorScheme },
     Hmac { hmac_scheme: HmacScheme },
@@ -76,7 +76,7 @@ impl TryFrom<TPMT_KEYEDHASH_SCHEME> for KeyedHashScheme {
 /// This corresponds to TPMT_RSA_SCHEME.
 /// This uses a subset of the TPMU_ASYM_SCHEME
 /// that has the TPMI_ALG_RSA_SCHEME as selector.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RsaScheme {
     RsaSsa(HashScheme),
     RsaEs,
@@ -211,7 +211,7 @@ impl TryFrom<TPMT_RSA_SCHEME> for RsaScheme {
 /// This corresponds to TPMT_ECC_SCHEME.
 /// This uses a subset of the TPMU_ASYM_SCHEME
 /// that has the TPMI_ALG_ECC_SCHEME as selector.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EccScheme {
     EcDsa(HashScheme),
     EcDh(HashScheme),
@@ -375,7 +375,7 @@ impl TryFrom<TPMT_ECC_SCHEME> for EccScheme {
 ///
 /// # Details
 /// This corresponds to TPMT_KDF_SCHEME.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KeyDerivationFunctionScheme {
     Kdf1Sp800_56a(HashScheme),
     Kdf2(HashScheme),
@@ -445,7 +445,7 @@ impl TryFrom<TPMT_KDF_SCHEME> for KeyDerivationFunctionScheme {
 ///
 /// # Details
 /// This corresponds to TPMT_RSA_DECRYPT.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RsaDecryptionScheme {
     RsaEs,
     Oaep(HashScheme),

--- a/tss-esapi/src/structures/tagged/signature.rs
+++ b/tss-esapi/src/structures/tagged/signature.rs
@@ -12,7 +12,7 @@ use std::convert::{TryFrom, TryInto};
 ///
 /// # Details
 /// This corresponds TPMT_SIGNATURE
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Signature {
     RsaSsa(RsaSignature),
     RsaPss(RsaSignature),

--- a/tss-esapi/src/structures/tagged/symmetric.rs
+++ b/tss-esapi/src/structures/tagged/symmetric.rs
@@ -136,7 +136,7 @@ impl TryFrom<TPMT_SYM_DEF> for SymmetricDefinition {
 ///
 /// # Details
 /// This corresponds to TPMT_SYM_DEF_OBJECT
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SymmetricDefinitionObject {
     // TDOD: Investigate why TDES is missing.
     Aes {

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/mod.rs
@@ -10,3 +10,4 @@ mod public_ecc_parameters_tests;
 mod public_marshall_tests;
 mod public_rsa_exponent_tests;
 mod public_rsa_parameters_tests;
+mod signature_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/mod.rs
@@ -7,5 +7,6 @@ mod digest_tests;
 mod max_buffer_tests;
 mod nonce_tests;
 mod public_ecc_parameters_tests;
+mod public_marshall_tests;
 mod public_rsa_exponent_tests;
 mod public_rsa_parameters_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/public_marshall_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/public_marshall_tests.rs
@@ -1,0 +1,48 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use tss_esapi::attributes::ObjectAttributes;
+use tss_esapi::interface_types::algorithm::*;
+use tss_esapi::interface_types::ecc::EccCurve;
+use tss_esapi::structures::*;
+use tss_esapi::traits::{Marshall, UnMarshall};
+
+use crate::common::setup_logging;
+
+#[test]
+fn test_marshall_unmarshall() {
+    setup_logging();
+
+    let public = PublicBuilder::new()
+        .with_public_algorithm(PublicAlgorithm::Ecc)
+        .with_object_attributes(ObjectAttributes::new_fixed_parent_key())
+        .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+        .with_ecc_parameters(
+            PublicEccParametersBuilder::new()
+                .with_restricted(false)
+                .with_is_decryption_key(false)
+                .with_is_signing_key(true)
+                .with_ecc_scheme(
+                    EccScheme::create(
+                        EccSchemeAlgorithm::EcDsa,
+                        Some(HashingAlgorithm::Sha256),
+                        None,
+                    )
+                    .unwrap(),
+                )
+                .with_curve(EccCurve::NistP256)
+                .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+                .with_symmetric(SymmetricDefinitionObject::Null)
+                .build()
+                .expect("Failed to build public ECC parameters"),
+        )
+        .with_ecc_unique_identifier(&EccPoint::default())
+        .build()
+        .expect("Failed to build public data");
+
+    let pub_data_vec = public.marshall().expect("Failed to marshall public data");
+
+    let new_public = Public::unmarshall(&pub_data_vec).expect("Failed to unmarshall public data");
+
+    assert_eq!(new_public, public);
+}

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/signature_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/signature_tests.rs
@@ -1,0 +1,20 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use tss_esapi::{
+    structures::*,
+    traits::{Marshall, UnMarshall},
+};
+
+use crate::common::setup_logging;
+
+#[test]
+fn test_marshal_unmarshal_null() {
+    setup_logging();
+
+    let sig = Signature::Null;
+    let sig_vec = sig.marshall().expect("Failed to marshall signature");
+    let new_sig = Signature::unmarshall(sig_vec.as_ref()).expect("Failed to unmarshal signature");
+
+    assert_eq!(new_sig, sig);
+}


### PR DESCRIPTION
When performing remote attestation then it is often necessary to transmit certain TPM objects over a network to the remote entity and the Public and Signature are such objects, so being able to marshall/unmarshall them is useful.

This set of changes adds implementations to marshall/unmarshall to support this use case.