### PR TITLE
Replace type in CapabilityData::EccCurves

### DIFF
--- a/tss-esapi/src/constants/ecc.rs
+++ b/tss-esapi/src/constants/ecc.rs
@@ -14,6 +14,9 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use std::convert::TryFrom;
 /// Enum that contains the constants for the
 /// implemented elliptic curves.
+///
+/// # Details
+/// This corresponds to `TPM2_ECC_CURVE`
 #[derive(FromPrimitive, ToPrimitive, Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u16)]
 pub enum EccCurveIdentifier {

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -28,7 +28,6 @@
     unused_results,
     missing_copy_implementations
 )]
-#![allow(clippy::upper_case_acronyms)]
 //! # TSS 2.0 Rust Wrapper over Enhanced System API
 //! This crate exposes the functionality of the TCG Software Stack Enhanced System API to
 //! Rust developers, both directly through FFI bindings and through more Rust-tailored interfaces

--- a/tss-esapi/src/structures/lists/ecc_curves.rs
+++ b/tss-esapi/src/structures/lists/ecc_curves.rs
@@ -1,0 +1,106 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::constants::ecc::EccCurveIdentifier;
+use crate::tss2_esys::{TPM2_ECC_CURVE, TPML_ECC_CURVE};
+use crate::{Error, Result, WrapperErrorKind};
+use log::error;
+use std::convert::TryFrom;
+use std::ops::Deref;
+
+/// A list of ECC curves
+///
+/// # Details
+/// This corresponds to `TPML_ECC_CURVE`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct EccCurveList {
+    ecc_curves: Vec<EccCurveIdentifier>,
+}
+
+impl EccCurveList {
+    pub const MAX_SIZE: usize =
+        crate::structures::capabilitydata::max_cap_size::<TPM2_ECC_CURVE>() as usize;
+
+    pub fn new() -> Self {
+        EccCurveList {
+            ecc_curves: Vec::new(),
+        }
+    }
+
+    /// Adds an ECC curve to the list of curves.
+    pub fn add(&mut self, ecc_curve: EccCurveIdentifier) -> Result<()> {
+        if self.ecc_curves.len() + 1 > EccCurveList::MAX_SIZE {
+            error!(
+                "Adding ECC curve to list will make the list exceeded its maximum count(> {})",
+                EccCurveList::MAX_SIZE
+            );
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        self.ecc_curves.push(ecc_curve);
+        Ok(())
+    }
+
+    /// Returns the inner type.
+    pub fn into_inner(self) -> Vec<EccCurveIdentifier> {
+        self.ecc_curves
+    }
+}
+
+impl TryFrom<TPML_ECC_CURVE> for EccCurveList {
+    type Error = Error;
+
+    fn try_from(ecc_curves: TPML_ECC_CURVE) -> Result<Self> {
+        let ecc_curve_count = ecc_curves.count as usize;
+        if ecc_curve_count > Self::MAX_SIZE {
+            error!("Error: Invalid TPML_ECC_CURVE count(> {})", Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        ecc_curves.eccCurves[..ecc_curve_count]
+            .iter()
+            .map(|&cc| EccCurveIdentifier::try_from(cc))
+            .collect::<Result<Vec<EccCurveIdentifier>>>()
+            .map(|ecc_curves| EccCurveList { ecc_curves })
+    }
+}
+
+impl From<EccCurveList> for TPML_ECC_CURVE {
+    fn from(ecc_curves: EccCurveList) -> Self {
+        let mut tss_ecc_curves: TPML_ECC_CURVE = Default::default();
+        for ecc_curve in ecc_curves.ecc_curves {
+            tss_ecc_curves.eccCurves[tss_ecc_curves.count as usize] = ecc_curve.into();
+            tss_ecc_curves.count += 1;
+        }
+        tss_ecc_curves
+    }
+}
+
+impl TryFrom<Vec<EccCurveIdentifier>> for EccCurveList {
+    type Error = Error;
+
+    fn try_from(ecc_curves: Vec<EccCurveIdentifier>) -> Result<Self> {
+        if ecc_curves.len() > Self::MAX_SIZE {
+            error!("Error: Invalid TPML_ECC_CURVE count(> {})", Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(EccCurveList { ecc_curves })
+    }
+}
+
+impl From<EccCurveList> for Vec<EccCurveIdentifier> {
+    fn from(ecc_curve_list: EccCurveList) -> Self {
+        ecc_curve_list.ecc_curves
+    }
+}
+
+impl AsRef<[EccCurveIdentifier]> for EccCurveList {
+    fn as_ref(&self) -> &[EccCurveIdentifier] {
+        self.ecc_curves.as_slice()
+    }
+}
+
+impl Deref for EccCurveList {
+    type Target = Vec<EccCurveIdentifier>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ecc_curves
+    }
+}

--- a/tss-esapi/src/structures/lists/handles.rs
+++ b/tss-esapi/src/structures/lists/handles.rs
@@ -1,0 +1,106 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::handles::TpmHandle;
+use crate::tss2_esys::{TPM2_HANDLE, TPML_HANDLE};
+use crate::{Error, Result, WrapperErrorKind};
+use log::error;
+use std::convert::TryFrom;
+use std::ops::Deref;
+
+/// A list of TPM handles
+///
+/// # Details
+/// This corresponds to `TPML_HANDLE`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct HandleList {
+    handles: Vec<TpmHandle>,
+}
+
+impl HandleList {
+    pub const MAX_SIZE: usize =
+        crate::structures::capabilitydata::max_cap_size::<TPM2_HANDLE>() as usize;
+
+    pub fn new() -> Self {
+        HandleList {
+            handles: Vec::new(),
+        }
+    }
+
+    /// Adds a handle to the current list of handles.
+    pub fn add(&mut self, handle: TpmHandle) -> Result<()> {
+        if self.handles.len() + 1 > HandleList::MAX_SIZE {
+            error!(
+                "Adding TPM handle to list will make the list exceeded its maximum count(> {})",
+                HandleList::MAX_SIZE
+            );
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        self.handles.push(handle);
+        Ok(())
+    }
+
+    /// Returns the inner type.
+    pub fn into_inner(self) -> Vec<TpmHandle> {
+        self.handles
+    }
+}
+
+impl TryFrom<TPML_HANDLE> for HandleList {
+    type Error = Error;
+
+    fn try_from(handles: TPML_HANDLE) -> Result<Self> {
+        let handle_count = handles.count as usize;
+        if handle_count > Self::MAX_SIZE {
+            error!("Error: Invalid TPML_HANDLE count(> {})", Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        handles.handle[..handle_count]
+            .iter()
+            .map(|&cc| TpmHandle::try_from(cc))
+            .collect::<Result<Vec<TpmHandle>>>()
+            .map(|handles| HandleList { handles })
+    }
+}
+
+impl From<HandleList> for TPML_HANDLE {
+    fn from(handles: HandleList) -> Self {
+        let mut tss_handles: TPML_HANDLE = Default::default();
+        for handle in handles.handles {
+            tss_handles.handle[tss_handles.count as usize] = handle.into();
+            tss_handles.count += 1;
+        }
+        tss_handles
+    }
+}
+
+impl TryFrom<Vec<TpmHandle>> for HandleList {
+    type Error = Error;
+
+    fn try_from(handles: Vec<TpmHandle>) -> Result<Self> {
+        if handles.len() > Self::MAX_SIZE {
+            error!("Error: Invalid TPML_HANDLE count(> {})", Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(HandleList { handles })
+    }
+}
+
+impl From<HandleList> for Vec<TpmHandle> {
+    fn from(handle_list: HandleList) -> Self {
+        handle_list.handles
+    }
+}
+
+impl AsRef<[TpmHandle]> for HandleList {
+    fn as_ref(&self) -> &[TpmHandle] {
+        self.handles.as_slice()
+    }
+}
+
+impl Deref for HandleList {
+    type Target = Vec<TpmHandle>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.handles
+    }
+}

--- a/tss-esapi/src/structures/lists/mod.rs
+++ b/tss-esapi/src/structures/lists/mod.rs
@@ -5,6 +5,7 @@ pub mod command_code;
 pub mod digest;
 pub mod digest_values;
 pub mod ecc_curves;
+pub mod handles;
 pub mod pcr_selection;
 pub mod tagged_pcr_property;
 pub mod tagged_tpm_property;

--- a/tss-esapi/src/structures/lists/mod.rs
+++ b/tss-esapi/src/structures/lists/mod.rs
@@ -4,6 +4,7 @@ pub mod algorithm_property;
 pub mod command_code;
 pub mod digest;
 pub mod digest_values;
+pub mod ecc_curves;
 pub mod pcr_selection;
 pub mod tagged_pcr_property;
 pub mod tagged_tpm_property;

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -95,6 +95,11 @@ pub mod ecc_curves {
     pub use super::lists::ecc_curves::*;
 }
 
+pub use self::handle_list::HandleList;
+pub mod handle_list {
+    pub use super::lists::handles::*;
+}
+
 pub use self::pcr_selection_list::PcrSelectionList;
 pub use self::pcr_selection_list::PcrSelectionListBuilder;
 pub mod pcr_selection_list {

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -90,6 +90,11 @@ pub mod digest_values {
     pub use super::lists::digest_values::*;
 }
 
+pub use self::ecc_curves::EccCurveList;
+pub mod ecc_curves {
+    pub use super::lists::ecc_curves::*;
+}
+
 pub use self::pcr_selection_list::PcrSelectionList;
 pub use self::pcr_selection_list::PcrSelectionListBuilder;
 pub mod pcr_selection_list {

--- a/tss-esapi/tests/integration_tests/structures_tests/capability_data_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/capability_data_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use tss_esapi::constants::CapabilityType;
+use tss_esapi::structures::CapabilityData;
 
 use crate::common::create_ctx_without_session;
 
@@ -9,101 +10,165 @@ use crate::common::create_ctx_without_session;
 fn test_algorithms() {
     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
+    let (capabs, _more) = context
         .get_capability(CapabilityType::Algorithms, 0, 80)
         .unwrap();
+
+    if let CapabilityData::Algorithms(list) = capabs {
+        assert!(!list.is_empty());
+    } else {
+        panic!("Got wrong type of capability data: {:?}", capabs);
+    }
 }
 
 #[test]
 fn test_handles() {
     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
+    let (capabs, _more) = context
         .get_capability(CapabilityType::Handles, 0, 80)
         .unwrap();
+
+    if let CapabilityData::Handles(vec) = capabs {
+        assert!(!vec.is_empty());
+    } else {
+        panic!("Got wrong type of capability data: {:?}", capabs);
+    }
 }
 
 #[test]
 fn test_command() {
     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
+    let (capabs, _more) = context
         .get_capability(CapabilityType::Command, 0, 80)
         .unwrap();
+
+    if let CapabilityData::Commands(vec) = capabs {
+        assert!(!vec.is_empty());
+    } else {
+        panic!("Got wrong type of capability data: {:?}", capabs);
+    }
 }
 
 #[test]
 fn test_pp_commands() {
     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
+    let (capabs, _more) = context
         .get_capability(CapabilityType::PpCommands, 0, 80)
         .unwrap();
+
+    if let CapabilityData::PpCommands(list) = capabs {
+        assert!(!list.is_empty());
+    } else {
+        panic!("Got wrong type of capability data: {:?}", capabs);
+    }
 }
 
 #[test]
 fn test_audit_commands() {
     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
+    let (capabs, _more) = context
         .get_capability(CapabilityType::AuditCommands, 0, 80)
         .unwrap();
+
+    if let CapabilityData::AuditCommands(list) = capabs {
+        assert!(!list.is_empty());
+    } else {
+        panic!("Got wrong type of capability data: {:?}", capabs);
+    }
 }
 
 #[test]
 fn test_assigned_pcr() {
     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
+    let (capabs, _more) = context
         .get_capability(CapabilityType::AssignedPcr, 0, 80)
         .unwrap();
+
+    if let CapabilityData::AssignedPcr(list) = capabs {
+        assert!(!list.is_empty());
+    } else {
+        panic!("Got wrong type of capability data: {:?}", capabs);
+    }
 }
 
 #[test]
 fn test_tpm_properties() {
     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
+    let (capabs, _more) = context
         .get_capability(CapabilityType::TpmProperties, 0, 80)
         .unwrap();
+
+    if let CapabilityData::TpmProperties(list) = capabs {
+        assert!(!list.is_empty());
+    } else {
+        panic!("Got wrong type of capability data: {:?}", capabs);
+    }
 }
 
 #[test]
 fn test_pcr_properties() {
     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
+    let (capabs, _more) = context
         .get_capability(CapabilityType::PcrProperties, 0, 80)
         .unwrap();
+
+    if let CapabilityData::PcrProperties(list) = capabs {
+        assert!(!list.is_empty());
+    } else {
+        panic!("Got wrong type of capability data: {:?}", capabs);
+    }
 }
 
 #[test]
 fn test_ecc_curves() {
     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
+    let (capabs, _more) = context
         .get_capability(CapabilityType::EccCurves, 0, 80)
         .unwrap();
+
+    if let CapabilityData::EccCurves(vec) = capabs {
+        assert!(!vec.is_empty());
+    } else {
+        panic!("Got wrong type of capability data: {:?}", capabs);
+    }
 }
 
 // For these tests to work the tpm2-tss library need to have the
 // authPolicies field in the TPMU_CAPABILITIES union.
-#[ignore]
-#[test]
-fn test_auth_policies() {
-    let mut context = create_ctx_without_session();
+// #[test]
+// fn test_auth_policies() {
+//     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context
-        .get_capability(CapabilityType::AuthPolicies, 0, 80)
-        .unwrap();
-}
+//     let (capabs, _more) = context
+//         .get_capability(CapabilityType::AuthPolicies, 0, 80)
+//         .unwrap();
+
+//     if let CapabilityData::AuthPolicies(list) = capabs {
+//         assert!(!list.is_empty());
+//     } else {
+//         panic!("Got wrong type of capability data: {:?}", capabs);
+//     }
+// }
 
 // For these tests to work the tpm2-tss library need to have the
 // actData field in the TPMU_CAPABILITIES union.
-#[ignore]
-#[test]
-fn test_act() {
-    let mut context = create_ctx_without_session();
+// #[test]
+// fn test_act() {
+//     let mut context = create_ctx_without_session();
 
-    let (_capabs, _more) = context.get_capability(CapabilityType::Act, 0, 80).unwrap();
-}
+//     let (capabs, _more) = context.get_capability(CapabilityType::Act, 0, 80).unwrap();
+
+//     if let CapabilityData::ActData(list) = capabs {
+//         assert!(!list.is_empty());
+//     } else {
+//         panic!("Got wrong type of capability data: {:?}", capabs);
+//     }
+// }

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/ecc_curve_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/ecc_curve_list_tests.rs
@@ -1,0 +1,140 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use std::convert::TryFrom;
+use tss_esapi::{
+    constants::ecc::EccCurveIdentifier,
+    structures::EccCurveList,
+    tss2_esys::{TPM2_ECC_CURVE, TPML_ECC_CURVE},
+    Error, WrapperErrorKind,
+};
+
+#[test]
+fn test_conversions() {
+    let expected_ecc_curves: Vec<EccCurveIdentifier> = vec![];
+    let mut ecc_curve_list = EccCurveList::new();
+    for curve in expected_ecc_curves.iter() {
+        ecc_curve_list
+            .add(*curve)
+            .expect("Failed to add curve to list");
+    }
+
+    assert_eq!(expected_ecc_curves.len(), ecc_curve_list.len());
+
+    expected_ecc_curves
+        .iter()
+        .zip(ecc_curve_list.as_ref().iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                expected, actual,
+                "The created ECC curve list did not contain the expected values"
+            );
+        });
+
+    let tpml_ecc_curve =
+        TPML_ECC_CURVE::try_from(ecc_curve_list).expect("failed to convert to TPML_ECC_CURVE");
+    assert_eq!(
+        expected_ecc_curves.len(),
+        tpml_ecc_curve.count as usize,
+        "The number of ecc_curves in the TPML_ECC_CURVE is different than expected"
+    );
+
+    expected_ecc_curves
+        .iter()
+        .zip(tpml_ecc_curve.eccCurves[..expected_ecc_curves.len()].iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                TPM2_ECC_CURVE::from(*expected),
+                *actual,
+                "Got mismatch between expected FFI ECC curve and actual ECC curve"
+            )
+        });
+
+    let ecc_curve_list =
+        EccCurveList::try_from(tpml_ecc_curve).expect("Failed to convert from TPML_ECC_CURVE");
+
+    assert_eq!(
+        expected_ecc_curves.len(),
+        ecc_curve_list.len(),
+        "Converted ECC curve list has a different length"
+    );
+
+    expected_ecc_curves
+        .iter()
+        .zip(ecc_curve_list.as_ref().iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                expected, actual,
+                "The converted ECC curve list did not contain the expected values"
+            );
+        });
+}
+
+#[test]
+fn test_vector_conversion() {
+    let expected_ecc_curves: Vec<EccCurveIdentifier> = vec![
+        EccCurveIdentifier::NistP256,
+        EccCurveIdentifier::NistP192,
+        EccCurveIdentifier::NistP384,
+    ];
+
+    let ecc_curve_list =
+        EccCurveList::try_from(expected_ecc_curves.clone()).expect("Failed to convert from vector");
+
+    expected_ecc_curves
+        .iter()
+        .zip(ecc_curve_list.as_ref().iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                expected, actual,
+                "The converted curve list did not contain the expected values"
+            );
+        });
+
+    let converted_ecc_curves = Vec::<EccCurveIdentifier>::from(ecc_curve_list);
+
+    assert_eq!(
+        expected_ecc_curves, converted_ecc_curves,
+        "Converted vector did not match initial vector"
+    );
+}
+
+#[test]
+fn test_add_too_many() {
+    let mut ecc_curve_list = EccCurveList::new();
+    for _ in 0..EccCurveList::MAX_SIZE {
+        ecc_curve_list
+            .add(EccCurveIdentifier::NistP256)
+            .expect("Failed to add the maximum amount of ECC curves");
+    }
+
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::WrongParamSize)),
+        ecc_curve_list.add(EccCurveIdentifier::NistP256),
+        "Added more ECC curves than should've been possible"
+    );
+}
+
+#[test]
+fn test_invalid_size_tpml() {
+    let tpml = TPML_ECC_CURVE {
+        count: (EccCurveList::MAX_SIZE + 1) as u32,
+        eccCurves: [0; 508],
+    };
+
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+        EccCurveList::try_from(tpml),
+        "Converting from TPML_ECC_CURVE did not produce the expected failure"
+    );
+}
+
+#[test]
+fn test_invalid_size_vec() {
+    let vec = vec![EccCurveIdentifier::NistP256; EccCurveList::MAX_SIZE + 1];
+
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+        EccCurveList::try_from(vec),
+        "Converting from vector of curves did not produce the expected failure"
+    );
+}

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/handle_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/handle_list_tests.rs
@@ -1,0 +1,144 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use std::convert::TryFrom;
+use tss_esapi::{
+    constants::tss::{TPM2_PERSISTENT_FIRST, TPM2_TRANSIENT_FIRST},
+    handles::{PermanentTpmHandle, PersistentTpmHandle, TpmHandle, TransientTpmHandle},
+    structures::HandleList,
+    tss2_esys::{TPM2_HANDLE, TPML_HANDLE},
+    Error, WrapperErrorKind,
+};
+
+#[test]
+fn test_conversions() {
+    let expected_handles: Vec<TpmHandle> = vec![
+        PermanentTpmHandle::First.into(),
+        (PersistentTpmHandle::try_from(TPM2_PERSISTENT_FIRST).unwrap()).into(),
+        (TransientTpmHandle::try_from(TPM2_TRANSIENT_FIRST).unwrap()).into(),
+    ];
+    let mut handle_list = HandleList::new();
+    for handle in expected_handles.iter() {
+        handle_list
+            .add(*handle)
+            .expect("Failed to add handle to list");
+    }
+
+    assert_eq!(expected_handles.len(), handle_list.len());
+
+    expected_handles
+        .iter()
+        .zip(handle_list.as_ref().iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                expected, actual,
+                "The created handle list did not contain the expected values"
+            );
+        });
+
+    let tpml_handle = TPML_HANDLE::try_from(handle_list).expect("failed to convert to TPML_HANDLE");
+    assert_eq!(
+        expected_handles.len(),
+        tpml_handle.count as usize,
+        "The number of handles in the TPML_HANDLE is different than expected"
+    );
+
+    expected_handles
+        .iter()
+        .zip(tpml_handle.handle[..expected_handles.len()].iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                TPM2_HANDLE::from(*expected),
+                *actual,
+                "Got mismatch between expected FFI handle and actual handle"
+            )
+        });
+
+    let handle_list =
+        HandleList::try_from(tpml_handle).expect("Failed to convert from TPML_HANDLE");
+
+    assert_eq!(
+        expected_handles.len(),
+        handle_list.len(),
+        "Converted handle list has a different length"
+    );
+
+    expected_handles
+        .iter()
+        .zip(handle_list.as_ref().iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                expected, actual,
+                "The converted handle list did not contain the expected values"
+            );
+        });
+}
+
+#[test]
+fn test_vector_conversion() {
+    let expected_handles: Vec<TpmHandle> = vec![
+        PermanentTpmHandle::First.into(),
+        (PersistentTpmHandle::try_from(TPM2_PERSISTENT_FIRST).unwrap()).into(),
+        (TransientTpmHandle::try_from(TPM2_TRANSIENT_FIRST).unwrap()).into(),
+    ];
+
+    let handle_list =
+        HandleList::try_from(expected_handles.clone()).expect("Failed to convert from vector");
+
+    expected_handles
+        .iter()
+        .zip(handle_list.as_ref().iter())
+        .for_each(|(expected, actual)| {
+            assert_eq!(
+                expected, actual,
+                "The converted handle list did not contain the expected values"
+            );
+        });
+
+    let converted_handles = Vec::<TpmHandle>::from(handle_list);
+
+    assert_eq!(
+        expected_handles, converted_handles,
+        "Converted vector did not match initial vector"
+    );
+}
+
+#[test]
+fn test_add_too_many() {
+    let mut handle_list = HandleList::new();
+    for _ in 0..HandleList::MAX_SIZE {
+        handle_list
+            .add(PermanentTpmHandle::First.into())
+            .expect("Failed to add the maximum amount of handles");
+    }
+
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::WrongParamSize)),
+        handle_list.add(PermanentTpmHandle::First.into()),
+        "Added more handles than should've been possible"
+    );
+}
+
+#[test]
+fn test_invalid_size_tpml() {
+    let tpml = TPML_HANDLE {
+        count: (HandleList::MAX_SIZE + 1) as u32,
+        handle: [0; 254],
+    };
+
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+        HandleList::try_from(tpml),
+        "Converting from TPML_HANDLE did not produce the expected failure"
+    );
+}
+
+#[test]
+fn test_invalid_size_vec() {
+    let vec = vec![TpmHandle::Permanent(PermanentTpmHandle::First); HandleList::MAX_SIZE + 1];
+
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+        HandleList::try_from(vec),
+        "Converting from vector of handles did not produce the expected failure"
+    );
+}

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/mod.rs
@@ -4,6 +4,7 @@ mod algorithm_property_list_tests;
 mod command_code_list_tests;
 mod digest_list_tests;
 mod ecc_curve_list_tests;
+mod handle_list_tests;
 mod pcr_selection_list_builder_tests;
 mod pcr_selection_list_tests;
 mod tagged_pcr_property_list_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/mod.rs
@@ -3,6 +3,7 @@
 mod algorithm_property_list_tests;
 mod command_code_list_tests;
 mod digest_list_tests;
+mod ecc_curve_list_tests;
 mod pcr_selection_list_builder_tests;
 mod pcr_selection_list_tests;
 mod tagged_pcr_property_list_tests;


### PR DESCRIPTION
Replacing the FFI type with its abstraction for the contents of ECC
Curve capabilities.
The CapabilityData tests are also enhanced. A few of the variants are
renamed to follow the proper capitalization rules.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>