### PR TITLE
Make the crate compatible with 1.53 toolchain

### DIFF
--- a/tss-esapi/src/attributes/locality.rs
+++ b/tss-esapi/src/attributes/locality.rs
@@ -113,7 +113,7 @@ impl LocalityAttributesBuilder {
                     );
                     return Err(Error::local_error(WrapperErrorKind::InvalidParam));
                 }
-                32.. => {
+                32..=255 => {
                     if locality_attributes.0 != 0 {
                         error!("Locality attribute {new} is extended and cannot be combined with locality attribute(s) {old}", new=locality, old=locality_attributes.0);
                         return Err(Error::local_error(WrapperErrorKind::InvalidParam));


### PR DESCRIPTION
While building Parsec with the latest version of the crate (from
`main`), the legacy build failed due to range syntax that was not
supported in 1.53. This commit modifies the range to align with the
requirements in Parsec.

(failed Parsec build [here](https://github.com/parallaxsecond/parsec/runs/4869272668?check_suite_focus=true))