### PR TITLE
Update API to take ownership where needed

### DIFF
--- a/tss-esapi/src/abstraction/ak.rs
+++ b/tss-esapi/src/abstraction/ak.rs
@@ -67,7 +67,7 @@ fn create_ak_public<IKC: IntoKeyCustomization>(
                     .with_restricted(obj_attrs.restricted())
                     .build()?,
             )
-            .with_rsa_unique_identifier(&PublicKeyRsa::default())
+            .with_rsa_unique_identifier(PublicKeyRsa::default())
             .build(),
         AsymmetricAlgorithm::Ecc => PublicBuilder::new()
             .with_public_algorithm(PublicAlgorithm::Ecc)
@@ -97,7 +97,7 @@ fn create_ak_public<IKC: IntoKeyCustomization>(
 pub fn load_ak(
     context: &mut Context,
     parent: KeyHandle,
-    ak_auth_value: Option<&Auth>,
+    ak_auth_value: Option<Auth>,
     private: Private,
     public: Public,
 ) -> Result<KeyHandle> {
@@ -137,7 +137,7 @@ pub fn load_ak(
             })?;
 
             ctx.execute_with_session(Some(policy_auth_session), |ctx| {
-                ctx.load(parent, private, &public)
+                ctx.load(parent, private, public)
             })
         },
     )?;
@@ -155,7 +155,7 @@ pub fn create_ak<IKC: IntoKeyCustomization>(
     parent: KeyHandle,
     hash_alg: HashingAlgorithm,
     sign_alg: SignatureSchemeAlgorithm,
-    ak_auth_value: Option<&Auth>,
+    ak_auth_value: Option<Auth>,
     key_customization: IKC,
 ) -> Result<CreateKeyResult> {
     let key_alg = AsymmetricAlgorithm::try_from(sign_alg).map_err(|e| {
@@ -202,7 +202,7 @@ pub fn create_ak<IKC: IntoKeyCustomization>(
             })?;
 
             ctx.execute_with_session(Some(policy_auth_session), |ctx| {
-                ctx.create(parent, &ak_pub, ak_auth_value, None, None, None)
+                ctx.create(parent, ak_pub, ak_auth_value, None, None, None)
             })
         },
     )

--- a/tss-esapi/src/abstraction/ek.rs
+++ b/tss-esapi/src/abstraction/ek.rs
@@ -69,7 +69,7 @@ pub fn create_ek_public_from_default_template<IKC: IntoKeyCustomization>(
             .with_public_algorithm(PublicAlgorithm::Rsa)
             .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
             .with_object_attributes(obj_attrs)
-            .with_auth_policy(&Digest::try_from(authpolicy[0..32].to_vec())?)
+            .with_auth_policy(Digest::try_from(authpolicy[0..32].to_vec())?)
             .with_rsa_parameters(
                 PublicRsaParametersBuilder::new()
                     .with_symmetric(SymmetricDefinitionObject::AES_128_CFB)
@@ -81,12 +81,12 @@ pub fn create_ek_public_from_default_template<IKC: IntoKeyCustomization>(
                     .with_restricted(obj_attrs.decrypt())
                     .build()?,
             )
-            .with_rsa_unique_identifier(&PublicKeyRsa::new_empty_with_size(RsaKeyBits::Rsa2048)),
+            .with_rsa_unique_identifier(PublicKeyRsa::new_empty_with_size(RsaKeyBits::Rsa2048)),
         AsymmetricAlgorithm::Ecc => PublicBuilder::new()
             .with_public_algorithm(PublicAlgorithm::Ecc)
             .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
             .with_object_attributes(obj_attrs)
-            .with_auth_policy(&Digest::try_from(authpolicy[0..32].to_vec())?)
+            .with_auth_policy(Digest::try_from(authpolicy[0..32].to_vec())?)
             .with_ecc_parameters(
                 PublicEccParametersBuilder::new()
                     .with_symmetric(SymmetricDefinitionObject::AES_128_CFB)
@@ -98,7 +98,7 @@ pub fn create_ek_public_from_default_template<IKC: IntoKeyCustomization>(
                     .with_restricted(obj_attrs.decrypt())
                     .build()?,
             )
-            .with_ecc_unique_identifier(&EccPoint::new(
+            .with_ecc_unique_identifier(EccPoint::new(
                 EccParameter::try_from(vec![0u8; 32])?,
                 EccParameter::try_from(vec![0u8; 32])?,
             )),
@@ -126,7 +126,7 @@ pub fn create_ek_object<IKC: IntoKeyCustomization>(
 
     Ok(context
         .execute_with_nullauth_session(|ctx| {
-            ctx.create_primary(Hierarchy::Endorsement, &ek_public, None, None, None, None)
+            ctx.create_primary(Hierarchy::Endorsement, ek_public, None, None, None, None)
         })?
         .key_handle)
 }

--- a/tss-esapi/src/abstraction/pcr.rs
+++ b/tss-esapi/src/abstraction/pcr.rs
@@ -63,7 +63,7 @@ pub fn read_all(
 ) -> Result<PcrData> {
     let mut pcr_data = PcrData::new();
     while !pcr_selection_list.is_empty() {
-        let (_, pcrs_read, pcr_digests) = context.pcr_read(&pcr_selection_list)?;
+        let (_, pcrs_read, pcr_digests) = context.pcr_read(pcr_selection_list.clone())?;
         pcr_data.add(&pcrs_read, &pcr_digests)?;
         pcr_selection_list.subtract(&pcrs_read)?;
     }

--- a/tss-esapi/src/context/general_esys_tr.rs
+++ b/tss-esapi/src/context/general_esys_tr.rs
@@ -20,8 +20,8 @@ use zeroize::Zeroize;
 
 impl Context {
     /// Set the authentication value for a given object handle in the ESYS context.
-    pub fn tr_set_auth(&mut self, object_handle: ObjectHandle, auth: &Auth) -> Result<()> {
-        let mut tss_auth = auth.clone().into();
+    pub fn tr_set_auth(&mut self, object_handle: ObjectHandle, auth: Auth) -> Result<()> {
+        let mut tss_auth = auth.into();
         let ret = unsafe { Esys_TR_SetAuth(self.mut_context(), object_handle.into(), &tss_auth) };
         tss_auth.buffer.zeroize();
         let ret = Error::from_tss_rc(ret);

--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -166,15 +166,15 @@ impl Context {
     ///     .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
     ///     .with_object_attributes(object_attributes)
     ///     .with_ecc_parameters(ecc_parms)
-    ///     .with_ecc_unique_identifier(&EccPoint::default())
+    ///     .with_ecc_unique_identifier(EccPoint::default())
     ///     .build()
     ///     .unwrap();
     ///
     /// let key_handle = context
     ///     .create_primary(
     ///         Hierarchy::Owner,
-    ///         &public,
-    ///         Some(&key_auth),
+    ///         public,
+    ///         Some(key_auth),
     ///         None,
     ///         None,
     ///         None,
@@ -298,15 +298,15 @@ impl Context {
     ///     .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
     ///     .with_object_attributes(object_attributes)
     ///     .with_ecc_parameters(ecc_parms)
-    ///     .with_ecc_unique_identifier(&EccPoint::default())
+    ///     .with_ecc_unique_identifier(EccPoint::default())
     ///     .build()
     ///     .unwrap();
     ///
     /// let key_handle = context
     ///     .create_primary(
     ///         Hierarchy::Owner,
-    ///         &public,
-    ///         Some(&key_auth),
+    ///         public,
+    ///         Some(key_auth),
     ///         None,
     ///         None,
     ///         None,

--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -73,7 +73,7 @@ impl Context {
     /// # .expect("Failed to create an unrestricted signing rsa public structure");
     /// # let sign_key_handle = context
     /// #     .execute_with_nullauth_session(|ctx| {
-    /// #         ctx.create_primary(Hierarchy::Owner, &signing_key_pub, None, None, None, None)
+    /// #         ctx.create_primary(Hierarchy::Owner, signing_key_pub, None, None, None, None)
     /// #     })
     /// #     .unwrap()
     /// #     .key_handle;
@@ -89,7 +89,7 @@ impl Context {
     /// #     .execute_with_nullauth_session(|ctx| {
     /// #         ctx.create_primary(
     /// #             Hierarchy::Owner,
-    /// #             &decryption_key_pub,
+    /// #             decryption_key_pub,
     /// #             None,
     /// #             None,
     /// #             None,
@@ -109,7 +109,7 @@ impl Context {
     ///             ctx.certify(
     ///                 obj_key_handle.into(),
     ///                 sign_key_handle,
-    ///                 &Data::try_from(qualifying_data).unwrap(),
+    ///                 Data::try_from(qualifying_data).unwrap(),
     ///                 SignatureScheme::Null,
     ///             )
     ///         },
@@ -120,7 +120,7 @@ impl Context {
         &mut self,
         object_handle: ObjectHandle,
         signing_key_handle: KeyHandle,
-        qualifying_data: &Data,
+        qualifying_data: Data,
         signing_scheme: SignatureScheme,
     ) -> Result<(Attest, Signature)> {
         let mut certify_info = null_mut();
@@ -133,7 +133,7 @@ impl Context {
                 self.required_session_1()?,
                 self.required_session_2()?,
                 self.optional_session_3(),
-                &qualifying_data.clone().into(),
+                &qualifying_data.into(),
                 &signing_scheme.into(),
                 &mut certify_info,
                 &mut signature,
@@ -163,7 +163,7 @@ impl Context {
     pub fn quote(
         &mut self,
         signing_key_handle: KeyHandle,
-        qualifying_data: &Data,
+        qualifying_data: Data,
         signing_scheme: SignatureScheme,
         pcr_selection_list: PcrSelectionList,
     ) -> Result<(Attest, Signature)> {
@@ -176,7 +176,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &qualifying_data.clone().into(),
+                &qualifying_data.into(),
                 &signing_scheme.into(),
                 &pcr_selection_list.into(),
                 &mut quoted,

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -125,8 +125,8 @@ impl Context {
     ///     let key_handle = ctx
     ///         .create_primary(
     ///             Hierarchy::Owner,
-    ///             &public_area,
-    ///             Some(&key_auth),
+    ///             public_area,
+    ///             Some(key_auth),
     ///             None,
     ///             None,
     ///             None,
@@ -245,12 +245,12 @@ impl Context {
     /// #    ctx
     /// #        .create_primary(
     /// #            Hierarchy::Owner,
-    /// #            &create_restricted_decryption_rsa_public(
+    /// #            create_restricted_decryption_rsa_public(
     /// #               SymmetricDefinitionObject::AES_256_CFB,
     /// #               RsaKeyBits::Rsa2048,
     /// #               RsaExponent::default(),
     /// #            ).expect("Failed to Public structure for key"),
-    /// #            Some(auth_value_primary).as_ref(),
+    /// #            Some(auth_value_primary),
     /// #            None,
     /// #            None,
     /// #            None,
@@ -364,12 +364,12 @@ impl Context {
     /// #    ctx
     /// #        .create_primary(
     /// #            Hierarchy::Owner,
-    /// #            &create_restricted_decryption_rsa_public(
+    /// #            create_restricted_decryption_rsa_public(
     /// #               SymmetricDefinitionObject::AES_256_CFB,
     /// #               RsaKeyBits::Rsa2048,
     /// #               RsaExponent::default(),
     /// #            ).expect("Failed to Public structure for key"),
-    /// #            Some(auth_value_primary).as_ref(),
+    /// #            Some(auth_value_primary),
     /// #            None,
     /// #            None,
     /// #            None,

--- a/tss-esapi/src/context/tpm_commands/duplication_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/duplication_commands.rs
@@ -161,14 +161,14 @@ impl Context {
     /// #         .build()
     /// #         .unwrap(),
     /// #     )
-    /// #     .with_rsa_unique_identifier(&PublicKeyRsa::default())
+    /// #     .with_rsa_unique_identifier(PublicKeyRsa::default())
     /// #     .build()
     /// #     .unwrap();
     /// #
     /// # let parent_of_object_to_duplicate_handle = context
     /// #     .create_primary(
     /// #         Hierarchy::Owner,
-    /// #         &parent_public,
+    /// #         parent_public.clone(),
     /// #         None,
     /// #         None,
     /// #         None,
@@ -194,7 +194,7 @@ impl Context {
     /// #     .with_public_algorithm(PublicAlgorithm::Rsa)
     /// #     .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
     /// #     .with_object_attributes(object_attributes)
-    /// #     .with_auth_policy(&digest)
+    /// #     .with_auth_policy(digest)
     /// #     .with_rsa_parameters(
     /// #         PublicRsaParametersBuilder::new()
     /// #             .with_scheme(RsaScheme::Null)
@@ -205,14 +205,14 @@ impl Context {
     /// #             .build()
     /// #             .expect("Params to be valid"),
     /// #     )
-    /// #     .with_rsa_unique_identifier(&PublicKeyRsa::default())
+    /// #     .with_rsa_unique_identifier(PublicKeyRsa::default())
     /// #     .build()
     /// #     .expect("public to be valid");
     /// #
     /// # let result = context
     /// #     .create(
     /// #         parent_of_object_to_duplicate_handle,
-    /// #         &public_child,
+    /// #         public_child,
     /// #         None,
     /// #         None,
     /// #         None,
@@ -224,7 +224,7 @@ impl Context {
     /// #     .load(
     /// #         parent_of_object_to_duplicate_handle,
     /// #         result.out_private.clone(),
-    /// #         &result.out_public,
+    /// #         result.out_public,
     /// #     )
     /// #     .unwrap()
     /// #     .into();
@@ -232,7 +232,7 @@ impl Context {
     /// # let new_parent_handle: ObjectHandle = context
     /// #     .create_primary(
     /// #         Hierarchy::Owner,
-    /// #         &parent_public,
+    /// #         parent_public,
     /// #         None,
     /// #         None,
     /// #         None,
@@ -483,14 +483,14 @@ impl Context {
     /// #         .build()
     /// #         .unwrap(),
     /// #     )
-    /// #     .with_rsa_unique_identifier(&PublicKeyRsa::default())
+    /// #     .with_rsa_unique_identifier(PublicKeyRsa::default())
     /// #     .build()
     /// #     .unwrap();
     /// #
     /// # let parent_of_object_to_duplicate_handle = context
     /// #     .create_primary(
     /// #         Hierarchy::Owner,
-    /// #         &parent_public,
+    /// #         parent_public.clone(),
     /// #         None,
     /// #         None,
     /// #         None,
@@ -516,7 +516,7 @@ impl Context {
     /// #     .with_public_algorithm(PublicAlgorithm::Rsa)
     /// #     .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
     /// #     .with_object_attributes(object_attributes)
-    /// #     .with_auth_policy(&digest)
+    /// #     .with_auth_policy(digest)
     /// #     .with_rsa_parameters(
     /// #         PublicRsaParametersBuilder::new()
     /// #             .with_scheme(RsaScheme::Null)
@@ -527,14 +527,14 @@ impl Context {
     /// #             .build()
     /// #             .expect("Params to be valid"),
     /// #     )
-    /// #     .with_rsa_unique_identifier(&PublicKeyRsa::default())
+    /// #     .with_rsa_unique_identifier(PublicKeyRsa::default())
     /// #     .build()
     /// #     .expect("public to be valid");
     /// #
     /// # let result = context
     /// #     .create(
     /// #         parent_of_object_to_duplicate_handle,
-    /// #         &public_child,
+    /// #         public_child,
     /// #         None,
     /// #         None,
     /// #         None,
@@ -546,7 +546,7 @@ impl Context {
     /// #     .load(
     /// #         parent_of_object_to_duplicate_handle,
     /// #         result.out_private.clone(),
-    /// #         &result.out_public,
+    /// #         result.out_public,
     /// #     )
     /// #     .unwrap()
     /// #     .into();
@@ -554,7 +554,7 @@ impl Context {
     /// # let new_parent_handle: ObjectHandle = context
     /// #     .create_primary(
     /// #         Hierarchy::Owner,
-    /// #         &parent_public,
+    /// #         parent_public,
     /// #         None,
     /// #         None,
     /// #         None,

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -182,7 +182,7 @@ impl Context {
     pub fn policy_pcr(
         &mut self,
         policy_session: PolicySession,
-        pcr_policy_digest: &Digest,
+        pcr_policy_digest: Digest,
         pcr_selection_list: PcrSelectionList,
     ) -> Result<()> {
         let ret = unsafe {
@@ -192,7 +192,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &pcr_policy_digest.clone().into(),
+                &pcr_policy_digest.into(),
                 &pcr_selection_list.into(),
             )
         };
@@ -294,7 +294,7 @@ impl Context {
     pub fn policy_cp_hash(
         &mut self,
         policy_session: PolicySession,
-        cp_hash_a: &Digest,
+        cp_hash_a: Digest,
     ) -> Result<()> {
         let ret = unsafe {
             Esys_PolicyCpHash(
@@ -303,7 +303,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &cp_hash_a.clone().into(),
+                &cp_hash_a.into(),
             )
         };
         let ret = Error::from_tss_rc(ret);
@@ -322,7 +322,7 @@ impl Context {
     pub fn policy_name_hash(
         &mut self,
         policy_session: PolicySession,
-        name_hash: &Digest,
+        name_hash: Digest,
     ) -> Result<()> {
         let ret = unsafe {
             Esys_PolicyNameHash(
@@ -331,7 +331,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &name_hash.clone().into(),
+                &name_hash.into(),
             )
         };
         let ret = Error::from_tss_rc(ret);
@@ -461,8 +461,8 @@ impl Context {
     pub fn policy_authorize(
         &mut self,
         policy_session: PolicySession,
-        approved_policy: &Digest,
-        policy_ref: &Nonce,
+        approved_policy: Digest,
+        policy_ref: Nonce,
         key_sign: &Name,
         check_ticket: VerifiedTicket,
     ) -> Result<()> {
@@ -474,8 +474,8 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &approved_policy.clone().into(),
-                &policy_ref.clone().into(),
+                &approved_policy.into(),
+                &policy_ref.into(),
                 key_sign.as_ref(),
                 &check_ticket,
             )
@@ -597,7 +597,7 @@ impl Context {
     pub fn policy_template(
         &mut self,
         policy_session: PolicySession,
-        template_hash: &Digest,
+        template_hash: Digest,
     ) -> Result<()> {
         let ret = unsafe {
             Esys_PolicyTemplate(
@@ -606,7 +606,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &template_hash.clone().into(),
+                &template_hash.into(),
             )
         };
         let ret = Error::from_tss_rc(ret);

--- a/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
@@ -30,10 +30,10 @@ impl Context {
     pub fn create_primary(
         &mut self,
         primary_handle: Hierarchy,
-        public: &Public,
-        auth_value: Option<&Auth>,
-        initial_data: Option<&SensitiveData>,
-        outside_info: Option<&Data>,
+        public: Public,
+        auth_value: Option<Auth>,
+        initial_data: Option<SensitiveData>,
+        outside_info: Option<Data>,
         creation_pcrs: Option<PcrSelectionList>,
     ) -> Result<CreatePrimaryKeyResult> {
         let sensitive_create = TPM2B_SENSITIVE_CREATE {
@@ -41,8 +41,8 @@ impl Context {
                 .try_into()
                 .unwrap(),
             sensitive: TPMS_SENSITIVE_CREATE {
-                userAuth: auth_value.cloned().unwrap_or_default().into(),
-                data: initial_data.cloned().unwrap_or_default().into(),
+                userAuth: auth_value.unwrap_or_default().into(),
+                data: initial_data.unwrap_or_default().into(),
             },
         };
         let creation_pcrs = PcrSelectionList::list_from_option(creation_pcrs);
@@ -61,8 +61,8 @@ impl Context {
                 self.optional_session_2(),
                 self.optional_session_3(),
                 &sensitive_create,
-                &public.clone().try_into()?,
-                &outside_info.cloned().unwrap_or_default().into(),
+                &public.try_into()?,
+                &outside_info.unwrap_or_default().into(),
                 &creation_pcrs.into(),
                 &mut esys_prim_key_handle,
                 &mut out_public_ptr,

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -148,12 +148,12 @@ impl Context {
     ///     .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0, PcrSlot::Slot1])
     ///     .build();
     ///
-    /// let (update_counter, read_pcr_list, digest_list) = context.pcr_read(&pcr_selection_list)
+    /// let (update_counter, read_pcr_list, digest_list) = context.pcr_read(pcr_selection_list)
     ///     .expect("Call to pcr_read failed");
     /// ```
     pub fn pcr_read(
         &mut self,
-        pcr_selection_list: &PcrSelectionList,
+        pcr_selection_list: PcrSelectionList,
     ) -> Result<(u32, PcrSelectionList, DigestList)> {
         let mut pcr_update_counter: u32 = 0;
         let mut tss_pcr_selection_list_out_ptr = null_mut();
@@ -164,7 +164,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &pcr_selection_list.clone().into(),
+                &pcr_selection_list.into(),
                 &mut pcr_update_counter,
                 &mut tss_pcr_selection_list_out_ptr,
                 &mut tss_digest_list_out_ptr,

--- a/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
+++ b/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
@@ -28,8 +28,8 @@ impl Context {
     pub fn nv_define_space(
         &mut self,
         nv_auth: Provision,
-        auth: Option<&Auth>,
-        public_info: &NvPublic,
+        auth: Option<Auth>,
+        public_info: NvPublic,
     ) -> Result<NvIndexHandle> {
         let mut object_identifier: ESYS_TR = ESYS_TR_NONE;
         let ret = unsafe {
@@ -39,8 +39,8 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &auth.cloned().unwrap_or_default().into(),
-                &public_info.clone().try_into()?,
+                &auth.unwrap_or_default().into(),
+                &public_info.try_into()?,
                 &mut object_identifier,
             )
         };
@@ -135,7 +135,7 @@ impl Context {
         &mut self,
         auth_handle: NvAuth,
         nv_index_handle: NvIndexHandle,
-        data: &MaxNvBuffer,
+        data: MaxNvBuffer,
         offset: u16,
     ) -> Result<()> {
         let ret = unsafe {
@@ -146,7 +146,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &data.clone().into(),
+                &data.into(),
                 offset,
             )
         };

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -40,10 +40,10 @@ impl Context {
     pub fn create(
         &mut self,
         parent_handle: KeyHandle,
-        public: &Public,
-        auth_value: Option<&Auth>,
-        sensitive_data: Option<&SensitiveData>,
-        outside_info: Option<&Data>,
+        public: Public,
+        auth_value: Option<Auth>,
+        sensitive_data: Option<SensitiveData>,
+        outside_info: Option<Data>,
         creation_pcrs: Option<PcrSelectionList>,
     ) -> Result<CreateKeyResult> {
         let sensitive_create = TPM2B_SENSITIVE_CREATE {
@@ -51,8 +51,8 @@ impl Context {
                 .try_into()
                 .unwrap(), // will not fail on targets of at least 16 bits
             sensitive: TPMS_SENSITIVE_CREATE {
-                userAuth: auth_value.cloned().unwrap_or_default().into(),
-                data: sensitive_data.cloned().unwrap_or_default().into(),
+                userAuth: auth_value.unwrap_or_default().into(),
+                data: sensitive_data.unwrap_or_default().into(),
             },
         };
         let creation_pcrs = PcrSelectionList::list_from_option(creation_pcrs);
@@ -71,8 +71,8 @@ impl Context {
                 self.optional_session_2(),
                 self.optional_session_3(),
                 &sensitive_create,
-                &public.clone().try_into()?,
-                &outside_info.cloned().unwrap_or_default().into(),
+                &public.try_into()?,
+                &outside_info.unwrap_or_default().into(),
                 &creation_pcrs.into(),
                 &mut out_private_ptr,
                 &mut out_public_ptr,
@@ -107,7 +107,7 @@ impl Context {
         &mut self,
         parent_handle: KeyHandle,
         private: Private,
-        public: &Public,
+        public: Public,
     ) -> Result<KeyHandle> {
         let mut esys_key_handle = ESYS_TR_NONE;
         let ret = unsafe {
@@ -118,7 +118,7 @@ impl Context {
                 self.optional_session_2(),
                 self.optional_session_3(),
                 &private.into(),
-                &public.clone().try_into()?,
+                &public.try_into()?,
                 &mut esys_key_handle,
             )
         };
@@ -138,7 +138,7 @@ impl Context {
     pub fn load_external(
         &mut self,
         private: Sensitive,
-        public: &Public,
+        public: Public,
         hierarchy: Hierarchy,
     ) -> Result<KeyHandle> {
         let mut esys_key_handle = ESYS_TR_NONE;
@@ -149,7 +149,7 @@ impl Context {
                 self.optional_session_2(),
                 self.optional_session_3(),
                 &private.try_into()?,
-                &public.clone().try_into()?,
+                &public.try_into()?,
                 if cfg!(tpm2_tss_version = "3") {
                     ObjectHandle::from(hierarchy).into()
                 } else {
@@ -175,7 +175,7 @@ impl Context {
     /// Load the public part of an external key and return its new handle.
     pub fn load_external_public(
         &mut self,
-        public: &Public,
+        public: Public,
         hierarchy: Hierarchy,
     ) -> Result<KeyHandle> {
         let mut esys_key_handle = ESYS_TR_NONE;
@@ -186,7 +186,7 @@ impl Context {
                 self.optional_session_2(),
                 self.optional_session_3(),
                 null(),
-                &public.clone().try_into()?,
+                &public.try_into()?,
                 if cfg!(tpm2_tss_version = "3") {
                     ObjectHandle::from(hierarchy).into()
                 } else {

--- a/tss-esapi/src/context/tpm_commands/session_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/session_commands.rs
@@ -53,13 +53,13 @@ impl Context {
         &mut self,
         tpm_key: Option<KeyHandle>,
         bind: Option<ObjectHandle>,
-        nonce: Option<&Nonce>,
+        nonce: Option<Nonce>,
         session_type: SessionType,
         symmetric: SymmetricDefinition,
         auth_hash: HashingAlgorithm,
     ) -> Result<Option<AuthSession>> {
         let nonce_ptr: *const TPM2B_NONCE = match nonce {
-            Some(val) => &val.clone().into(),
+            Some(val) => &val.into(),
             None => null(),
         };
 

--- a/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
+++ b/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
@@ -16,7 +16,7 @@ impl Context {
     pub fn verify_signature(
         &mut self,
         key_handle: KeyHandle,
-        digest: &Digest,
+        digest: Digest,
         signature: Signature,
     ) -> Result<VerifiedTicket> {
         let mut validation = null_mut();
@@ -28,7 +28,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &digest.clone().into(),
+                &digest.into(),
                 &signature,
                 &mut validation,
             )
@@ -49,7 +49,7 @@ impl Context {
     pub fn sign(
         &mut self,
         key_handle: KeyHandle,
-        digest: &Digest,
+        digest: Digest,
         scheme: SignatureScheme,
         validation: HashcheckTicket,
     ) -> Result<Signature> {
@@ -62,7 +62,7 @@ impl Context {
                 self.required_session_1()?,
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &digest.clone().into(),
+                &digest.into(),
                 &scheme.into(),
                 &validation,
                 &mut signature,

--- a/tss-esapi/src/nv/storage/public.rs
+++ b/tss-esapi/src/nv/storage/public.rs
@@ -120,8 +120,8 @@ impl NvPublicBuilder {
         self
     }
 
-    pub fn with_index_auth_policy(mut self, nv_index_auth_policy: &Digest) -> Self {
-        self.authorization_policy = Some(nv_index_auth_policy.clone());
+    pub fn with_index_auth_policy(mut self, nv_index_auth_policy: Digest) -> Self {
+        self.authorization_policy = Some(nv_index_auth_policy);
         self
     }
 

--- a/tss-esapi/src/structures/pcr/select.rs
+++ b/tss-esapi/src/structures/pcr/select.rs
@@ -30,7 +30,7 @@ impl PcrSelect {
     pub fn new(size_of_select: PcrSelectSize, pcr_slots: &[PcrSlot]) -> Self {
         PcrSelect {
             size_of_select,
-            selected_pcrs: pcr_slots.iter().cloned().collect(),
+            selected_pcrs: pcr_slots.iter().copied().collect(),
         }
     }
 

--- a/tss-esapi/src/structures/tagged/public.rs
+++ b/tss-esapi/src/structures/tagged/public.rs
@@ -88,8 +88,8 @@ impl PublicBuilder {
 
     /// Adds the auth policy for the [Public] strucutre
     /// to the builder
-    pub fn with_auth_policy(mut self, auth_policy: &Digest) -> Self {
-        self.auth_policy = Some(auth_policy.clone());
+    pub fn with_auth_policy(mut self, auth_policy: Digest) -> Self {
+        self.auth_policy = Some(auth_policy);
         self
     }
 
@@ -112,8 +112,8 @@ impl PublicBuilder {
     /// [Rsa][`crate::interface_types::algorithm::PublicAlgorithm::Rsa].
     ///
     /// The unique identifier is the public key.
-    pub fn with_rsa_unique_identifier(mut self, rsa_unique_identifier: &PublicKeyRsa) -> Self {
-        self.rsa_unique_identifier = Some(rsa_unique_identifier.clone());
+    pub fn with_rsa_unique_identifier(mut self, rsa_unique_identifier: PublicKeyRsa) -> Self {
+        self.rsa_unique_identifier = Some(rsa_unique_identifier);
         self
     }
 
@@ -139,9 +139,9 @@ impl PublicBuilder {
     /// [KeyedHash][`crate::interface_types::algorithm::PublicAlgorithm::KeyedHash].
     pub fn with_keyed_hash_unique_identifier(
         mut self,
-        keyed_hash_unique_identifier: &Digest,
+        keyed_hash_unique_identifier: Digest,
     ) -> Self {
-        self.keyed_hash_unique_identifier = Some(keyed_hash_unique_identifier.clone());
+        self.keyed_hash_unique_identifier = Some(keyed_hash_unique_identifier);
         self
     }
 
@@ -164,8 +164,8 @@ impl PublicBuilder {
     /// [Ecc][`crate::interface_types::algorithm::PublicAlgorithm::Ecc].
     ///
     /// The unique identifier is a ecc point.
-    pub fn with_ecc_unique_identifier(mut self, ecc_unique_identifier: &EccPoint) -> Self {
-        self.ecc_unique_identifier = Some(ecc_unique_identifier.clone());
+    pub fn with_ecc_unique_identifier(mut self, ecc_unique_identifier: EccPoint) -> Self {
+        self.ecc_unique_identifier = Some(ecc_unique_identifier);
         self
     }
 
@@ -191,9 +191,9 @@ impl PublicBuilder {
     /// [SymCipher][`crate::interface_types::algorithm::PublicAlgorithm::SymCipher].
     pub fn with_symmetric_cipher_unique_identifier(
         mut self,
-        symmetric_cipher_unique_identifier: &Digest,
+        symmetric_cipher_unique_identifier: Digest,
     ) -> Self {
-        self.symmetric_cipher_unique_identifier = Some(symmetric_cipher_unique_identifier.clone());
+        self.symmetric_cipher_unique_identifier = Some(symmetric_cipher_unique_identifier);
         self
     }
 

--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -128,7 +128,7 @@ pub fn create_restricted_decryption_rsa_public(
             )
             .build()?,
         )
-        .with_rsa_unique_identifier(&PublicKeyRsa::default())
+        .with_rsa_unique_identifier(PublicKeyRsa::default())
         .build()
 }
 
@@ -165,7 +165,7 @@ pub fn create_unrestricted_encryption_decryption_rsa_public(
                 .with_restricted(false)
                 .build()?,
         )
-        .with_rsa_unique_identifier(&PublicKeyRsa::default())
+        .with_rsa_unique_identifier(PublicKeyRsa::default())
         .build()
 }
 
@@ -201,7 +201,7 @@ pub fn create_unrestricted_signing_rsa_public(
             )
             .build()?,
         )
-        .with_rsa_unique_identifier(&PublicKeyRsa::default())
+        .with_rsa_unique_identifier(PublicKeyRsa::default())
         .build()
 }
 
@@ -215,7 +215,7 @@ pub fn create_unrestricted_signing_rsa_public_with_unique(
     scheme: RsaScheme,
     rsa_key_bits: RsaKeyBits,
     rsa_pub_exponent: RsaExponent,
-    rsa_public_key: &PublicKeyRsa,
+    rsa_public_key: PublicKeyRsa,
 ) -> Result<Public> {
     let object_attributes = ObjectAttributesBuilder::new()
         .with_fixed_tpm(true)
@@ -268,7 +268,7 @@ pub fn create_unrestricted_signing_ecc_public(
         .with_ecc_parameters(
             PublicEccParametersBuilder::new_unrestricted_signing_key(scheme, curve).build()?,
         )
-        .with_ecc_unique_identifier(&EccPoint::default())
+        .with_ecc_unique_identifier(EccPoint::default())
         .build()
 }
 

--- a/tss-esapi/tests/integration_tests/abstraction_tests/ak_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/ak_tests.rs
@@ -64,7 +64,7 @@ fn test_create_and_use_ak() {
         ek_rsa,
         HashingAlgorithm::Sha256,
         SignatureSchemeAlgorithm::RsaPss,
-        Some(&ak_auth),
+        Some(ak_auth.clone()),
         None,
     )
     .unwrap();
@@ -72,7 +72,7 @@ fn test_create_and_use_ak() {
     let loaded_ak = ak::load_ak(
         &mut context,
         ek_rsa,
-        Some(&ak_auth),
+        Some(ak_auth),
         att_key.out_private,
         att_key.out_public,
     )
@@ -162,7 +162,7 @@ fn test_create_custom_ak() {
         ek_rsa,
         HashingAlgorithm::Sha256,
         SignatureSchemeAlgorithm::RsaPss,
-        Some(&ak_auth),
+        Some(ak_auth.clone()),
         None,
     )
     .unwrap();
@@ -178,7 +178,7 @@ fn test_create_custom_ak() {
         ek_rsa,
         HashingAlgorithm::Sha256,
         SignatureSchemeAlgorithm::RsaPss,
-        Some(&ak_auth),
+        Some(ak_auth),
         &StClearKeys,
     )
     .unwrap();

--- a/tss-esapi/tests/integration_tests/abstraction_tests/nv_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/nv_tests.rs
@@ -36,7 +36,7 @@ fn write_nv_index(context: &mut Context, nv_index: NvIndexTpmHandle) -> NvIndexH
         .unwrap();
 
     let owner_nv_index_handle = context
-        .nv_define_space(Provision::Owner, None, &owner_nv_public)
+        .nv_define_space(Provision::Owner, None, owner_nv_public)
         .unwrap();
 
     let value = [1, 2, 3, 4, 5, 6, 7];
@@ -44,10 +44,15 @@ fn write_nv_index(context: &mut Context, nv_index: NvIndexTpmHandle) -> NvIndexH
 
     // Write the data using Owner authorization
     context
-        .nv_write(NvAuth::Owner, owner_nv_index_handle, &expected_data, 0)
+        .nv_write(
+            NvAuth::Owner,
+            owner_nv_index_handle,
+            expected_data.clone(),
+            0,
+        )
         .unwrap();
     context
-        .nv_write(NvAuth::Owner, owner_nv_index_handle, &expected_data, 1024)
+        .nv_write(NvAuth::Owner, owner_nv_index_handle, expected_data, 1024)
         .unwrap();
 
     owner_nv_index_handle

--- a/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
@@ -57,7 +57,7 @@ fn test_pcr_read_all() {
 
     let (_count, _read_pcr_selection_1, read_pcrs_1) = context
         .pcr_read(
-            &PcrSelectionListBuilder::new()
+            PcrSelectionListBuilder::new()
                 .with_selection(
                     HashingAlgorithm::Sha256,
                     &[
@@ -77,7 +77,7 @@ fn test_pcr_read_all() {
 
     let (_count, _read_pcr_selection_2, read_pcrs_2) = context
         .pcr_read(
-            &PcrSelectionListBuilder::new()
+            PcrSelectionListBuilder::new()
                 .with_selection(
                     HashingAlgorithm::Sha256,
                     &[
@@ -97,7 +97,7 @@ fn test_pcr_read_all() {
 
     let (_count, _read_pcr_selection_3, read_pcrs_3) = context
         .pcr_read(
-            &PcrSelectionListBuilder::new()
+            PcrSelectionListBuilder::new()
                 .with_selection(
                     HashingAlgorithm::Sha256,
                     &[

--- a/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
@@ -508,13 +508,13 @@ fn ctx_migration_test() {
     let prim_key_handle = basic_ctx
         .create_primary(
             Hierarchy::Owner,
-            &create_restricted_decryption_rsa_public(
+            create_restricted_decryption_rsa_public(
                 SymmetricDefinitionObject::AES_256_CFB,
                 RsaKeyBits::Rsa2048,
                 RsaExponent::create(0).unwrap(),
             )
             .unwrap(),
-            Some(&key_auth),
+            Some(key_auth.clone()),
             None,
             None,
             None,
@@ -525,8 +525,8 @@ fn ctx_migration_test() {
     let result = basic_ctx
         .create(
             prim_key_handle,
-            &crate::common::signing_key_pub(),
-            Some(&key_auth),
+            crate::common::signing_key_pub(),
+            Some(key_auth.clone()),
             None,
             None,
             None,
@@ -537,13 +537,13 @@ fn ctx_migration_test() {
         .load(
             prim_key_handle,
             result.out_private.clone(),
-            &result.out_public,
+            result.out_public.clone(),
         )
         .unwrap();
     let key_context = basic_ctx.context_save(key_handle.into()).unwrap();
 
     let pub_key_handle = basic_ctx
-        .load_external_public(&result.out_public, Hierarchy::Owner)
+        .load_external_public(result.out_public.clone(), Hierarchy::Owner)
         .unwrap();
     let pub_key_context = basic_ctx.context_save(pub_key_handle.into()).unwrap();
 
@@ -654,7 +654,7 @@ fn activate_credential() {
         panic!("Wrong Public type");
     };
     let pub_handle = basic_ctx
-        .load_external_public(&key_pub, Hierarchy::Owner)
+        .load_external_public(key_pub, Hierarchy::Owner)
         .unwrap();
 
     // Credential to expect back as proof for attestation
@@ -773,7 +773,7 @@ fn activate_credential_wrong_key() {
         panic!("Wrong Public type");
     };
     let pub_handle = basic_ctx
-        .load_external_public(&key_pub, Hierarchy::Owner)
+        .load_external_public(key_pub, Hierarchy::Owner)
         .unwrap();
 
     // Credential to expect back as proof for attestation

--- a/tss-esapi/tests/integration_tests/common/mod.rs
+++ b/tss-esapi/tests/integration_tests/common/mod.rs
@@ -266,7 +266,7 @@ pub fn get_pcr_policy_digest(
         .build();
 
     let (_update_counter, pcr_selection_list_out, pcr_data) = context
-        .pcr_read(&pcr_selection_list)
+        .pcr_read(pcr_selection_list.clone())
         .map(|(update_counter, read_pcr_selections, read_pcr_digests)| {
             (
                 update_counter,
@@ -307,7 +307,7 @@ pub fn get_pcr_policy_digest(
 
     let (hashed_data, _ticket) = context
         .hash(
-            &MaxBuffer::try_from(concatenated_pcr_values.to_vec()).unwrap(),
+            MaxBuffer::try_from(concatenated_pcr_values.to_vec()).unwrap(),
             HashingAlgorithm::Sha256,
             Hierarchy::Owner,
         )
@@ -345,7 +345,7 @@ pub fn get_pcr_policy_digest(
             .expect("Failed to convert auth session into policy session");
         // There should be no errors setting pcr policy for trial session.
         context
-            .policy_pcr(trial_policy_session, &hashed_data, pcr_selection_list)
+            .policy_pcr(trial_policy_session, hashed_data, pcr_selection_list)
             .expect("Failed to call policy pcr");
 
         // There is now a policy digest that can be retrieved and used.
@@ -389,7 +389,7 @@ pub fn get_pcr_policy_digest(
             .expect("Failed to convert auth session into policy session");
         // There should be no errors setting pcr policy for trial session.
         context
-            .policy_pcr(policy_session, &hashed_data, pcr_selection_list)
+            .policy_pcr(policy_session, hashed_data, pcr_selection_list)
             .expect("Failed to call policy_pcr");
 
         // There is now a policy digest that can be retrieved and used.
@@ -419,9 +419,9 @@ pub fn create_public_sealed_object() -> Public {
         .with_public_algorithm(PublicAlgorithm::KeyedHash)
         .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
         .with_object_attributes(object_attributes)
-        .with_auth_policy(&Default::default())
+        .with_auth_policy(Default::default())
         .with_keyed_hash_parameters(PublicKeyedHashParameters::new(KeyedHashScheme::Null))
-        .with_keyed_hash_unique_identifier(&Default::default())
+        .with_keyed_hash_unique_identifier(Default::default())
         .build()
         .expect("Failed to create public structure.")
 }

--- a/tss-esapi/tests/integration_tests/context_tests/general_esys_tr_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/general_esys_tr_tests.rs
@@ -84,7 +84,7 @@ mod test_tr_from_tpm_public {
             .unwrap();
 
         let initial_nv_index_handle = context
-            .nv_define_space(Provision::Owner, None, &nv_public)
+            .nv_define_space(Provision::Owner, None, nv_public)
             .unwrap();
         ///////////////////////////////////////////
         // Read the name from the tpm
@@ -167,7 +167,7 @@ mod test_tr_from_tpm_public {
         // Set password authorization when creating the space.
         context.set_sessions((Some(AuthSession::Password), None, None));
         let initial_nv_index_handle = context
-            .nv_define_space(Provision::Owner, Some(&auth), &nv_public)
+            .nv_define_space(Provision::Owner, Some(auth), nv_public)
             .expect("Failed to call nv_define_space");
         ///////////////////////////////////////////////////////////////
         // Read the name from the tpm
@@ -268,7 +268,7 @@ mod test_tr_from_tpm_public {
         // Set password authorization when creating the space.
         context.set_sessions((Some(AuthSession::Password), None, None));
         let initial_nv_index_handle = context
-            .nv_define_space(Provision::Owner, Some(&auth), &nv_public)
+            .nv_define_space(Provision::Owner, Some(auth.clone()), nv_public)
             .unwrap();
         ///////////////////////////////////////////////////////////////
         // Read the name from the tpm
@@ -294,7 +294,7 @@ mod test_tr_from_tpm_public {
             .nv_write(
                 NvAuth::NvIndex(initial_nv_index_handle),
                 initial_nv_index_handle,
-                &expected_data,
+                expected_data.clone(),
                 0,
             )
             .map_err(|e| cleanup(&mut context, e, initial_nv_index_handle, "nv_write"))
@@ -344,7 +344,7 @@ mod test_tr_from_tpm_public {
 
         // Set authorization for the retrieved handle
         context
-            .tr_set_auth(new_nv_index_handle.into(), &auth)
+            .tr_set_auth(new_nv_index_handle.into(), auth)
             .map_err(|e| cleanup(&mut context, e, new_nv_index_handle, "tr_set_auth"))
             .unwrap();
         // read the data

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
@@ -25,8 +25,8 @@ mod test_rsa_encrypt_decrypt {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &encryption_decryption_key_pub(),
-                Some(&key_auth),
+                encryption_decryption_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -88,12 +88,12 @@ mod test_rsa_encrypt_decrypt {
             .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
             .with_object_attributes(object_attributes)
             .with_ecc_parameters(ecc_parms)
-            .with_ecc_unique_identifier(&EccPoint::default())
+            .with_ecc_unique_identifier(EccPoint::default())
             .build()
             .unwrap();
 
         let key_handle = context
-            .create_primary(Hierarchy::Owner, &public, Some(&key_auth), None, None, None)
+            .create_primary(Hierarchy::Owner, public, Some(key_auth), None, None, None)
             .unwrap()
             .key_handle;
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
@@ -30,14 +30,14 @@ mod test_quote {
         let qualifying_data = vec![0xff; 16];
 
         let key_handle = context
-            .create_primary(Hierarchy::Owner, &signing_key_pub(), None, None, None, None)
+            .create_primary(Hierarchy::Owner, signing_key_pub(), None, None, None, None)
             .unwrap()
             .key_handle;
 
         let (attest, _signature) = context
             .quote(
                 key_handle,
-                &Data::try_from(qualifying_data).unwrap(),
+                Data::try_from(qualifying_data).unwrap(),
                 SignatureScheme::Null,
                 pcr_selection_list.clone(),
             )
@@ -70,13 +70,13 @@ mod test_quote {
         let qualifying_data = vec![0xff; 16];
 
         let sign_key_handle = context
-            .create_primary(Hierarchy::Owner, &signing_key_pub(), None, None, None, None)
+            .create_primary(Hierarchy::Owner, signing_key_pub(), None, None, None, None)
             .unwrap()
             .key_handle;
         let obj_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
+                decryption_key_pub(),
                 None,
                 None,
                 None,
@@ -96,7 +96,7 @@ mod test_quote {
                     ctx.certify(
                         obj_key_handle.into(),
                         sign_key_handle,
-                        &Data::try_from(qualifying_data.clone()).unwrap(),
+                        Data::try_from(qualifying_data.clone()).unwrap(),
                         SignatureScheme::Null,
                     )
                 },
@@ -108,12 +108,12 @@ mod test_quote {
         let data = MaxBuffer::try_from(attest.marshall().unwrap())
             .expect("Failed to get data buffer from attestation data");
         let (digest, _) = context
-            .hash(&data, HashingAlgorithm::Sha256, Hierarchy::Null)
+            .hash(data, HashingAlgorithm::Sha256, Hierarchy::Null)
             .expect("Failed to hash data");
 
         let ticket = context
             .execute_with_nullauth_session(|ctx| {
-                ctx.verify_signature(sign_key_handle, &digest, signature)
+                ctx.verify_signature(sign_key_handle, digest, signature)
             })
             .expect("Failed to verify signature");
         assert_eq!(ticket.tag(), StructureTag::Verified);
@@ -136,7 +136,7 @@ mod test_quote {
         let obj_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
+                decryption_key_pub(),
                 None,
                 None,
                 None,
@@ -156,7 +156,7 @@ mod test_quote {
                     ctx.certify(
                         obj_key_handle.into(),
                         KeyHandle::Null,
-                        &Data::try_from(qualifying_data).unwrap(),
+                        Data::try_from(qualifying_data).unwrap(),
                         sign_scheme,
                     )
                 },

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
@@ -14,8 +14,8 @@ mod test_ctx_save {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -34,8 +34,8 @@ mod test_ctx_save {
         let prim_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
-                Some(&key_auth),
+                decryption_key_pub(),
+                Some(key_auth.clone()),
                 None,
                 None,
                 None,
@@ -46,8 +46,8 @@ mod test_ctx_save {
         let result = context
             .create(
                 prim_key_handle,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -55,7 +55,7 @@ mod test_ctx_save {
             .unwrap();
 
         let key_handle = context
-            .load(prim_key_handle, result.out_private, &result.out_public)
+            .load(prim_key_handle, result.out_private, result.out_public)
             .unwrap();
         context.flush_context(prim_key_handle.into()).unwrap();
         let _ = context.context_save(key_handle.into()).unwrap();
@@ -77,8 +77,8 @@ mod test_ctx_load {
         let prim_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
-                Some(Auth::try_from(key_auth.value().to_vec()).unwrap()).as_ref(),
+                decryption_key_pub(),
+                Some(Auth::try_from(key_auth.value().to_vec()).unwrap()),
                 None,
                 None,
                 None,
@@ -89,8 +89,8 @@ mod test_ctx_load {
         let result = context
             .create(
                 prim_key_handle,
-                &signing_key_pub(),
-                Some(Auth::try_from(key_auth.value().to_vec()).unwrap()).as_ref(),
+                signing_key_pub(),
+                Some(Auth::try_from(key_auth.value().to_vec()).unwrap()),
                 None,
                 None,
                 None,
@@ -98,7 +98,7 @@ mod test_ctx_load {
             .unwrap();
 
         let key_handle = context
-            .load(prim_key_handle, result.out_private, &result.out_public)
+            .load(prim_key_handle, result.out_private, result.out_public)
             .unwrap();
         context.flush_context(prim_key_handle.into()).unwrap();
         let key_ctx = context.context_save(key_handle.into()).unwrap();
@@ -121,8 +121,8 @@ mod test_flush_context {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -142,8 +142,8 @@ mod test_flush_context {
         let prim_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
-                Some(&key_auth),
+                decryption_key_pub(),
+                Some(key_auth.clone()),
                 None,
                 None,
                 None,
@@ -154,8 +154,8 @@ mod test_flush_context {
         let result = context
             .create(
                 prim_key_handle,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -163,7 +163,7 @@ mod test_flush_context {
             .unwrap();
 
         let key_handle = context
-            .load(prim_key_handle, result.out_private, &result.out_public)
+            .load(prim_key_handle, result.out_private, result.out_public)
             .unwrap();
         context.flush_context(prim_key_handle.into()).unwrap();
         let _ = context.read_public(key_handle).unwrap();
@@ -243,8 +243,8 @@ mod test_evict_control {
         let primary_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
-                Some(auth_value_primary).as_ref(),
+                decryption_key_pub(),
+                Some(auth_value_primary),
                 None,
                 None,
                 None,

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/duplication_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/duplication_commands_tests.rs
@@ -52,12 +52,19 @@ mod test_duplicate {
                     .build()
                     .expect("Params to be valid"),
             )
-            .with_ecc_unique_identifier(&EccPoint::default())
+            .with_ecc_unique_identifier(EccPoint::default())
             .build()
             .expect("public to be valid");
 
         let new_parent_handle = context
-            .create_primary(Hierarchy::Owner, &public_parent, None, None, None, None)
+            .create_primary(
+                Hierarchy::Owner,
+                public_parent.clone(),
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap()
             .key_handle;
 
@@ -137,7 +144,7 @@ mod test_duplicate {
             .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
             .with_object_attributes(object_attributes)
             // Use policy digest computed using the trial session
-            .with_auth_policy(&digest)
+            .with_auth_policy(digest)
             .with_ecc_parameters(
                 PublicEccParametersBuilder::new()
                     .with_ecc_scheme(EccScheme::Null)
@@ -149,7 +156,7 @@ mod test_duplicate {
                     .build()
                     .expect("Params to be valid"),
             )
-            .with_ecc_unique_identifier(&EccPoint::default())
+            .with_ecc_unique_identifier(EccPoint::default())
             .build()
             .expect("public to be valid");
 
@@ -158,20 +165,27 @@ mod test_duplicate {
         // that was used to get the "parent_name".
         // In real world the new parent will likely be persisted in the TPM.
         let new_parent_handle: ObjectHandle = context
-            .create_primary(Hierarchy::Owner, &public_parent, None, None, None, None)
+            .create_primary(
+                Hierarchy::Owner,
+                public_parent.clone(),
+                None,
+                None,
+                None,
+                None,
+            )
             .unwrap()
             .key_handle
             .into();
 
         let parent_of_object_to_duplicate_handle = context
-            .create_primary(Hierarchy::Owner, &public_parent, None, None, None, None)
+            .create_primary(Hierarchy::Owner, public_parent, None, None, None, None)
             .unwrap()
             .key_handle;
 
         let result = context
             .create(
                 parent_of_object_to_duplicate_handle,
-                &public_child,
+                public_child,
                 None,
                 None,
                 None,
@@ -183,7 +197,7 @@ mod test_duplicate {
             .load(
                 parent_of_object_to_duplicate_handle,
                 result.out_private.clone(),
-                &result.out_public,
+                result.out_public,
             )
             .unwrap()
             .into();

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
@@ -16,8 +16,8 @@ mod test_create_primary {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
-                Some(&key_auth),
+                decryption_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -69,7 +69,7 @@ mod test_change_auth {
         let prim_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
+                decryption_key_pub(),
                 None,
                 None,
                 None,
@@ -80,7 +80,7 @@ mod test_change_auth {
         let keyresult = context
             .create(
                 prim_key_handle,
-                &decryption_key_pub(),
+                decryption_key_pub(),
                 None,
                 None,
                 None,
@@ -91,7 +91,7 @@ mod test_change_auth {
             .load(
                 prim_key_handle,
                 keyresult.out_private,
-                &keyresult.out_public,
+                keyresult.out_public.clone(),
             )
             .unwrap();
 
@@ -102,7 +102,7 @@ mod test_change_auth {
             .object_change_auth(loaded_key.into(), prim_key_handle.into(), new_key_auth)
             .unwrap();
         context
-            .load(prim_key_handle, new_private, &keyresult.out_public)
+            .load(prim_key_handle, new_private, keyresult.out_public)
             .unwrap();
     }
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
@@ -28,7 +28,7 @@ mod test_pcr_extend_reset {
             .build();
         // pcr_read is NO_SESSIONS
         let (_, read_pcr_selections, read_pcr_digests) = context.execute_without_session(|ctx| {
-            ctx.pcr_read(&pcr_selection_list)
+            ctx.pcr_read(pcr_selection_list.clone())
                 .expect("Failed to call pcr_read")
         });
 
@@ -73,7 +73,7 @@ mod test_pcr_extend_reset {
 
         // Read PCR contents
         let (_, read_pcr_selections_2, read_pcr_digests_2) =
-            context.execute_without_session(|ctx| ctx.pcr_read(&pcr_selection_list).unwrap());
+            context.execute_without_session(|ctx| ctx.pcr_read(pcr_selection_list).unwrap());
         // Needs to have the length of associated with the hashing algorithm
         /*
           Right Hand Side determined by:
@@ -126,7 +126,7 @@ mod test_pcr_extend_reset {
             .build();
         let pcr_data = context
             .execute_without_session(|ctx| {
-                ctx.pcr_read(&pcr_selection_list).map(
+                ctx.pcr_read(pcr_selection_list).map(
                     |(_, read_pcr_selections, read_pcr_digests)| {
                         PcrData::create(&read_pcr_selections, &read_pcr_digests)
                             .expect("Failed to create PcrData")
@@ -170,7 +170,7 @@ mod test_pcr_read {
         assert_eq!(input.pcrSelections[0].pcrSelect[2], 0b0000_0000);
         // Read the pcr slots.
         let (update_counter, read_pcr_selections, read_pcr_digests) = context
-            .pcr_read(&pcr_selection_list)
+            .pcr_read(pcr_selection_list)
             .expect("Failed to call pcr_read");
 
         // Verify that the selected slots have been read.
@@ -236,7 +236,7 @@ mod test_pcr_read {
             )
             .build();
         let (_update_counter, pcr_selection_list_out, _pcr_data) =
-            context.pcr_read(&pcr_selection_list_in).unwrap();
+            context.pcr_read(pcr_selection_list_in.clone()).unwrap();
         assert_ne!(pcr_selection_list_in, pcr_selection_list_out);
     }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/non_volatile_storage_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/non_volatile_storage_tests.rs
@@ -48,11 +48,11 @@ mod test_nv_define_space {
 
         // Fails because attributes dont match hierarchy auth.
         let _ = context
-            .nv_define_space(Provision::Platform, None, &owner_nv_public)
+            .nv_define_space(Provision::Platform, None, owner_nv_public)
             .unwrap_err();
 
         let _ = context
-            .nv_define_space(Provision::Owner, None, &platform_nv_public)
+            .nv_define_space(Provision::Owner, None, platform_nv_public)
             .unwrap_err();
     }
 
@@ -94,7 +94,7 @@ mod test_nv_define_space {
             .expect("Failed to build NvPublic for platform");
 
         let owner_nv_index_handle = context
-            .nv_define_space(Provision::Owner, None, &owner_nv_public)
+            .nv_define_space(Provision::Owner, None, owner_nv_public)
             .expect("Call to nv_define_space failed");
 
         let _ = context
@@ -105,7 +105,7 @@ mod test_nv_define_space {
         // On many TPMs, you will get error 0x00000185, indicating the Platform hierarchy to
         // be unavailable (because the system went to operating system)
         let platform_nv_index_handle = context
-            .nv_define_space(Provision::Platform, None, &platform_nv_public)
+            .nv_define_space(Provision::Platform, None, platform_nv_public)
             .expect("Call to nv_define_space failed");
 
         let _ = context
@@ -145,7 +145,7 @@ mod test_nv_undefine_space {
             .expect("Failed to build NvPublic for owner");
 
         let owner_nv_index_handle = context
-            .nv_define_space(Provision::Owner, None, &owner_nv_public)
+            .nv_define_space(Provision::Owner, None, owner_nv_public)
             .expect("Call to nv_define_space failed");
 
         // Succeeds
@@ -185,7 +185,7 @@ mod test_nv_read_public {
             .expect("Failed to build the expected NvPublic");
 
         let nv_index_handle = context
-            .nv_define_space(Provision::Owner, None, &expected_nv_public)
+            .nv_define_space(Provision::Owner, None, expected_nv_public.clone())
             .expect("Call to nv_define_space failed");
 
         let read_public_result = context.nv_read_public(nv_index_handle);
@@ -240,14 +240,14 @@ mod test_nv_write {
             .expect("Failed to build NvPublic for owner");
 
         let owner_nv_index_handle = context
-            .nv_define_space(Provision::Owner, None, &owner_nv_public)
+            .nv_define_space(Provision::Owner, None, owner_nv_public)
             .expect("Call to nv_define_space failed");
 
         // Use owner authorization
         let write_result = context.nv_write(
             NvAuth::Owner,
             owner_nv_index_handle,
-            &MaxNvBuffer::try_from([1, 2, 3, 4, 5, 6, 7].to_vec()).unwrap(),
+            MaxNvBuffer::try_from([1, 2, 3, 4, 5, 6, 7].to_vec()).unwrap(),
             0,
         );
 
@@ -296,7 +296,7 @@ mod test_nv_read {
             .expect("Failed to build NvPublic for owner");
 
         let owner_nv_index_handle = context
-            .nv_define_space(Provision::Owner, None, &owner_nv_public)
+            .nv_define_space(Provision::Owner, None, owner_nv_public)
             .expect("Call to nv_define_space failed");
 
         let value = [1, 2, 3, 4, 5, 6, 7];
@@ -304,8 +304,12 @@ mod test_nv_read {
             MaxNvBuffer::try_from(value.to_vec()).expect("Failed to create MaxBuffer from data");
 
         // Write the data using Owner authorization
-        let write_result =
-            context.nv_write(NvAuth::Owner, owner_nv_index_handle, &expected_data, 0);
+        let write_result = context.nv_write(
+            NvAuth::Owner,
+            owner_nv_index_handle,
+            expected_data.clone(),
+            0,
+        );
         // read data using owner authorization
         let read_result =
             context.nv_read(NvAuth::Owner, owner_nv_index_handle, value.len() as u16, 0);

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/object_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/object_commands_tests.rs
@@ -14,8 +14,8 @@ mod test_create {
         let prim_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
-                Some(&key_auth),
+                decryption_key_pub(),
+                Some(key_auth.clone()),
                 None,
                 None,
                 None,
@@ -26,8 +26,8 @@ mod test_create {
         let _ = context
             .create(
                 prim_key_handle,
-                &decryption_key_pub(),
-                Some(&key_auth),
+                decryption_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -50,8 +50,8 @@ mod test_load {
         let prim_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
-                Some(&key_auth),
+                decryption_key_pub(),
+                Some(key_auth.clone()),
                 None,
                 None,
                 None,
@@ -62,8 +62,8 @@ mod test_load {
         let result = context
             .create(
                 prim_key_handle,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -71,7 +71,7 @@ mod test_load {
             .unwrap();
 
         let _ = context
-            .load(prim_key_handle, result.out_private, &result.out_public)
+            .load(prim_key_handle, result.out_private, result.out_public)
             .unwrap();
     }
 }
@@ -113,7 +113,7 @@ mod test_load_external_public {
                 .expect("Failed to create rsa parameters for public structure"),
             )
             .with_rsa_unique_identifier(
-                &PublicKeyRsa::try_from(&KEY[..256])
+                PublicKeyRsa::try_from(&KEY[..256])
                     .expect("Failed to create Public RSA key from buffer"),
             )
             .build()
@@ -126,7 +126,7 @@ mod test_load_external_public {
         let pub_key = get_ext_rsa_pub();
 
         context
-            .load_external_public(&pub_key, Hierarchy::Owner)
+            .load_external_public(pub_key, Hierarchy::Owner)
             .unwrap();
     }
 }
@@ -211,7 +211,7 @@ mod test_load_external {
                 .expect("Failed to create rsa parameters for public structure"),
             )
             .with_rsa_unique_identifier(
-                &PublicKeyRsa::try_from(&KEY[..])
+                PublicKeyRsa::try_from(&KEY[..])
                     .expect("Failed to create Public RSA key from buffer"),
             )
             .build()
@@ -225,7 +225,7 @@ mod test_load_external {
         let priv_key = get_ext_rsa_priv();
 
         let key_handle = context
-            .load_external(priv_key, &pub_key, Hierarchy::Null)
+            .load_external(priv_key, pub_key, Hierarchy::Null)
             .unwrap();
         context.flush_context(key_handle.into()).unwrap();
     }
@@ -245,8 +245,8 @@ mod test_read_public {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -269,7 +269,7 @@ mod test_make_credential {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
+                decryption_key_pub(),
                 None,
                 None,
                 None,
@@ -341,7 +341,7 @@ mod test_activate_credential {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
+                decryption_key_pub(),
                 None,
                 None,
                 None,
@@ -389,7 +389,7 @@ mod test_unseal {
         let key_handle_seal = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
+                decryption_key_pub(),
                 None,
                 None,
                 None,
@@ -400,7 +400,7 @@ mod test_unseal {
         let key_handle_unseal = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
+                decryption_key_pub(),
                 None,
                 None,
                 None,
@@ -413,15 +413,15 @@ mod test_unseal {
         let result = context
             .create(
                 key_handle_seal,
-                &key_pub,
+                key_pub,
                 None,
-                Some(SensitiveData::try_from(testbytes.to_vec()).unwrap()).as_ref(),
+                Some(SensitiveData::try_from(testbytes.to_vec()).unwrap()),
                 None,
                 None,
             )
             .unwrap();
         let loaded_key = context
-            .load(key_handle_unseal, result.out_private, &result.out_public)
+            .load(key_handle_unseal, result.out_private, result.out_public)
             .unwrap();
         let unsealed = context.unseal(loaded_key.into()).unwrap();
         let unsealed = unsealed.value();

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/session_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/session_commands_tests.rs
@@ -40,8 +40,7 @@ mod test_start_auth_session {
                         .to_vec(),
                     )
                     .unwrap(),
-                )
-                .as_ref(),
+                ),
                 SessionType::Hmac,
                 SymmetricDefinition::AES_256_CFB,
                 HashingAlgorithm::Sha256,
@@ -55,7 +54,7 @@ mod test_start_auth_session {
         let prim_key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &decryption_key_pub(),
+                decryption_key_pub(),
                 None,
                 None,
                 None,

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
@@ -19,8 +19,8 @@ mod test_verify_signature {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -36,7 +36,7 @@ mod test_verify_signature {
         let signature = context
             .sign(
                 key_handle,
-                &Digest::try_from(HASH[..32].to_vec()).unwrap(),
+                Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )
@@ -45,7 +45,7 @@ mod test_verify_signature {
         context
             .verify_signature(
                 key_handle,
-                &Digest::try_from(HASH[..32].to_vec()).unwrap(),
+                Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 signature,
             )
             .unwrap();
@@ -60,8 +60,8 @@ mod test_verify_signature {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -77,7 +77,7 @@ mod test_verify_signature {
         let mut signature = context
             .sign(
                 key_handle,
-                &Digest::try_from(HASH[..32].to_vec()).unwrap(),
+                Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )
@@ -96,7 +96,7 @@ mod test_verify_signature {
         assert!(context
             .verify_signature(
                 key_handle,
-                &Digest::try_from(HASH[..32].to_vec()).unwrap(),
+                Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 signature,
             )
             .is_err());
@@ -111,8 +111,8 @@ mod test_verify_signature {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -132,7 +132,7 @@ mod test_verify_signature {
         assert!(context
             .verify_signature(
                 key_handle,
-                &Digest::try_from(HASH[..32].to_vec()).unwrap(),
+                Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 signature,
             )
             .is_err());
@@ -147,8 +147,8 @@ mod test_verify_signature {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -167,7 +167,7 @@ mod test_verify_signature {
         assert!(context
             .verify_signature(
                 key_handle,
-                &Digest::try_from(HASH[..32].to_vec()).unwrap(),
+                Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 signature,
             )
             .is_err());
@@ -193,8 +193,8 @@ mod test_sign {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -210,7 +210,7 @@ mod test_sign {
         context
             .sign(
                 key_handle,
-                &Digest::try_from(HASH[..32].to_vec()).unwrap(),
+                Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )
@@ -226,8 +226,8 @@ mod test_sign {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -243,7 +243,7 @@ mod test_sign {
         context
             .sign(
                 key_handle,
-                &Digest::try_from(Vec::<u8>::new()).unwrap(),
+                Digest::try_from(Vec::<u8>::new()).unwrap(),
                 SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )
@@ -259,8 +259,8 @@ mod test_sign {
         let key_handle = context
             .create_primary(
                 Hierarchy::Owner,
-                &signing_key_pub(),
-                Some(&key_auth),
+                signing_key_pub(),
+                Some(key_auth),
                 None,
                 None,
                 None,
@@ -276,7 +276,7 @@ mod test_sign {
         context
             .sign(
                 key_handle,
-                &Digest::try_from([0xbb; 40].to_vec()).unwrap(),
+                Digest::try_from([0xbb; 40].to_vec()).unwrap(),
                 SignatureScheme::Null,
                 validation.try_into().unwrap(),
             )


### PR DESCRIPTION
Updating functions and methods in the API (particularly for `Context`
methods) where we take a reference and then clone the object, instead of
taking ownership directly, letting the user clone whenever needed.

This includes updates to the tests and documentation.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>