### PR TITLE
Command code list

### DIFF
--- a/tss-esapi/src/constants/command_code.rs
+++ b/tss-esapi/src/constants/command_code.rs
@@ -9,6 +9,10 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use std::convert::TryFrom;
 use structure::CommandCodeStructure;
 
+/// Enum representing the command code constants.
+///
+/// # Details
+/// This corresponds to the TPM2_CC constants.
 #[derive(FromPrimitive, ToPrimitive, Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[repr(u32)]
 pub enum CommandCode {

--- a/tss-esapi/src/structures/lists/command_code.rs
+++ b/tss-esapi/src/structures/lists/command_code.rs
@@ -7,7 +7,7 @@ use crate::{
     Error, Result, WrapperErrorKind,
 };
 use log::error;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, ops::Deref};
 
 /// A list of command codes.
 #[derive(Debug, Clone, Default)]
@@ -92,5 +92,13 @@ impl From<CommandCodeList> for Vec<CommandCode> {
 impl AsRef<[CommandCode]> for CommandCodeList {
     fn as_ref(&self) -> &[CommandCode] {
         self.command_codes.as_slice()
+    }
+}
+
+impl Deref for CommandCodeList {
+    type Target = Vec<CommandCode>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.command_codes
     }
 }

--- a/tss-esapi/src/structures/lists/command_code.rs
+++ b/tss-esapi/src/structures/lists/command_code.rs
@@ -1,0 +1,96 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    constants::CommandCode,
+    tss2_esys::{TPM2_MAX_CAP_CC, TPML_CC},
+    Error, Result, WrapperErrorKind,
+};
+use log::error;
+use std::convert::TryFrom;
+
+/// A list of command codes.
+#[derive(Debug, Clone, Default)]
+pub struct CommandCodeList {
+    command_codes: Vec<CommandCode>,
+}
+
+impl CommandCodeList {
+    pub const MAX_SIZE: usize = TPM2_MAX_CAP_CC as usize;
+    /// Creates a new CommandCodeList
+    pub const fn new() -> Self {
+        CommandCodeList {
+            command_codes: Vec::new(),
+        }
+    }
+
+    /// Adds a command code to the command code list.
+    pub fn add(&mut self, command_code: CommandCode) -> Result<()> {
+        if self.command_codes.len() + 1 > CommandCodeList::MAX_SIZE {
+            error!(
+                "Adding command code to list will make the list exceeded its maximum count(> {})",
+                CommandCodeList::MAX_SIZE
+            );
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        self.command_codes.push(command_code);
+        Ok(())
+    }
+
+    /// Returns the inner type.
+    pub fn into_inner(self) -> Vec<CommandCode> {
+        self.command_codes
+    }
+}
+
+impl TryFrom<TPML_CC> for CommandCodeList {
+    type Error = Error;
+
+    fn try_from(tpml_cc: TPML_CC) -> Result<Self> {
+        let command_code_count = tpml_cc.count as usize;
+        if command_code_count > Self::MAX_SIZE {
+            error!("Error: Invalid TPML_CC count(> {})", Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        tpml_cc.commandCodes[..command_code_count]
+            .iter()
+            .map(|&cc| CommandCode::try_from(cc))
+            .collect::<Result<Vec<CommandCode>>>()
+            .map(|command_codes| CommandCodeList { command_codes })
+    }
+}
+
+impl From<CommandCodeList> for TPML_CC {
+    fn from(command_code_list: CommandCodeList) -> Self {
+        let mut tpml_cc = TPML_CC::default();
+        for cc in command_code_list.command_codes {
+            tpml_cc.commandCodes[tpml_cc.count as usize] = cc.into();
+            tpml_cc.count += 1;
+        }
+        tpml_cc
+    }
+}
+
+impl TryFrom<Vec<CommandCode>> for CommandCodeList {
+    type Error = Error;
+
+    fn try_from(command_codes: Vec<CommandCode>) -> Result<Self> {
+        if command_codes.len() > Self::MAX_SIZE {
+            error!("Error: Invalid TPML_CC count(> {})", Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(CommandCodeList { command_codes })
+    }
+}
+
+impl From<CommandCodeList> for Vec<CommandCode> {
+    fn from(command_code_list: CommandCodeList) -> Self {
+        command_code_list.command_codes
+    }
+}
+
+impl AsRef<[CommandCode]> for CommandCodeList {
+    fn as_ref(&self) -> &[CommandCode] {
+        self.command_codes.as_slice()
+    }
+}

--- a/tss-esapi/src/structures/lists/mod.rs
+++ b/tss-esapi/src/structures/lists/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+pub mod command_code;
 pub mod digest;
 pub mod digest_values;
 pub mod pcr_selection;

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -101,6 +101,11 @@ pub use self::pcr_selection_list::PcrSelectionListBuilder;
 pub mod pcr_selection_list {
     pub use super::lists::pcr_selection::*;
 }
+
+pub use self::command_code_list::CommandCodeList;
+pub mod command_code_list {
+    pub use super::lists::command_code::*;
+}
 /////////////////////////////////////////////////////////
 /// The parameters section
 /////////////////////////////////////////////////////////

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/command_code_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/command_code_list_tests.rs
@@ -1,0 +1,99 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use tss_esapi::{
+    constants::CommandCode,
+    structures::CommandCodeList,
+    tss2_esys::{TPM2_CC, TPML_CC},
+    Error, WrapperErrorKind,
+};
+
+use std::convert::TryInto;
+
+#[test]
+fn test_conversions() {
+    let expected_command_codes = vec![
+        CommandCode::ChangeEps,
+        CommandCode::ChangePps,
+        CommandCode::Clear,
+    ];
+    let mut command_code_list = CommandCodeList::new();
+    for command_code in expected_command_codes.iter() {
+        command_code_list
+            .add(*command_code)
+            .expect("Failed to add command code to command code list");
+    }
+
+    assert_eq!(
+        expected_command_codes.len(),
+        command_code_list.len(),
+        "The created command code list did not contain the expected number of elements"
+    );
+
+    expected_command_codes
+        .iter()
+        .zip(command_code_list.as_ref().iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                expected, actual,
+                "The created command code list did not contain the expected value"
+            )
+        });
+
+    let tpml_cc: TPML_CC = command_code_list
+        .clone()
+        .try_into()
+        .expect("Failed to convert CommandCodeList into TPML_CC");
+
+    assert_eq!(
+        expected_command_codes.len(),
+        tpml_cc.count as usize,
+        "The number count field in TPML_CC did not contain the expected value"
+    );
+
+    expected_command_codes
+        .iter()
+        .zip(tpml_cc.commandCodes[0..tpml_cc.count as usize].iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                TPM2_CC::from(*expected),
+                *actual,
+                "Command code missmatch between command codes in CommandCodeList and converted CommandCodeList"
+            )
+        });
+
+    let converted_command_code_list: CommandCodeList = tpml_cc
+        .try_into()
+        .expect("Failed to convert TPML_CC to CommandCodeList");
+
+    assert_eq!(
+        expected_command_codes.len(),
+        converted_command_code_list.len(),
+        "The command code list converted from TPML_CC did not contain the expected number of elements"
+    );
+
+    expected_command_codes
+        .iter()
+        .zip(converted_command_code_list.as_ref().iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                expected, actual, "Command code in command code list converted from TPML_CC did not match the expected value"
+            )
+        });
+}
+
+#[test]
+fn test_invalid_conversions() {
+    let mut command_code_list = CommandCodeList::new();
+    for _ in 0..CommandCodeList::MAX_SIZE {
+        command_code_list
+            .add(CommandCode::ChangeEps)
+            .expect("Failed to command code to list");
+    }
+
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::WrongParamSize)),
+        command_code_list.add(CommandCode::ChangeEps),
+        "Adding more command codes to command code list then it supports did not produce the expected error"
+    );
+}

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod command_code_list_tests;
 mod digest_list_tests;
 mod pcr_selection_list_builder_tests;
 mod pcr_selection_list_tests;


### PR DESCRIPTION
This adds the CommandCodeList type. It was supposed to be part of #299 but got left out.