### PR TITLE
Fixes some pcr issues.

### DIFF
--- a/tss-esapi/src/abstraction/pcr.rs
+++ b/tss-esapi/src/abstraction/pcr.rs
@@ -53,7 +53,8 @@ pub use data::PcrData;
 ///             PcrSlot::Slot20,
 ///             PcrSlot::Slot21,
 ///     ])
-///     .build();
+///     .build()
+///     .expect("Failed to build PcrSelectionList");
 /// let _pcr_data = tss_esapi::abstraction::pcr::read_all(&mut context, pcr_selection_list)
 ///     .expect("pcr::read_all failed");
 /// ```

--- a/tss-esapi/src/abstraction/pcr/bank.rs
+++ b/tss-esapi/src/abstraction/pcr/bank.rs
@@ -22,7 +22,7 @@ impl PcrBank {
     /// # Details
     /// The order of pcr slots are assumed to match the order of the Digests.
     ///
-    /// # Error
+    /// # Errors
     /// - If number of pcr slots does not match the number of pcr digests
     ///   InconsistentParams error is returned.
     ///
@@ -88,7 +88,7 @@ impl PcrBank {
 
     /// Inserts [Digest] value associated with a [PcrSlot] into the bank.
     ///
-    /// # Error
+    /// # Errors
     /// Returns an error if a [Digest] is already associated with the
     /// provided [PcrSlot].
     pub fn insert_digest(&mut self, pcr_slot: PcrSlot, digest: Digest) -> Result<()> {
@@ -99,7 +99,7 @@ impl PcrBank {
 
     /// Attempts to extend the [PcrBank] with `other`.
     ///
-    /// # Error
+    /// # Errors
     /// Returns an error if the a value in `other` already
     /// exists.
     pub fn try_extend(&mut self, other: PcrBank) -> Result<()> {

--- a/tss-esapi/src/attributes/locality.rs
+++ b/tss-esapi/src/attributes/locality.rs
@@ -38,7 +38,7 @@ impl LocalityAttributes {
 
     /// Returns the LocalityAttributes as a number.
     ///
-    /// # Error
+    /// # Errors
     /// If the attributes are not extended en InvalidParams error
     /// is returned.
     pub fn as_extended(&self) -> Result<u8> {

--- a/tss-esapi/src/context/handle_manager.rs
+++ b/tss-esapi/src/context/handle_manager.rs
@@ -50,7 +50,7 @@ impl HandleManager {
 
     /// Sets the handle as flushed which removes it from the manager.
     ///
-    /// # Error
+    /// # Errors
     /// If the handle was not set to be flushed then this will cause an
     /// error but the handle will still be removed from the handler.
     pub fn set_as_flushed(&mut self, handle: ObjectHandle) -> Result<()> {
@@ -75,7 +75,7 @@ impl HandleManager {
 
     /// Sets the handles as closed which removes it from the handler.
     ///
-    /// # Error
+    /// # Errors
     /// If the handle was set to be flushed then this will cause an
     /// error but the handle will still be removed from the handler.
     pub fn set_as_closed(&mut self, handle: ObjectHandle) -> Result<()> {

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -146,7 +146,8 @@ impl Context {
     /// // that is going to be read.
     /// let pcr_selection_list = PcrSelectionListBuilder::new()
     ///     .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0, PcrSlot::Slot1])
-    ///     .build();
+    ///     .build()
+    ///     .expect("Failed to build PcrSelectionList");
     ///
     /// let (update_counter, read_pcr_list, digest_list) = context.pcr_read(pcr_selection_list)
     ///     .expect("Call to pcr_read failed");

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -131,7 +131,7 @@ pub mod command_code_attributes_list {
     pub use super::lists::command_code_attributes::*;
 }
 
-pub use pcr::slot_collection::PcrSlotCollection;
+pub(crate) use pcr::slot_collection::PcrSlotCollection;
 /////////////////////////////////////////////////////////
 /// The parameters section
 /////////////////////////////////////////////////////////

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -130,6 +130,8 @@ pub use self::command_code_attributes_list::CommandCodeAttributesList;
 pub mod command_code_attributes_list {
     pub use super::lists::command_code_attributes::*;
 }
+
+pub use pcr::slot_collection::PcrSlotCollection;
 /////////////////////////////////////////////////////////
 /// The parameters section
 /////////////////////////////////////////////////////////

--- a/tss-esapi/src/structures/pcr/mod.rs
+++ b/tss-esapi/src/structures/pcr/mod.rs
@@ -4,3 +4,4 @@ pub mod select;
 pub mod select_size;
 pub mod selection;
 pub mod slot;
+pub mod slot_collection;

--- a/tss-esapi/src/structures/pcr/select.rs
+++ b/tss-esapi/src/structures/pcr/select.rs
@@ -58,7 +58,7 @@ impl TryFrom<TPMS_PCR_SELECT> for PcrSelect {
 
         // Select only the octets indicated by sizeofSelect
         let mut selected_octets = [0u8; TPM2_PCR_SELECT_MAX as usize];
-        let number_of_selected_octets: usize = size_of_select.into();
+        let number_of_selected_octets: usize = size_of_select.as_usize();
         selected_octets[..number_of_selected_octets]
             .copy_from_slice(&tss_pcr_select.pcrSelect[..number_of_selected_octets]);
 
@@ -79,7 +79,7 @@ impl TryFrom<TPMS_PCR_SELECT> for PcrSelect {
 impl From<PcrSelect> for TPMS_PCR_SELECT {
     fn from(pcr_select: PcrSelect) -> Self {
         TPMS_PCR_SELECT {
-            sizeofSelect: pcr_select.size_of_select.into(),
+            sizeofSelect: pcr_select.size_of_select.as_u8(),
             pcrSelect: pcr_select.selected_pcrs.bits().to_le_bytes(),
         }
     }

--- a/tss-esapi/src/structures/pcr/select.rs
+++ b/tss-esapi/src/structures/pcr/select.rs
@@ -1,13 +1,10 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    structures::{PcrSelectSize, PcrSlot},
-    tss2_esys::{TPM2_PCR_SELECT_MAX, TPMS_PCR_SELECT},
-    Error, Result, WrapperErrorKind,
+    structures::{PcrSelectSize, PcrSlot, PcrSlotCollection},
+    tss2_esys::TPMS_PCR_SELECT,
+    Error, Result,
 };
-
-use enumflags2::BitFlags;
-use log::error;
 
 use std::convert::TryFrom;
 /// This module contains necessary representations
@@ -21,17 +18,15 @@ use std::convert::TryFrom;
 /// not adhering to a platform-specific specification.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PcrSelect {
-    size_of_select: PcrSelectSize,
-    selected_pcrs: BitFlags<PcrSlot>,
+    pcr_slot_collection: PcrSlotCollection,
 }
 
 impl PcrSelect {
     /// Creates a new PcrSelect
-    pub fn new(size_of_select: PcrSelectSize, pcr_slots: &[PcrSlot]) -> Self {
-        PcrSelect {
-            size_of_select,
-            selected_pcrs: pcr_slots.iter().copied().collect(),
-        }
+    pub fn create(pcr_select_size: PcrSelectSize, pcr_slots: &[PcrSlot]) -> Result<Self> {
+        PcrSlotCollection::create(pcr_select_size, pcr_slots).map(|pcr_slot_collection| PcrSelect {
+            pcr_slot_collection,
+        })
     }
 
     /// Returns the size of the select.
@@ -41,46 +36,32 @@ impl PcrSelect {
     /// octets that are needed to hold the bit field
     /// that indicate what slots that are selected.
     pub fn size_of_select(&self) -> PcrSelectSize {
-        self.size_of_select
+        self.pcr_slot_collection.size_of_select()
     }
 
     /// Returns the selected PCRs in the select.
     pub fn selected_pcrs(&self) -> Vec<PcrSlot> {
-        self.selected_pcrs.iter().collect()
+        self.pcr_slot_collection.collection()
     }
 }
 
 impl TryFrom<TPMS_PCR_SELECT> for PcrSelect {
     type Error = Error;
     fn try_from(tss_pcr_select: TPMS_PCR_SELECT) -> Result<Self> {
-        // Parse the sizeofSelect into a SelectSize.
-        let size_of_select = PcrSelectSize::try_from(tss_pcr_select.sizeofSelect)?;
-
-        // Select only the octets indicated by sizeofSelect
-        let mut selected_octets = [0u8; TPM2_PCR_SELECT_MAX as usize];
-        let number_of_selected_octets: usize = size_of_select.as_usize();
-        selected_octets[..number_of_selected_octets]
-            .copy_from_slice(&tss_pcr_select.pcrSelect[..number_of_selected_octets]);
-
-        // Parse selected pcrs into BitFlags
-        let selected_pcrs = BitFlags::<PcrSlot>::try_from(u32::from_le_bytes(selected_octets))
-            .map_err(|e| {
-                error!("Error parsing pcrSelect to a BitFlags<PcrSlot>: {}.", e);
-                Error::local_error(WrapperErrorKind::UnsupportedParam)
-            })?;
-
-        Ok(PcrSelect {
-            size_of_select,
-            selected_pcrs,
-        })
+        PcrSlotCollection::try_from((tss_pcr_select.sizeofSelect, tss_pcr_select.pcrSelect)).map(
+            |pcr_slot_collection| PcrSelect {
+                pcr_slot_collection,
+            },
+        )
     }
 }
 
 impl From<PcrSelect> for TPMS_PCR_SELECT {
     fn from(pcr_select: PcrSelect) -> Self {
+        let (size_of_select, pcr_select) = pcr_select.pcr_slot_collection.into();
         TPMS_PCR_SELECT {
-            sizeofSelect: pcr_select.size_of_select.as_u8(),
-            pcrSelect: pcr_select.selected_pcrs.bits().to_le_bytes(),
+            sizeofSelect: size_of_select,
+            pcrSelect: pcr_select,
         }
     }
 }

--- a/tss-esapi/src/structures/pcr/select_size.rs
+++ b/tss-esapi/src/structures/pcr/select_size.rs
@@ -12,10 +12,10 @@ use std::convert::TryFrom;
 #[derive(FromPrimitive, ToPrimitive, Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum PcrSelectSize {
-    OneByte = 1,
-    TwoBytes = 2,
-    ThreeBytes = 3,
-    FourBytes = 4,
+    OneOctet = 1,
+    TwoOctets = 2,
+    ThreeOctets = 3,
+    FourOctets = 4,
 }
 
 impl PcrSelectSize {
@@ -74,15 +74,15 @@ impl PcrSelectSize {
     }
 }
 
-/// The default for PcrSelectSize is three bytes.
+/// The default for PcrSelectSize is three octets.
 /// A value for the sizeofSelect that works
 /// on most platforms.
 impl Default for PcrSelectSize {
     fn default() -> PcrSelectSize {
         match TPM2_PCR_SELECT_MAX {
-            1 => PcrSelectSize::OneByte,
-            2 => PcrSelectSize::TwoBytes,
-            _ => PcrSelectSize::ThreeBytes,
+            1 => PcrSelectSize::OneOctet,
+            2 => PcrSelectSize::TwoOctets,
+            _ => PcrSelectSize::ThreeOctets,
         }
     }
 }

--- a/tss-esapi/src/structures/pcr/select_size.rs
+++ b/tss-esapi/src/structures/pcr/select_size.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::{Error, Result, WrapperErrorKind};
+use crate::{tss2_esys::TPM2_PCR_SELECT_MAX, Error, Result, WrapperErrorKind};
 
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
@@ -18,20 +18,53 @@ pub enum PcrSelectSize {
     FourBytes = 4,
 }
 
-/// The default for PcrSelectSize is three bytes.
-/// A value for the sizeofSelect that works
-/// on most platforms.
-impl Default for PcrSelectSize {
-    fn default() -> PcrSelectSize {
-        PcrSelectSize::ThreeBytes
+impl PcrSelectSize {
+    /// Returns the PcrSelectSize value as u8
+    pub fn as_u8(&self) -> u8 {
+        // The value is well defined so unwrap will
+        // never cause panic.
+        self.to_u8().unwrap()
     }
-}
 
-impl TryFrom<u8> for PcrSelectSize {
-    type Error = Error;
+    /// Returns the PcrSelectSize value as u32
+    pub fn as_u32(&self) -> u32 {
+        // The value is well defined so unwrap will
+        // never cause panic.
+        self.to_u32().unwrap()
+    }
 
-    fn try_from(value: u8) -> Result<Self> {
+    /// Returns the PcrSelectSize value as usize
+    pub fn as_usize(&self) -> usize {
+        // The value is well defined so unwrap will
+        // never cause panic.
+        self.to_usize().unwrap()
+    }
+
+    /// Parses the u8 value as PcrSelectSize
+    pub fn try_parse_u8(value: u8) -> Result<Self> {
         PcrSelectSize::from_u8(value).ok_or_else(|| {
+            error!(
+                "Error converting sizeofSelect to a SelectSize: Invalid value {}",
+                value
+            );
+            Error::local_error(WrapperErrorKind::InvalidParam)
+        })
+    }
+
+    /// Parses the u32 value as PcrSelectSize
+    pub fn try_parse_u32(value: u32) -> Result<Self> {
+        PcrSelectSize::from_u32(value).ok_or_else(|| {
+            error!(
+                "Error converting sizeofSelect to a SelectSize: Invalid value {}",
+                value
+            );
+            Error::local_error(WrapperErrorKind::InvalidParam)
+        })
+    }
+
+    /// Parses the usize value as PcrSelectSize
+    pub fn try_parse_usize(value: usize) -> Result<Self> {
+        PcrSelectSize::from_usize(value).ok_or_else(|| {
             error!(
                 "Error converting sizeofSelect to a SelectSize: Invalid value {}",
                 value
@@ -41,18 +74,43 @@ impl TryFrom<u8> for PcrSelectSize {
     }
 }
 
-impl From<PcrSelectSize> for u8 {
-    fn from(pcr_select_size: PcrSelectSize) -> Self {
-        // The value is well defined so unwrap will
-        // never cause panic.
-        pcr_select_size.to_u8().unwrap()
+/// The default for PcrSelectSize is three bytes.
+/// A value for the sizeofSelect that works
+/// on most platforms.
+impl Default for PcrSelectSize {
+    fn default() -> PcrSelectSize {
+        match TPM2_PCR_SELECT_MAX {
+            1 => PcrSelectSize::OneByte,
+            2 => PcrSelectSize::TwoBytes,
+            _ => PcrSelectSize::ThreeBytes,
+        }
     }
 }
 
-impl From<PcrSelectSize> for usize {
-    fn from(pcr_select_size: PcrSelectSize) -> Self {
-        // The value is well defined so unwrap will
-        // never cause panic.
-        pcr_select_size.to_usize().unwrap()
+impl TryFrom<u8> for PcrSelectSize {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self> {
+        if u32::from(value) > TPM2_PCR_SELECT_MAX {
+            error!(
+                "Found size of select value(= {}) that is larger then TPM2_PCR_SELECT_MAX(={}",
+                value, TPM2_PCR_SELECT_MAX
+            );
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+
+        PcrSelectSize::try_parse_u8(value)
+    }
+}
+
+impl TryFrom<PcrSelectSize> for u8 {
+    type Error = Error;
+
+    fn try_from(pcr_select_size: PcrSelectSize) -> Result<Self> {
+        if pcr_select_size.as_u32() > TPM2_PCR_SELECT_MAX {
+            error!("The number of octets specified by PcrSelectSize value us greater then TPM2_PCR_SELECT_MAX");
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(pcr_select_size.as_u8())
     }
 }

--- a/tss-esapi/src/structures/pcr/selection.rs
+++ b/tss-esapi/src/structures/pcr/selection.rs
@@ -157,7 +157,7 @@ impl TryFrom<TPMS_PCR_SELECTION> for PcrSelection {
 
         // Select only the octets indicated by sizeofSelect
         let mut selected_octets = [0u8; TPM2_PCR_SELECT_MAX as usize];
-        let number_of_selected_octets: usize = size_of_select.into();
+        let number_of_selected_octets: usize = size_of_select.as_usize();
         selected_octets[..number_of_selected_octets]
             .copy_from_slice(&tss_pcr_selection.pcrSelect[..number_of_selected_octets]);
 
@@ -180,7 +180,7 @@ impl From<PcrSelection> for TPMS_PCR_SELECTION {
     fn from(pcr_selection: PcrSelection) -> Self {
         TPMS_PCR_SELECTION {
             hash: pcr_selection.hashing_algorithm.into(),
-            sizeofSelect: pcr_selection.size_of_select.into(),
+            sizeofSelect: pcr_selection.size_of_select.as_u8(),
             pcrSelect: pcr_selection.selected_pcrs.bits().to_le_bytes(),
         }
     }

--- a/tss-esapi/src/structures/pcr/selection.rs
+++ b/tss-esapi/src/structures/pcr/selection.rs
@@ -1,35 +1,40 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::interface_types::algorithm::HashingAlgorithm;
-use crate::structures::{PcrSelectSize, PcrSlot};
-use crate::tss2_esys::{TPM2_PCR_SELECT_MAX, TPMS_PCR_SELECTION};
-use crate::{Error, Result, WrapperErrorKind};
-use enumflags2::BitFlags;
+use crate::{
+    interface_types::algorithm::HashingAlgorithm,
+    structures::{PcrSelectSize, PcrSlot, PcrSlotCollection},
+    tss2_esys::TPMS_PCR_SELECTION,
+    Error, Result, WrapperErrorKind,
+};
 use log::error;
-use std::convert::{From, TryFrom};
-use std::iter::FromIterator;
+use std::convert::TryFrom;
 /// This module contains the PcrSelection struct.
 /// The TSS counterpart of this struct is the
 /// TPMS_PCR_SELECTION.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PcrSelection {
     hashing_algorithm: HashingAlgorithm,
-    size_of_select: PcrSelectSize,
-    selected_pcrs: BitFlags<PcrSlot>,
+    pcr_slot_collection: PcrSlotCollection,
 }
 
 impl PcrSelection {
     /// Creates new PcrSelection
-    pub fn new(
+    ///
+    /// # Error
+    /// Returns InconsistentParams error if a pcr slot
+    /// has been provided that ends up in an octet outside the
+    /// range specified by the `size_of_select` parameter.
+    pub fn create(
         hashing_algorithm: HashingAlgorithm,
         size_of_select: PcrSelectSize,
         selected_pcr_slots: &[PcrSlot],
-    ) -> Self {
-        PcrSelection {
-            hashing_algorithm,
-            size_of_select,
-            selected_pcrs: Self::to_internal_representation(selected_pcr_slots),
-        }
+    ) -> Result<Self> {
+        PcrSlotCollection::create(size_of_select, selected_pcr_slots).map(|pcr_slot_collection| {
+            PcrSelection {
+                hashing_algorithm,
+                pcr_slot_collection,
+            }
+        })
     }
 
     /// Returns the hashing algorithm for the selection
@@ -44,18 +49,18 @@ impl PcrSelection {
     /// octets that are needed to hold the bit field
     /// that indicate what slots that are selected.
     pub const fn size_of_select(&self) -> PcrSelectSize {
-        self.size_of_select
+        self.pcr_slot_collection.size_of_select()
     }
 
     /// Returns the selected pcrs.
     pub fn selected(&self) -> Vec<PcrSlot> {
-        self.selected_pcrs.iter().collect()
+        self.pcr_slot_collection.collection()
     }
 
     /// Returns true if the specified [PcrSlot] is selected in
     /// the [PcrSelection].
     pub fn is_selected(&self, pcr_slot: PcrSlot) -> bool {
-        self.selected_pcrs.contains(pcr_slot)
+        self.pcr_slot_collection.contains(pcr_slot)
     }
 
     /// Removes the specified [PcrSlot]s from the selected pcrs.
@@ -63,81 +68,65 @@ impl PcrSelection {
     /// # Error
     /// If one of the specified pcr slots does not exist in the selected pcrs.
     pub fn deselect_exact(&mut self, pcr_slot: PcrSlot) -> Result<()> {
-        self.remove_exact(pcr_slot.into())
+        self.pcr_slot_collection.remove_exact(pcr_slot)
     }
 
     /// Removes the specified [PcrSlot]s from the selected pcrs.
     pub fn deselect(&mut self, pcr_slot: PcrSlot) {
-        self.remove(pcr_slot.into())
+        self.pcr_slot_collection.remove(pcr_slot)
     }
 
-    /// Merges another [PcrSelection] into this one.
-    pub fn merge(&mut self, other: &Self) -> Result<()> {
-        // Check that the hashing algorithm match
-        if self.hashing_algorithm != other.hashing_algorithm {
-            error!("Found inconsistencies in the hashing algorithm");
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
-        // Check that size of select match.
-        if self.size_of_select != other.size_of_select {
-            error!("Found inconsistencies in the size of select");
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
-        self.selected_pcrs |= other.selected_pcrs;
-        Ok(())
-    }
-
-    /// Removes the selected values in `other` from `self`.
+    /// Merges another [PcrSelection] into `self` if the
+    /// elements in the collection does not already exist
+    /// in `self`.
     ///
     /// # Constraints
     /// * Cannot be called with `other` that has a hashing_algorithm
     ///   that is different from the one in `self`.
     /// * Cannot be called with `other` that has a size_of_select
     ///   that is different from the one in `self`.
-    pub fn subtract(&mut self, other: &Self) -> Result<()> {
+    /// * Cannot be called with `other`that contains pcr slots present
+    ///   in `self`.
+    ///
+    /// # Error
+    /// Returns InvalidParam if there is a hashing algorithm mismatch
+    /// Returns InvalidParam if there is size of select mismatch.
+    /// Returns InvalidParam if `other` contains items that are present in `self`
+    pub fn merge_exact(&mut self, other: &Self) -> Result<()> {
+        // Check that the hashing algorithm match
+        if self.hashing_algorithm != other.hashing_algorithm {
+            error!("Found inconsistencies in the hashing algorithm");
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+
+        self.pcr_slot_collection
+            .merge_exact(&other.pcr_slot_collection)
+    }
+
+    /// Removes the selected pcr slots in `other` from `self`if none
+    /// of the pcr slots are present in `self`.
+    ///
+    /// # Constraints
+    /// * Cannot be called with `other` that has a hashing_algorithm
+    ///   that is different from the one in `self`.
+    /// * Cannot be called with `other` that has a size_of_select
+    ///   that is different from the one in `self`.
+    /// * Cannot be called with `other`that contains pcr slots not present
+    ///   in `self`.
+    pub fn subtract_exact(&mut self, other: &Self) -> Result<()> {
         // Check that the hashing algorithm match
         if self.hashing_algorithm != other.hashing_algorithm {
             error!("Mismatched hashing algorithm ");
             return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
         }
-        // Check that size of select match.
-        if self.size_of_select != other.size_of_select {
-            error!("Mismatched size of select");
-            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
-        }
 
-        self.remove_exact(other.selected_pcrs)
+        self.pcr_slot_collection
+            .subtract_exact(&other.pcr_slot_collection)
     }
 
     /// Indicates whether the pcr selection is empty.
     pub fn is_empty(&self) -> bool {
-        self.selected_pcrs.is_empty()
-    }
-
-    /// Private function for converting a slize of pcr slots to
-    /// internal representation.
-    fn to_internal_representation(pcr_slots: &[PcrSlot]) -> BitFlags<PcrSlot> {
-        BitFlags::<PcrSlot>::from_iter(pcr_slots.iter().copied())
-    }
-
-    /// Removes bitflags from selected pcrs
-    ///
-    /// # Error
-    /// Returns an error if the any of the bit flags does
-    /// not exist in the selected pcrs.
-    fn remove_exact(&mut self, bit_flags: BitFlags<PcrSlot>) -> Result<()> {
-        if self.selected_pcrs.contains(bit_flags) {
-            self.remove(bit_flags);
-            Ok(())
-        } else {
-            error!("Failed to remove item, it does not exist");
-            Err(Error::local_error(WrapperErrorKind::InvalidParam))
-        }
-    }
-
-    /// Removes bitflags from selected pcrs
-    fn remove(&mut self, bit_flags: BitFlags<PcrSlot>) {
-        self.selected_pcrs.remove(bit_flags)
+        self.pcr_slot_collection.is_empty()
     }
 }
 
@@ -152,36 +141,25 @@ impl TryFrom<TPMS_PCR_SELECTION> for PcrSelection {
                 Error::local_error(WrapperErrorKind::InvalidParam)
             })?;
 
-        // Parse the sizeofSelect into a SelectSize.
-        let size_of_select = PcrSelectSize::try_from(tss_pcr_selection.sizeofSelect)?;
-
-        // Select only the octets indicated by sizeofSelect
-        let mut selected_octets = [0u8; TPM2_PCR_SELECT_MAX as usize];
-        let number_of_selected_octets: usize = size_of_select.as_usize();
-        selected_octets[..number_of_selected_octets]
-            .copy_from_slice(&tss_pcr_selection.pcrSelect[..number_of_selected_octets]);
-
-        // Parse selected pcrs into BitFlags
-        let selected_pcrs = BitFlags::<PcrSlot>::try_from(u32::from_le_bytes(selected_octets))
-            .map_err(|e| {
-                error!("Error parsing pcrSelect to a BitFlags<PcrSlot>: {}", e);
-                Error::local_error(WrapperErrorKind::UnsupportedParam)
-            })?;
+        let pcr_slot_collection = PcrSlotCollection::try_from((
+            tss_pcr_selection.sizeofSelect,
+            tss_pcr_selection.pcrSelect,
+        ))?;
 
         Ok(PcrSelection {
             hashing_algorithm,
-            size_of_select,
-            selected_pcrs,
+            pcr_slot_collection,
         })
     }
 }
 
 impl From<PcrSelection> for TPMS_PCR_SELECTION {
     fn from(pcr_selection: PcrSelection) -> Self {
+        let (size_of_select, pcr_select) = pcr_selection.pcr_slot_collection.into();
         TPMS_PCR_SELECTION {
             hash: pcr_selection.hashing_algorithm.into(),
-            sizeofSelect: pcr_selection.size_of_select.as_u8(),
-            pcrSelect: pcr_selection.selected_pcrs.bits().to_le_bytes(),
+            sizeofSelect: size_of_select,
+            pcrSelect: pcr_select,
         }
     }
 }

--- a/tss-esapi/src/structures/pcr/selection.rs
+++ b/tss-esapi/src/structures/pcr/selection.rs
@@ -20,7 +20,7 @@ pub struct PcrSelection {
 impl PcrSelection {
     /// Creates new PcrSelection
     ///
-    /// # Error
+    /// # Errors
     /// Returns InconsistentParams error if a pcr slot
     /// has been provided that ends up in an octet outside the
     /// range specified by the `size_of_select` parameter.
@@ -65,7 +65,7 @@ impl PcrSelection {
 
     /// Removes the specified [PcrSlot]s from the selected pcrs.
     ///
-    /// # Error
+    /// # Errors
     /// If one of the specified pcr slots does not exist in the selected pcrs.
     pub fn deselect_exact(&mut self, pcr_slot: PcrSlot) -> Result<()> {
         self.pcr_slot_collection.remove_exact(pcr_slot)
@@ -88,7 +88,7 @@ impl PcrSelection {
     /// * Cannot be called with `other`that contains pcr slots present
     ///   in `self`.
     ///
-    /// # Error
+    /// # Errors
     /// Returns InvalidParam if there is a hashing algorithm mismatch
     /// Returns InvalidParam if there is size of select mismatch.
     /// Returns InvalidParam if `other` contains items that are present in `self`

--- a/tss-esapi/src/structures/pcr/slot.rs
+++ b/tss-esapi/src/structures/pcr/slot.rs
@@ -37,6 +37,14 @@ pub enum PcrSlot {
     Slot21 = 0x0020_0000,
     Slot22 = 0x0040_0000,
     Slot23 = 0x0080_0000,
+    Slot24 = 0x0100_0000,
+    Slot25 = 0x0200_0000,
+    Slot26 = 0x0400_0000,
+    Slot27 = 0x0800_0000,
+    Slot28 = 0x1000_0000,
+    Slot29 = 0x2000_0000,
+    Slot30 = 0x4000_0000,
+    Slot31 = 0x8000_0000,
 }
 
 impl From<PcrSlot> for u32 {

--- a/tss-esapi/src/structures/pcr/slot_collection.rs
+++ b/tss-esapi/src/structures/pcr/slot_collection.rs
@@ -197,10 +197,10 @@ impl PcrSlotCollection {
     /// pcr slots with regard to the PcrSelectSize
     const fn calculate_max_pcr_slots_value(pcr_select_size: PcrSelectSize) -> u32 {
         match pcr_select_size {
-            PcrSelectSize::OneByte => 0x000000FF,
-            PcrSelectSize::TwoBytes => 0x0000FFFF,
-            PcrSelectSize::ThreeBytes => 0x00FFFFFF,
-            PcrSelectSize::FourBytes => 0xFFFFFFFF,
+            PcrSelectSize::OneOctet => 0x000000FF,
+            PcrSelectSize::TwoOctets => 0x0000FFFF,
+            PcrSelectSize::ThreeOctets => 0x00FFFFFF,
+            PcrSelectSize::FourOctets => 0xFFFFFFFF,
         }
     }
 }

--- a/tss-esapi/src/structures/pcr/slot_collection.rs
+++ b/tss-esapi/src/structures/pcr/slot_collection.rs
@@ -1,0 +1,240 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    structures::{PcrSelectSize, PcrSlot},
+    tss2_esys::TPM2_PCR_SELECT_MAX,
+    Error, Result, WrapperErrorKind,
+};
+use enumflags2::BitFlags;
+use log::error;
+use std::convert::TryFrom;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct PcrSlotCollection {
+    pcr_select_size: PcrSelectSize,
+    pcr_slots: BitFlags<PcrSlot>,
+}
+
+impl PcrSlotCollection {
+    const MAX_SIZE: usize = TPM2_PCR_SELECT_MAX as usize;
+
+    /// Creates a new PcrSlotCollection
+    pub fn new() -> Self {
+        PcrSlotCollection {
+            pcr_select_size: PcrSelectSize::default(),
+            pcr_slots: BitFlags::<PcrSlot>::empty(),
+        }
+    }
+
+    /// Creates a PcrCollection from the given arguments.
+    pub fn create(pcr_select_size: PcrSelectSize, pcr_slots: &[PcrSlot]) -> Result<Self> {
+        Self::validate_parameters(pcr_select_size, pcr_slots)?;
+
+        Ok(PcrSlotCollection {
+            pcr_select_size,
+            pcr_slots: pcr_slots.iter().copied().collect(),
+        })
+    }
+
+    /// Validates that the combination of parameters
+    /// provided can be used together.
+    pub fn validate_parameters(
+        pcr_select_size: PcrSelectSize,
+        pcr_slots: &[PcrSlot],
+    ) -> Result<()> {
+        let _number_of_octets: u32 = u8::try_from(pcr_select_size).map(u32::from)?;
+
+        let max_pcr_slot_value = Self::calculate_max_pcr_slots_value(pcr_select_size);
+
+        if pcr_slots
+            .iter()
+            .any(|&item| u32::from(item) > max_pcr_slot_value)
+        {
+            error!("pcr_slots contained a pcr slot that does not reside in octets specified by size_of_select");
+            return Err(Error::local_error(WrapperErrorKind::InconsistentParams));
+        }
+        Ok(())
+    }
+
+    /// Returns the size of the select.
+    pub const fn size_of_select(&self) -> PcrSelectSize {
+        self.pcr_select_size
+    }
+
+    /// Returns true if the collection contains the
+    /// specified pcr slot.
+    pub fn contains(&self, pcr_slot: PcrSlot) -> bool {
+        self.pcr_slots.contains(pcr_slot)
+    }
+
+    /// Returns true if the collection is empty.
+    pub fn is_empty(&self) -> bool {
+        self.pcr_slots.is_empty()
+    }
+
+    /// Returns the pcr slots in the collection.
+    pub fn collection(&self) -> Vec<PcrSlot> {
+        self.pcr_slots.iter().collect()
+    }
+
+    /// Removes pcr slot from the collection
+    pub fn remove(&mut self, pcr_slot: PcrSlot) {
+        self.pcr_slots.remove(pcr_slot)
+    }
+
+    /// Removes pcr slot from the collection if it
+    /// exists.
+    ///
+    /// # Constraints
+    /// Cannot remove a pcr slot from the collection
+    /// if it does not reside inside the collection.
+    ///
+    /// # Errors
+    /// Returns InvalidParam error if the collection
+    /// did not contain the specified pcr slot.
+    pub fn remove_exact(&mut self, pcr_slot: PcrSlot) -> Result<()> {
+        self.ensure_contains_all(pcr_slot, "remove_exact")?;
+        self.pcr_slots.remove(pcr_slot);
+        Ok(())
+    }
+
+    /// Merges another PcrSlotCollection into `self` if it contains no
+    /// pcr slots that are already present in `self`.
+    ///
+    /// # Errors
+    /// Returns InconsistentParams if a size of select mismatch is detected.
+    /// Returns InvalidParam if `other` contains items that are present in `self`
+    pub fn merge_exact(&mut self, other: &Self) -> Result<()> {
+        // Check that size of select match.
+        self.ensure_pcr_select_size_equality(other, "merge_exact")?;
+        self.ensure_contains_none(other.pcr_slots, "merge_exact")?;
+        self.pcr_slots |= other.pcr_slots;
+        Ok(())
+    }
+
+    /// Subtracts another PcrSlotCollection from `self` if none the
+    /// items in the other collection is present in `self`.
+    ///
+    /// # Errors
+    /// Returns InconsistentParams if a size of select mismatch is detected.
+    /// Returns InvalidParam if `other` contains items that are not present in `self`
+    pub fn subtract_exact(&mut self, other: &Self) -> Result<()> {
+        // Check that size of select match.
+        self.ensure_pcr_select_size_equality(other, "subtract_unique")?;
+        self.ensure_contains_all(other.pcr_slots, "subtract_unique")?;
+        self.pcr_slots.remove(other.pcr_slots);
+        Ok(())
+    }
+
+    /// Private method for ensuring that a size of select
+    /// is equal to the one present in `self`.
+    fn ensure_pcr_select_size_equality(
+        &self,
+        other: &PcrSlotCollection,
+        action: &str,
+    ) -> Result<()> {
+        if self.pcr_select_size != other.pcr_select_size {
+            error!(
+                "Failed to perform '{}' due to size of select mismatch",
+                action
+            );
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(())
+    }
+
+    /// Private method for ensuring that provided pcr slots does not
+    /// already exists in `self`.
+    fn ensure_contains_none(&self, pcr_slots: BitFlags<PcrSlot>, action: &str) -> Result<()> {
+        if self.pcr_slots.intersects(pcr_slots) {
+            error!(
+                "Failed to perform '{}' because `self` contained the specified pcr slots",
+                action
+            );
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        }
+        Ok(())
+    }
+
+    /// Private method that ensures that all the specified pcr slots
+    /// exists in `self`.
+    fn ensure_contains_all<T>(&self, pcr_slots: T, action: &str) -> Result<()>
+    where
+        T: Into<BitFlags<PcrSlot>>,
+    {
+        if self.pcr_slots.contains(pcr_slots) {
+            Ok(())
+        } else {
+            error!(
+                "Failed to perform '{}' because `self` did not contain the specified pcr slots",
+                action
+            );
+            Err(Error::local_error(WrapperErrorKind::InvalidParam))
+        }
+    }
+
+    /// Private function for parsing the octets into the internal representation.
+    fn parse_octets(
+        mut octets: [u8; PcrSlotCollection::MAX_SIZE],
+        pcr_select_size: PcrSelectSize,
+    ) -> Result<BitFlags<PcrSlot>> {
+        // Mask all octets not indicated by pcr_select_size
+        // to be included.
+        octets[..]
+            .iter_mut()
+            .enumerate()
+            .for_each(|(index, value)| {
+                if index + 1 > pcr_select_size.as_usize() {
+                    *value = 0u8;
+                }
+            });
+
+        BitFlags::<PcrSlot>::try_from(u32::from_le_bytes(octets)).map_err(|e| {
+            error!("Error parsing octets to a BitFlags<PcrSlot>: {}", e);
+            Error::local_error(WrapperErrorKind::UnsupportedParam)
+        })
+    }
+
+    /// Private function that calculates the maximum value for
+    /// pcr slots with regard to the PcrSelectSize
+    const fn calculate_max_pcr_slots_value(pcr_select_size: PcrSelectSize) -> u32 {
+        match pcr_select_size {
+            PcrSelectSize::OneByte => 0x000000FF,
+            PcrSelectSize::TwoBytes => 0x0000FFFF,
+            PcrSelectSize::ThreeBytes => 0x00FFFFFF,
+            PcrSelectSize::FourBytes => 0xFFFFFFFF,
+        }
+    }
+}
+
+impl Default for PcrSlotCollection {
+    fn default() -> Self {
+        PcrSlotCollection::new()
+    }
+}
+
+impl From<PcrSlotCollection> for (u8, [u8; PcrSlotCollection::MAX_SIZE]) {
+    fn from(pcr_slot_collection: PcrSlotCollection) -> Self {
+        // PcrSlotCollection should not be able to contain
+        // an invalid pcr_select_size.
+        let size_of_select = pcr_slot_collection.pcr_select_size.as_u8();
+        let number_of_octets = pcr_slot_collection.pcr_select_size.as_usize();
+        let u32_bytes = pcr_slot_collection.pcr_slots.bits().to_le_bytes();
+        let mut octets: [u8; TPM2_PCR_SELECT_MAX as usize] = Default::default();
+        octets[..number_of_octets].copy_from_slice(&u32_bytes[..number_of_octets]);
+        (size_of_select, octets)
+    }
+}
+
+impl TryFrom<(u8, [u8; Self::MAX_SIZE])> for PcrSlotCollection {
+    type Error = Error;
+
+    fn try_from((size_of_select, octets): (u8, [u8; Self::MAX_SIZE])) -> Result<Self> {
+        let pcr_select_size = PcrSelectSize::try_from(size_of_select)?;
+        Ok(PcrSlotCollection {
+            pcr_select_size,
+            pcr_slots: PcrSlotCollection::parse_octets(octets, pcr_select_size)?,
+        })
+    }
+}

--- a/tss-esapi/src/structures/pcr/slot_collection.rs
+++ b/tss-esapi/src/structures/pcr/slot_collection.rs
@@ -10,7 +10,7 @@ use enumflags2::BitFlags;
 use log::error;
 use std::convert::TryFrom;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct PcrSlotCollection {
     pcr_select_size: PcrSelectSize,
     pcr_slots: BitFlags<PcrSlot>,
@@ -21,10 +21,7 @@ impl PcrSlotCollection {
 
     /// Creates a new PcrSlotCollection
     pub fn new() -> Self {
-        PcrSlotCollection {
-            pcr_select_size: PcrSelectSize::default(),
-            pcr_slots: BitFlags::<PcrSlot>::empty(),
-        }
+        PcrSlotCollection::default()
     }
 
     /// Creates a PcrCollection from the given arguments.
@@ -205,12 +202,6 @@ impl PcrSlotCollection {
             PcrSelectSize::ThreeBytes => 0x00FFFFFF,
             PcrSelectSize::FourBytes => 0xFFFFFFFF,
         }
-    }
-}
-
-impl Default for PcrSlotCollection {
-    fn default() -> Self {
-        PcrSlotCollection::new()
     }
 }
 

--- a/tss-esapi/src/structures/property/tagged_pcr_select.rs
+++ b/tss-esapi/src/structures/property/tagged_pcr_select.rs
@@ -78,7 +78,7 @@ impl TryFrom<TPMS_TAGGED_PCR_SELECT> for TaggedPcrSelect {
 
         // Select only the octets indicated by sizeofSelect
         let mut selected_octets = [0u8; TPM2_PCR_SELECT_MAX as usize];
-        let number_of_selected_octets: usize = size_of_select.into();
+        let number_of_selected_octets: usize = size_of_select.as_usize();
         selected_octets[..number_of_selected_octets]
             .copy_from_slice(&tpms_tagged_pcr_select.pcrSelect[..number_of_selected_octets]);
 
@@ -101,7 +101,7 @@ impl From<TaggedPcrSelect> for TPMS_TAGGED_PCR_SELECT {
     fn from(tagged_pcr_select: TaggedPcrSelect) -> Self {
         TPMS_TAGGED_PCR_SELECT {
             tag: tagged_pcr_select.pcr_property_tag.into(),
-            sizeofSelect: tagged_pcr_select.size_of_select.into(),
+            sizeofSelect: tagged_pcr_select.size_of_select.as_u8(),
             pcrSelect: tagged_pcr_select.selected_pcrs.bits().to_le_bytes(),
         }
     }

--- a/tss-esapi/src/structures/tagged/schemes.rs
+++ b/tss-esapi/src/structures/tagged/schemes.rs
@@ -567,7 +567,7 @@ impl SignatureScheme {
     /// This is intended to provide the functionality of reading
     /// from the ```anySig``` field in the TPMU_SIG_SCHEME union.
     ///
-    /// # Error
+    /// # Errors
     /// Returns an InvalidParam error if the trying to read from
     /// SignatureScheme that is not a signing scheme.
     pub fn signing_scheme(&self) -> Result<HashingAlgorithm> {
@@ -591,7 +591,7 @@ impl SignatureScheme {
     /// This is intended to provide the functionality of writing
     /// to the ```anySig``` field in the TPMU_SIG_SCHEME union.
     ///
-    /// # Error
+    /// # Errors
     /// Returns an InvalidParam error if the trying to read from
     /// SignatureScheme that is not a signing scheme.
     pub fn set_signing_scheme(&mut self, hashing_algorithm: HashingAlgorithm) -> Result<()> {

--- a/tss-esapi/tests/integration_tests/abstraction_tests/pcr_data_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/pcr_data_tests.rs
@@ -24,7 +24,8 @@ fn test_valid_to_tpml_digest_conversion() {
                 PcrSlot::Slot7,
             ],
         )
-        .build();
+        .build()
+        .expect("Failed to create PcrSelectionList 1");
 
     let mut pcr_digest_list_1 = DigestList::new();
     for i in 0u8..8u8 {
@@ -48,7 +49,8 @@ fn test_valid_to_tpml_digest_conversion() {
                 PcrSlot::Slot15,
             ],
         )
-        .build();
+        .build()
+        .expect("Failed to create PcrSelectionList 2");
 
     let mut pcr_digest_list_2 = DigestList::new();
     for i in 8u8..16u8 {
@@ -107,7 +109,8 @@ fn test_invalid_to_tpml_digest_conversion() {
                 PcrSlot::Slot7,
             ],
         )
-        .build();
+        .build()
+        .expect("Failed to create PcrSelectionList 1");
 
     let mut pcr_digest_list_1 = DigestList::new();
     for i in 0u8..7u8 {

--- a/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
@@ -41,7 +41,8 @@ fn test_pcr_read_all() {
                 PcrSlot::Slot23,
             ],
         )
-        .build();
+        .build()
+        .expect("Failed to create PcrSelectionList for read_all call");
 
     let pcr_data = tss_esapi::abstraction::pcr::read_all(&mut context, pcr_selection_list)
         .expect("Call to pcr_read_all failed");
@@ -71,7 +72,8 @@ fn test_pcr_read_all() {
                         PcrSlot::Slot7,
                     ],
                 )
-                .build(),
+                .build()
+                .expect("Failed to create PcrSekectinList for first pcr_read call"),
         )
         .expect("Call 1 to pcr_read failed");
 
@@ -91,7 +93,8 @@ fn test_pcr_read_all() {
                         PcrSlot::Slot15,
                     ],
                 )
-                .build(),
+                .build()
+                .expect("Failed to create PcrSekectinList for second pcr_read call"),
         )
         .expect("Call 2 to pcr_read failed");
 
@@ -111,9 +114,10 @@ fn test_pcr_read_all() {
                         PcrSlot::Slot23,
                     ],
                 )
-                .build(),
+                .build()
+                .expect("Failed to create PcrSekectinList for third pcr_read call"),
         )
-        .expect("Call 2 to pcr_read failed");
+        .expect("Call 3 to pcr_read failed");
 
     vec![read_pcrs_1, read_pcrs_2, read_pcrs_3]
         .iter()

--- a/tss-esapi/tests/integration_tests/common/mod.rs
+++ b/tss-esapi/tests/integration_tests/common/mod.rs
@@ -265,7 +265,8 @@ pub fn get_pcr_policy_digest(
     // Read the pcr values using pcr_read
     let pcr_selection_list = PcrSelectionListBuilder::new()
         .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0, PcrSlot::Slot1])
-        .build();
+        .build()
+        .expect("Failed to create PcrSelectionList");
 
     let (_update_counter, pcr_selection_list_out, pcr_data) = context
         .pcr_read(pcr_selection_list.clone())

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
@@ -25,7 +25,8 @@ mod test_quote {
         // Quote PCR 0
         let pcr_selection_list = PcrSelectionListBuilder::new()
             .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0])
-            .build();
+            .build()
+            .expect("Failed to create PcrSelectionList");
         // No qualifying data
         let qualifying_data = vec![0xff; 16];
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -237,7 +237,8 @@ mod test_policy_pcr {
         // Read the pcr values using pcr_read
         let pcr_selection_list = PcrSelectionListBuilder::new()
             .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0, PcrSlot::Slot1])
-            .build();
+            .build()
+            .expect("Failed to create PcrSelectionList");
 
         let (_update_counter, pcr_selection_list_out, pcr_data) = context
             .pcr_read(pcr_selection_list.clone())
@@ -730,7 +731,8 @@ mod test_policy_get_digest {
         // Read the pcr values using pcr_read
         let pcr_selection_list = PcrSelectionListBuilder::new()
             .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0, PcrSlot::Slot1])
-            .build();
+            .build()
+            .expect("Failed to create PcrSelectionList");
 
         let trial_policy_session = PolicySession::try_from(trial_policy_auth_session)
             .expect("Failed to convert auth session into policy session");

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
@@ -25,7 +25,8 @@ mod test_pcr_extend_reset {
         let pcr_selection_list = PcrSelectionListBuilder::new()
             .with_selection(HashingAlgorithm::Sha1, &[PcrSlot::Slot16])
             .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot16])
-            .build();
+            .build()
+            .expect("Failed to create first PcrSelectionList for pcr_read call");
         // pcr_read is NO_SESSIONS
         let (_, read_pcr_selections, read_pcr_digests) = context.execute_without_session(|ctx| {
             ctx.pcr_read(pcr_selection_list.clone())
@@ -123,7 +124,8 @@ mod test_pcr_extend_reset {
         let pcr_selection_list = PcrSelectionListBuilder::new()
             .with_selection(HashingAlgorithm::Sha1, &[PcrSlot::Slot16])
             .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot16])
-            .build();
+            .build()
+            .expect("Failed to create PcrSelectionList for pcr_read call after pcr_reset");
         let pcr_data = context
             .execute_without_session(|ctx| {
                 ctx.pcr_read(pcr_selection_list).map(
@@ -158,7 +160,8 @@ mod test_pcr_read {
         // Read PCR 0
         let pcr_selection_list = PcrSelectionListBuilder::new()
             .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0])
-            .build();
+            .build()
+            .expect("Failed to create PcrSelectionList");
         let input: TPML_PCR_SELECTION = pcr_selection_list.clone().into();
         // Verify input
         assert_eq!(pcr_selection_list.len(), 1);
@@ -234,9 +237,11 @@ mod test_pcr_read {
                     PcrSlot::Slot16,
                 ],
             )
-            .build();
-        let (_update_counter, pcr_selection_list_out, _pcr_data) =
-            context.pcr_read(pcr_selection_list_in.clone()).unwrap();
+            .build()
+            .expect("Failed to create PcrSelectionList");
+        let (_update_counter, pcr_selection_list_out, _pcr_data) = context
+            .pcr_read(pcr_selection_list_in.clone())
+            .expect("pcr_read call failed");
         assert_ne!(pcr_selection_list_in, pcr_selection_list_out);
     }
 }

--- a/tss-esapi/tests/integration_tests/structures_tests/attest_info_test.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/attest_info_test.rs
@@ -55,6 +55,7 @@ fn test_quote_into_tpm_type_conversions() {
                 ],
             )
             .build()
+            .expect("Failed to createm PcrSelectionList")
             .into(),
         pcrDigest: Digest::try_from(vec![0xffu8; 32])
             .expect("Failed to create digest")

--- a/tss-esapi/tests/integration_tests/structures_tests/attest_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/attest_tests.rs
@@ -73,7 +73,8 @@ fn test_attest_with_quote_info_into_tpm_type_conversions() {
                 PcrSlot::Slot4,
             ],
         )
-        .build();
+        .build()
+        .expect("Failed to createm PcrSelectionList");
     let expected_pcr_digest = Digest::try_from(vec![0xffu8; 32]).expect("Failed to create digest");
     let expected_attest_info = AttestInfo::Quote {
         info: TPMS_QUOTE_INFO {

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/pcr_selection_list_builder_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/pcr_selection_list_builder_tests.rs
@@ -147,7 +147,7 @@ fn test_conversion_of_data_with_invalid_pcr_select_bit_flags() {
 
     assert_eq!(
         pcr_selection_list.get_selections()[0].size_of_select(),
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         "PcrSelection in index 0, in the converted pcr selection list, contained an unexpected 'size of select' value",
     );
 

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/pcr_selection_list_builder_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/pcr_selection_list_builder_tests.rs
@@ -16,7 +16,8 @@ fn test_one_selection() {
             HashingAlgorithm::Sha256,
             &[PcrSlot::Slot0, PcrSlot::Slot8, PcrSlot::Slot16],
         )
-        .build();
+        .build()
+        .expect("Failed to createm PcrSelectionList");
 
     let pcr_selection_list_size = pcr_selection_list.len();
     let actual: TPML_PCR_SELECTION = pcr_selection_list.into();
@@ -52,7 +53,8 @@ fn test_multiple_selection() {
                 PcrSlot::Slot23,
             ],
         )
-        .build();
+        .build()
+        .expect("Failed to createm PcrSelectionList");
 
     let pcr_selection_list_size = pcr_selection_list.len();
     let actual: TPML_PCR_SELECTION = pcr_selection_list.into();
@@ -87,7 +89,8 @@ fn test_multiple_conversions() {
             HashingAlgorithm::Sha256,
             &[PcrSlot::Slot0, PcrSlot::Slot8, PcrSlot::Slot16],
         )
-        .build();
+        .build()
+        .expect("Failed to create PcrSelectionList");
     let pcr_selection_list_size = pcr_selection_list.len();
     let converted: TPML_PCR_SELECTION = pcr_selection_list.into();
     assert_eq!(converted.count as usize, pcr_selection_list_size);
@@ -125,6 +128,7 @@ fn test_conversion_of_data_with_invalid_pcr_select_bit_flags() {
     let mut tpml_pcr_selection: TPML_PCR_SELECTION = PcrSelectionListBuilder::new()
         .with_selection(expected_hash_algorithm, &expected_pcr_slots)
         .build()
+        .expect("Failed to create PcrSelectionList")
         .into();
 
     // Size of select is 3 indicating that only 3 first octets
@@ -162,6 +166,7 @@ fn test_conversion_of_data_with_invalid_size_of_select() {
             &[PcrSlot::Slot0, PcrSlot::Slot8, PcrSlot::Slot16],
         )
         .build()
+        .expect("Failed to create PcrSelectionList")
         .into();
 
     // 1,2,3,4 are theonly valid values for sizeofSelect.
@@ -179,6 +184,7 @@ fn test_conversion_of_data_with_invalid_hash_alg_id() {
             &[PcrSlot::Slot0, PcrSlot::Slot8, PcrSlot::Slot16],
         )
         .build()
+        .expect("Failed to create PcrSelectionList")
         .into();
 
     // Si

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/pcr_selection_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/pcr_selection_list_tests.rs
@@ -10,33 +10,41 @@ use tss_esapi::{
 
 #[test]
 fn from_tpml_retains_order() {
-    let selection_1 = PcrSelection::new(
+    let selection_1 = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::ThreeBytes,
         &[PcrSlot::Slot10],
-    );
-    let selection_1 = TPMS_PCR_SELECTION::try_from(selection_1).unwrap();
+    )
+    .expect("Failed to create PcrSelection 1");
+    let selection_1 = TPMS_PCR_SELECTION::try_from(selection_1)
+        .expect("Failed to convert PcrSelection 1 into TPMS_PCR_SELECTION");
 
-    let selection_2 = PcrSelection::new(
+    let selection_2 = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::ThreeBytes,
         &[PcrSlot::Slot11],
-    );
-    let selection_2 = TPMS_PCR_SELECTION::try_from(selection_2).unwrap();
+    )
+    .expect("Failed to create PcrSelection 2");
+    let selection_2 = TPMS_PCR_SELECTION::try_from(selection_2)
+        .expect("Failed to convert PcrSelection 2 into TPMS_PCR_SELECTION");
 
-    let selection_3 = PcrSelection::new(
+    let selection_3 = PcrSelection::create(
         HashingAlgorithm::Sha1,
         PcrSelectSize::ThreeBytes,
         &[PcrSlot::Slot16],
-    );
-    let selection_3 = TPMS_PCR_SELECTION::try_from(selection_3).unwrap();
+    )
+    .expect("Failed to create PcrSelection 3");
+    let selection_3 = TPMS_PCR_SELECTION::try_from(selection_3)
+        .expect("Failed to convert PcrSelection 3 into TPMS_PCR_SELECTION");
 
-    let selection_4 = PcrSelection::new(
+    let selection_4 = PcrSelection::create(
         HashingAlgorithm::Sha1,
         PcrSelectSize::ThreeBytes,
         &[PcrSlot::Slot2],
-    );
-    let selection_4 = TPMS_PCR_SELECTION::try_from(selection_4).unwrap();
+    )
+    .expect("Failed to create PcrSelection 4");
+    let selection_4 = TPMS_PCR_SELECTION::try_from(selection_4)
+        .expect("Failed to convert PcrSelection 4 into TPMS_PCR_SELECTION");
 
     let tpml_selections = TPML_PCR_SELECTION {
         count: 4,
@@ -91,35 +99,43 @@ fn from_tpml_retains_order() {
 
 #[test]
 fn test_subtract() {
-    let pcr_selection_1 = PcrSelection::new(
+    let pcr_selection_1 = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::ThreeBytes,
         &[PcrSlot::Slot10],
-    );
+    )
+    .expect("Failed to create PcrSelection 1");
     let tpms_pcr_selection_1 = TPMS_PCR_SELECTION::try_from(pcr_selection_1)
-        .expect("Failed to create tpms_pcr_selection_1");
+        .expect("Failed to convert PcrSelection 1 into TPMS_PCR_SELECTION");
 
-    let pcr_selection_2 = PcrSelection::new(
+    let pcr_selection_2 = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::ThreeBytes,
         &[PcrSlot::Slot11],
-    );
+    )
+    .expect("Failed to create PcrSelection 2");
     let tpms_pcr_selection_2 = TPMS_PCR_SELECTION::try_from(pcr_selection_2)
-        .expect("Failed to create tpms_pcr_selection_2");
+        .expect("Failed to convert PcrSelection 2 into TPMS_PCR_SELECTION");
 
-    let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha1,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot16],
-    ))
-    .expect("Failed to create tpms_pcr_selection_3");
+    let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha1,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot16],
+        )
+        .expect("Failed to create PcrSelection 3"),
+    )
+    .expect("Failed to convert PcrSelection 3 into TPMS_PCR_SELECTION");
 
-    let tpms_pcr_selection_4 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha1,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot2],
-    ))
-    .expect("Failed to create tpms_pcr_selection_4");
+    let tpms_pcr_selection_4 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha1,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot2],
+        )
+        .expect("Failed to create PcrSelection 4"),
+    )
+    .expect("Failed to convert PcrSelection 4 into TPMS_PCR_SELECTION");
 
     let mut selection_list_1 = PcrSelectionList::try_from(TPML_PCR_SELECTION {
         count: 4,
@@ -188,26 +204,34 @@ fn test_subtract() {
 
 #[test]
 fn test_subtract_overlapping_without_remaining() {
-    let tpms_pcr_selection_1 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot10],
-    ))
-    .expect("Failed to create tpms_pcr_selection_1");
+    let tpms_pcr_selection_1 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha256,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot10],
+        )
+        .expect("Failed to create PcrSelection 1"),
+    )
+    .expect("Failed to convert PcrSelection 1 into TPMS_PCR_SELECTION");
+    let tpms_pcr_selection_2 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha256,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot11],
+        )
+        .expect("Failed to create PcrSelection 2"),
+    )
+    .expect("Failed to convert PcrSelection 2 into TPMS_PCR_SELECTION");
 
-    let tpms_pcr_selection_2 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot11],
-    ))
-    .expect("Failed to create tpms_pcr_selection_2");
-
-    let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot10, PcrSlot::Slot11],
-    ))
-    .expect("Failed to create tpms_pcr_selection_3");
+    let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha256,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot10, PcrSlot::Slot11],
+        )
+        .expect("Failed to create PcrSelection 3"),
+    )
+    .expect("Failed to convert PcrSelection 3 into TPMS_PCR_SELECTION");
 
     let mut selection_list_1 = PcrSelectionList::try_from(TPML_PCR_SELECTION {
         count: 2,
@@ -268,34 +292,44 @@ fn test_subtract_overlapping_without_remaining() {
 
 #[test]
 fn test_subtract_overlapping_with_remaining() {
-    let tpms_pcr_selection_1 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot10],
-    ))
-    .expect("Failed to create tpms_pcr_selection_1");
+    let tpms_pcr_selection_1 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha256,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot10],
+        )
+        .expect("Failed to create PcrSelection 1"),
+    )
+    .expect("Failed to convert PcrSelection 1 into TPMS_PCR_SELECTION");
 
-    let tpms_pcr_selection_2 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot11],
-    ))
-    .expect("Failed to create tpms_pcr_selection_2");
+    let tpms_pcr_selection_2 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha256,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot11],
+        )
+        .expect("Failed to create PcrSelection 2"),
+    )
+    .expect("Failed to convert PcrSelection 2 into TPMS_PCR_SELECTION");
 
-    let expected = PcrSelection::new(
+    let expected = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::ThreeBytes,
         &[PcrSlot::Slot12],
-    );
-    let tpms_pcr_selection_3 =
-        TPMS_PCR_SELECTION::try_from(expected).expect("Failed to create tpms_pcr_selection_2");
+    )
+    .expect("Failed to create PcrSelection 'expected'");
+    let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(expected)
+        .expect("Failed to convert PcrSelection 'expected' into TPMS_PCR_SELECTION");
 
-    let tpms_pcr_selection_4 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot10, PcrSlot::Slot11],
-    ))
-    .expect("Failed to create tpms_pcr_selection_3");
+    let tpms_pcr_selection_4 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha256,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot10, PcrSlot::Slot11],
+        )
+        .expect("Failed to create PcrSelection 4"),
+    )
+    .expect("Failed to convert PcrSelection 4 into TPMS_PCR_SELECTION");
 
     let mut selection_list_1 = PcrSelectionList::try_from(TPML_PCR_SELECTION {
         count: 3,
@@ -360,35 +394,42 @@ fn test_subtract_overlapping_with_remaining() {
 
 #[test]
 fn test_invalid_subtraction() {
-    let pcr_selection_1 = PcrSelection::new(
+    let pcr_selection_1 = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::ThreeBytes,
         &[PcrSlot::Slot10],
-    );
+    )
+    .expect("Failed to create PcrSelection 1");
     let tpms_pcr_selection_1 = TPMS_PCR_SELECTION::try_from(pcr_selection_1)
-        .expect("Failed to create tpms_pcr_selection_1");
+        .expect("Failed to convert PcrSelection 1 into TPMS_PCR_SELECTION");
 
-    let pcr_selection_2 = PcrSelection::new(
+    let pcr_selection_2 = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::ThreeBytes,
         &[PcrSlot::Slot11],
-    );
+    )
+    .expect("Failed to create PcrSelection 2");
     let tpms_pcr_selection_2 = TPMS_PCR_SELECTION::try_from(pcr_selection_2)
-        .expect("Failed to create tpms_pcr_selection_2");
+        .expect("Failed to convert PcrSelection 2 into TPMS_PCR_SELECTION");
 
-    let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha1,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot16],
-    ))
-    .expect("Failed to create tpms_pcr_selection_3");
-
-    let tpms_pcr_selection_4 = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha1,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot2],
-    ))
-    .expect("Failed to create tpms_pcr_selection_4");
+    let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha1,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot16],
+        )
+        .expect("Failed to create PcrSelection 3"),
+    )
+    .expect("Failed to convert PcrSelection 3 into TPMS_PCR_SELECTION");
+    let tpms_pcr_selection_4 = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha1,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot2],
+        )
+        .expect("Failed to create PcrSelection 4"),
+    )
+    .expect("Failed to convert PcrSelection 4 into TPMS_PCR_SELECTION");
 
     let mut selection_list_1 = PcrSelectionList::try_from(TPML_PCR_SELECTION {
         count: 2,

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/pcr_selection_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/pcr_selection_list_tests.rs
@@ -12,7 +12,7 @@ use tss_esapi::{
 fn from_tpml_retains_order() {
     let selection_1 = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[PcrSlot::Slot10],
     )
     .expect("Failed to create PcrSelection 1");
@@ -21,7 +21,7 @@ fn from_tpml_retains_order() {
 
     let selection_2 = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[PcrSlot::Slot11],
     )
     .expect("Failed to create PcrSelection 2");
@@ -30,7 +30,7 @@ fn from_tpml_retains_order() {
 
     let selection_3 = PcrSelection::create(
         HashingAlgorithm::Sha1,
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[PcrSlot::Slot16],
     )
     .expect("Failed to create PcrSelection 3");
@@ -39,7 +39,7 @@ fn from_tpml_retains_order() {
 
     let selection_4 = PcrSelection::create(
         HashingAlgorithm::Sha1,
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[PcrSlot::Slot2],
     )
     .expect("Failed to create PcrSelection 4");
@@ -101,7 +101,7 @@ fn from_tpml_retains_order() {
 fn test_subtract() {
     let pcr_selection_1 = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[PcrSlot::Slot10],
     )
     .expect("Failed to create PcrSelection 1");
@@ -110,7 +110,7 @@ fn test_subtract() {
 
     let pcr_selection_2 = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[PcrSlot::Slot11],
     )
     .expect("Failed to create PcrSelection 2");
@@ -120,7 +120,7 @@ fn test_subtract() {
     let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha1,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot16],
         )
         .expect("Failed to create PcrSelection 3"),
@@ -130,7 +130,7 @@ fn test_subtract() {
     let tpms_pcr_selection_4 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha1,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot2],
         )
         .expect("Failed to create PcrSelection 4"),
@@ -207,7 +207,7 @@ fn test_subtract_overlapping_without_remaining() {
     let tpms_pcr_selection_1 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha256,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot10],
         )
         .expect("Failed to create PcrSelection 1"),
@@ -216,7 +216,7 @@ fn test_subtract_overlapping_without_remaining() {
     let tpms_pcr_selection_2 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha256,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot11],
         )
         .expect("Failed to create PcrSelection 2"),
@@ -226,7 +226,7 @@ fn test_subtract_overlapping_without_remaining() {
     let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha256,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot10, PcrSlot::Slot11],
         )
         .expect("Failed to create PcrSelection 3"),
@@ -295,7 +295,7 @@ fn test_subtract_overlapping_with_remaining() {
     let tpms_pcr_selection_1 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha256,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot10],
         )
         .expect("Failed to create PcrSelection 1"),
@@ -305,7 +305,7 @@ fn test_subtract_overlapping_with_remaining() {
     let tpms_pcr_selection_2 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha256,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot11],
         )
         .expect("Failed to create PcrSelection 2"),
@@ -314,7 +314,7 @@ fn test_subtract_overlapping_with_remaining() {
 
     let expected = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[PcrSlot::Slot12],
     )
     .expect("Failed to create PcrSelection 'expected'");
@@ -324,7 +324,7 @@ fn test_subtract_overlapping_with_remaining() {
     let tpms_pcr_selection_4 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha256,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot10, PcrSlot::Slot11],
         )
         .expect("Failed to create PcrSelection 4"),
@@ -396,7 +396,7 @@ fn test_subtract_overlapping_with_remaining() {
 fn test_invalid_subtraction() {
     let pcr_selection_1 = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[PcrSlot::Slot10],
     )
     .expect("Failed to create PcrSelection 1");
@@ -405,7 +405,7 @@ fn test_invalid_subtraction() {
 
     let pcr_selection_2 = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[PcrSlot::Slot11],
     )
     .expect("Failed to create PcrSelection 2");
@@ -415,7 +415,7 @@ fn test_invalid_subtraction() {
     let tpms_pcr_selection_3 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha1,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot16],
         )
         .expect("Failed to create PcrSelection 3"),
@@ -424,7 +424,7 @@ fn test_invalid_subtraction() {
     let tpms_pcr_selection_4 = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha1,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot2],
         )
         .expect("Failed to create PcrSelection 4"),

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/tagged_pcr_property_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/tagged_pcr_property_list_tests.rs
@@ -13,19 +13,19 @@ fn test_valid_conversions() {
     let expected_tagged_pcr_properties = vec![
         TaggedPcrSelect::create(
             PcrPropertyTag::Auth,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot1, PcrSlot::Slot8, PcrSlot::Slot17],
         )
         .expect("Failed to create TaggedPcrSelect 1"),
         TaggedPcrSelect::create(
             PcrPropertyTag::DrtmReset,
-            PcrSelectSize::TwoBytes,
+            PcrSelectSize::TwoOctets,
             &[PcrSlot::Slot2, PcrSlot::Slot9],
         )
         .expect("Failed to create TaggedPcrSelect 2"),
         TaggedPcrSelect::create(
             PcrPropertyTag::ExtendL0,
-            PcrSelectSize::OneByte,
+            PcrSelectSize::OneOctet,
             &[
                 PcrSlot::Slot4,
                 PcrSlot::Slot5,

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/tagged_pcr_property_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/tagged_pcr_property_list_tests.rs
@@ -11,17 +11,19 @@ use tss_esapi::{
 #[test]
 fn test_valid_conversions() {
     let expected_tagged_pcr_properties = vec![
-        TaggedPcrSelect::new(
+        TaggedPcrSelect::create(
             PcrPropertyTag::Auth,
             PcrSelectSize::ThreeBytes,
             &[PcrSlot::Slot1, PcrSlot::Slot8, PcrSlot::Slot17],
-        ),
-        TaggedPcrSelect::new(
+        )
+        .expect("Failed to create TaggedPcrSelect 1"),
+        TaggedPcrSelect::create(
             PcrPropertyTag::DrtmReset,
             PcrSelectSize::TwoBytes,
             &[PcrSlot::Slot2, PcrSlot::Slot9],
-        ),
-        TaggedPcrSelect::new(
+        )
+        .expect("Failed to create TaggedPcrSelect 2"),
+        TaggedPcrSelect::create(
             PcrPropertyTag::ExtendL0,
             PcrSelectSize::OneByte,
             &[
@@ -30,7 +32,8 @@ fn test_valid_conversions() {
                 PcrSlot::Slot6,
                 PcrSlot::Slot7,
             ],
-        ),
+        )
+        .expect("Failed to create TaggedPcrSelect 3"),
     ];
 
     let expected_tpml_tagged_pcr_property: TPML_TAGGED_PCR_PROPERTY =

--- a/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_select_size_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_select_size_tests.rs
@@ -6,36 +6,87 @@ use tss_esapi::{structures::PcrSelectSize, Error, WrapperErrorKind};
 
 macro_rules! test_valid_conversions {
     (PcrSelectSize::$expected:ident, $value:expr) => {
-        let expected_u8: u8 = $value;
-        let expected_usize: usize = $value;
-
-        let actual = PcrSelectSize::try_from(expected_u8).expect(&format!(
-            "Failed to convert {} to PcrSelectSize",
-            expected_u8
-        ));
+        let expected_u8 = $value;
+        let expected_u32 = $value;
+        let expected_usize = $value;
 
         assert_eq!(
-            PcrSelectSize::$expected,
-            actual,
-            "PcrSelectSize converted from {} did not match the expected value {}",
             expected_u8,
+            PcrSelectSize::$expected.as_u8(),
+            "The PcrSelectSize as_u8() method for {} did not give the expected u8 value {}",
             stringify!(PcrSelectSize::$expected),
+            expected_u8
         );
 
         assert_eq!(
-            expected_u8,
-            u8::from(actual),
-            "PcrSelectSize {} did not convert to the expected u8 value {}",
+            expected_u32,
+            PcrSelectSize::$expected.as_u32(),
+            "The PcrSelectSize as_u32() method for {} did not give the expected u32 value {}",
             stringify!(PcrSelectSize::$expected),
-            expected_u8
+            expected_u32
         );
 
         assert_eq!(
             expected_usize,
-            usize::from(actual),
-            "PcrSelectSize {} did not convert to the expected usize value {}",
+            PcrSelectSize::$expected.as_usize(),
+            "The PcrSelectSize as_usize() method for {} did not give the expected usize value {}",
             stringify!(PcrSelectSize::$expected),
             expected_usize
+        );
+
+        assert_eq!(
+            PcrSelectSize::$expected,
+            PcrSelectSize::try_parse_u8(expected_u8).expect(&format!(
+                "try_parse_u8 failed to parse value {}",
+                expected_u8
+            )),
+            "The u8 value {} did not get parsed as the expected {}",
+            expected_u8,
+            stringify!(PcrSelectSize::$expected),
+        );
+
+        assert_eq!(
+            PcrSelectSize::$expected,
+            PcrSelectSize::try_parse_u32(expected_u32).expect(&format!(
+                "try_parse_u32 failed to parse value {}",
+                expected_u32
+            )),
+            "The u32 value {} did not get parsed as the expected {}",
+            expected_u32,
+            stringify!(PcrSelectSize::$expected),
+        );
+
+        assert_eq!(
+            PcrSelectSize::$expected,
+            PcrSelectSize::try_parse_usize(expected_usize).expect(&format!(
+                "try_parse_usize failed to parse value {}",
+                expected_usize
+            )),
+            "The usize value {} did not get parsed as the expected {}",
+            expected_u32,
+            stringify!(PcrSelectSize::$expected),
+        );
+
+        assert_eq!(
+            PcrSelectSize::$expected,
+            PcrSelectSize::try_from(expected_u8).expect(&format!(
+                "Failed to convert u8 value {} to a PcrSelectSize",
+                expected_u8
+            )),
+            "The value {} did not get converted into the expected {}",
+            expected_u8,
+            stringify!(PcrSelectSize::$expected),
+        );
+
+        assert_eq!(
+            expected_u8,
+            u8::try_from(PcrSelectSize::$expected).expect(&format!(
+                "Failed to convert {} to u8 value",
+                stringify!(PcrSelectSize::$expected)
+            )),
+            "{} did not get converted into the expected u8 value {}",
+            stringify!(PcrSelectSize::$expected),
+            expected_u8,
         );
     };
 }

--- a/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_select_size_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_select_size_tests.rs
@@ -93,10 +93,10 @@ macro_rules! test_valid_conversions {
 
 #[test]
 fn test_valid_conversions() {
-    test_valid_conversions!(PcrSelectSize::OneByte, 1);
-    test_valid_conversions!(PcrSelectSize::TwoBytes, 2);
-    test_valid_conversions!(PcrSelectSize::ThreeBytes, 3);
-    test_valid_conversions!(PcrSelectSize::FourBytes, 4);
+    test_valid_conversions!(PcrSelectSize::OneOctet, 1);
+    test_valid_conversions!(PcrSelectSize::TwoOctets, 2);
+    test_valid_conversions!(PcrSelectSize::ThreeOctets, 3);
+    test_valid_conversions!(PcrSelectSize::FourOctets, 4);
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn test_default() {
     // The default valuen should be the value that
     // works on most platforms i.e. three octets.
     assert_eq!(
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         PcrSelectSize::default(),
         "PcrSelectSize did not have the expected default value",
     );

--- a/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_select_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_select_tests.rs
@@ -9,7 +9,7 @@ use tss_esapi::{
 #[test]
 fn test_conversion_to_tss_pcr_select() {
     let actual = TPMS_PCR_SELECT::try_from(
-        PcrSelect::create(PcrSelectSize::TwoBytes, &[PcrSlot::Slot0, PcrSlot::Slot8])
+        PcrSelect::create(PcrSelectSize::TwoOctets, &[PcrSlot::Slot0, PcrSlot::Slot8])
             .expect("Failed to create PcrSelect"),
     )
     .expect("Failed to convert PcrSelect into TPMS_PCR_SELECT");
@@ -31,7 +31,7 @@ fn test_size_of_select_handling() {
     // Size of select is 3 so no values set in the fourth
     // octet should be present.
     let expected = PcrSelect::create(
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[
             PcrSlot::Slot1,
             PcrSlot::Slot8,
@@ -51,7 +51,7 @@ fn test_conversion_from_tss_pcr_select() {
     })
     .unwrap();
     let expected = PcrSelect::create(
-        PcrSelectSize::ThreeBytes,
+        PcrSelectSize::ThreeOctets,
         &[
             PcrSlot::Slot1,
             PcrSlot::Slot8,

--- a/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_select_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_select_tests.rs
@@ -8,11 +8,11 @@ use tss_esapi::{
 
 #[test]
 fn test_conversion_to_tss_pcr_select() {
-    let actual = TPMS_PCR_SELECT::try_from(PcrSelect::new(
-        PcrSelectSize::TwoBytes,
-        &[PcrSlot::Slot0, PcrSlot::Slot8],
-    ))
-    .unwrap();
+    let actual = TPMS_PCR_SELECT::try_from(
+        PcrSelect::create(PcrSelectSize::TwoBytes, &[PcrSlot::Slot0, PcrSlot::Slot8])
+            .expect("Failed to create PcrSelect"),
+    )
+    .expect("Failed to convert PcrSelect into TPMS_PCR_SELECT");
     let expected = TPMS_PCR_SELECT {
         sizeofSelect: 2,
         pcrSelect: [1, 1, 0, 0],
@@ -30,7 +30,7 @@ fn test_size_of_select_handling() {
     .expect("Failed to convert TPMS_PCR_SELECT to PcrSelect");
     // Size of select is 3 so no values set in the fourth
     // octet should be present.
-    let expected = PcrSelect::new(
+    let expected = PcrSelect::create(
         PcrSelectSize::ThreeBytes,
         &[
             PcrSlot::Slot1,
@@ -38,7 +38,8 @@ fn test_size_of_select_handling() {
             PcrSlot::Slot16,
             PcrSlot::Slot17,
         ],
-    );
+    )
+    .expect("Failed to create PcrSelect");
     assert_eq!(expected, actual);
 }
 
@@ -49,7 +50,7 @@ fn test_conversion_from_tss_pcr_select() {
         pcrSelect: [2, 1, 3, 0],
     })
     .unwrap();
-    let expected = PcrSelect::new(
+    let expected = PcrSelect::create(
         PcrSelectSize::ThreeBytes,
         &[
             PcrSlot::Slot1,
@@ -57,6 +58,7 @@ fn test_conversion_from_tss_pcr_select() {
             PcrSlot::Slot16,
             PcrSlot::Slot17,
         ],
-    );
+    )
+    .expect("Failed to create PcrSelect");
     assert_eq!(expected, actual);
 }

--- a/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_selection_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_selection_tests.rs
@@ -10,12 +10,15 @@ use tss_esapi::{
 
 #[test]
 fn test_conversion_to_tss_pcr_selection() {
-    let actual = TPMS_PCR_SELECTION::try_from(PcrSelection::new(
-        HashingAlgorithm::Sha512,
-        PcrSelectSize::ThreeBytes,
-        &[PcrSlot::Slot3, PcrSlot::Slot9, PcrSlot::Slot23],
-    ))
-    .unwrap();
+    let actual = TPMS_PCR_SELECTION::try_from(
+        PcrSelection::create(
+            HashingAlgorithm::Sha512,
+            PcrSelectSize::ThreeBytes,
+            &[PcrSlot::Slot3, PcrSlot::Slot9, PcrSlot::Slot23],
+        )
+        .expect("Failed to create pcr selection"),
+    )
+    .expect("Failed to convert PcrSelection to TPMS_PCR_SELECTION");
     let expected = TPMS_PCR_SELECTION {
         hash: TPM2_ALG_SHA512,
         sizeofSelect: 3,
@@ -34,11 +37,12 @@ fn test_conversion_from_tss_pcr_selection() {
         pcrSelect: [16, 128, 0, 0],
     })
     .unwrap();
-    let expected = PcrSelection::new(
+    let expected = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::TwoBytes,
         &[PcrSlot::Slot4, PcrSlot::Slot15],
-    );
+    )
+    .expect("Failed to create pcr selection");
     assert_eq!(expected, actual);
 }
 
@@ -54,30 +58,33 @@ fn test_size_of_select_handling() {
     // Size of select is 2 so the values in octet 3 and 4
     // should not appear in the converted pcr selection.
 
-    let expected = PcrSelection::new(
+    let expected = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::TwoBytes,
         &[PcrSlot::Slot4, PcrSlot::Slot15],
-    );
+    )
+    .expect("Failed to create PcrSelection");
     assert_eq!(expected, actual);
 }
 
 #[test]
 fn test_subtract() {
-    let mut pcr_select_1 = PcrSelection::new(
+    let mut pcr_select_1 = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::TwoBytes,
         &[PcrSlot::Slot4, PcrSlot::Slot15],
-    );
+    )
+    .expect("Failed to create PcrSelect pcr_select_1");
 
-    let pcr_select_2 = PcrSelection::new(
+    let pcr_select_2 = PcrSelection::create(
         HashingAlgorithm::Sha256,
         PcrSelectSize::TwoBytes,
         &[PcrSlot::Slot4],
-    );
+    )
+    .expect("Failed to create PcrSelect pcr_select_2");
 
     pcr_select_1
-        .subtract(&pcr_select_2)
+        .subtract_exact(&pcr_select_2)
         .expect("Failed to subtract pcr_select_2 from pcr_select_1");
 
     assert_eq!(

--- a/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_selection_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/pcr_tests/pcr_selection_tests.rs
@@ -13,7 +13,7 @@ fn test_conversion_to_tss_pcr_selection() {
     let actual = TPMS_PCR_SELECTION::try_from(
         PcrSelection::create(
             HashingAlgorithm::Sha512,
-            PcrSelectSize::ThreeBytes,
+            PcrSelectSize::ThreeOctets,
             &[PcrSlot::Slot3, PcrSlot::Slot9, PcrSlot::Slot23],
         )
         .expect("Failed to create pcr selection"),
@@ -39,7 +39,7 @@ fn test_conversion_from_tss_pcr_selection() {
     .unwrap();
     let expected = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::TwoBytes,
+        PcrSelectSize::TwoOctets,
         &[PcrSlot::Slot4, PcrSlot::Slot15],
     )
     .expect("Failed to create pcr selection");
@@ -60,7 +60,7 @@ fn test_size_of_select_handling() {
 
     let expected = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::TwoBytes,
+        PcrSelectSize::TwoOctets,
         &[PcrSlot::Slot4, PcrSlot::Slot15],
     )
     .expect("Failed to create PcrSelection");
@@ -71,14 +71,14 @@ fn test_size_of_select_handling() {
 fn test_subtract() {
     let mut pcr_select_1 = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::TwoBytes,
+        PcrSelectSize::TwoOctets,
         &[PcrSlot::Slot4, PcrSlot::Slot15],
     )
     .expect("Failed to create PcrSelect pcr_select_1");
 
     let pcr_select_2 = PcrSelection::create(
         HashingAlgorithm::Sha256,
-        PcrSelectSize::TwoBytes,
+        PcrSelectSize::TwoOctets,
         &[PcrSlot::Slot4],
     )
     .expect("Failed to create PcrSelect pcr_select_2");
@@ -95,7 +95,7 @@ fn test_subtract() {
 
     assert_eq!(
         pcr_select_1.size_of_select(),
-        PcrSelectSize::TwoBytes,
+        PcrSelectSize::TwoOctets,
         "The pcr_select_1 did not have the expected size of select after subtract"
     );
 

--- a/tss-esapi/tests/integration_tests/structures_tests/quote_info_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/quote_info_tests.rs
@@ -20,7 +20,8 @@ fn test_conversion() {
                 PcrSlot::Slot4,
             ],
         )
-        .build();
+        .build()
+        .expect("Failed to pcr selection list");
     let expected_pcr_digest = Digest::try_from(vec![0xffu8; 32]).expect("Failed to create digest");
     let expected_tpms_quote_info = TPMS_QUOTE_INFO {
         pcrSelect: expected_pcr_selection.clone().into(),

--- a/tss-esapi/tests/integration_tests/structures_tests/tagged_pcr_select_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/tagged_pcr_select_tests.rs
@@ -20,7 +20,7 @@ fn test_conversions() {
 
     let expected_tpms_tagged_pcr_select = TPMS_TAGGED_PCR_SELECT {
         tag: expected_pcr_property_tag.into(),
-        sizeofSelect: expected_size_of_select.into(),
+        sizeofSelect: expected_size_of_select.as_u8(),
         pcrSelect: [2, 1, 3, 0],
     };
 

--- a/tss-esapi/tests/integration_tests/structures_tests/tagged_pcr_select_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/tagged_pcr_select_tests.rs
@@ -10,7 +10,7 @@ use tss_esapi::{
 #[test]
 fn test_conversions() {
     let expected_pcr_property_tag = PcrPropertyTag::ExtendL0;
-    let expected_size_of_select = PcrSelectSize::ThreeBytes;
+    let expected_size_of_select = PcrSelectSize::ThreeOctets;
     let expected_pcr_slots = vec![
         PcrSlot::Slot1,
         PcrSlot::Slot8,


### PR DESCRIPTION
- Fixes issue that allowed a 'size_of_select' greater then ```TPM2_PCR_SELECT_MAX```.

- Increases the number of PcrSlots to 32 in order to match ```PcrSelectSize```.

- Adds the PcrSlotCollection internal type. This type is used to handle operations that involves 'sizeOfSelect' and 'pcrSelect' because the ```TPMS_TAGGED_PCR_SELECT``` and ```TPMS_PCR_SELECTION``` are not specified to be implemented using ```TPMS_PCR_SELECT```. So an internal type that handles the operations all of these types are conducting was needed.

- Changes the suffixes of the items in PcrSelectSize from 'bytes' to 'octets'.