### PR TITLE
Allow customizing AK public

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "7.0.0-beta.1"
+version = "7.0.0-beta.2"
 authors = ["Parsec Project Contributors"]
 edition = "2018"
 description = "Rust-native wrapper around TSS 2.0 Enhanced System API"

--- a/tss-esapi/src/constants/ecc.rs
+++ b/tss-esapi/src/constants/ecc.rs
@@ -17,7 +17,7 @@ use std::convert::TryFrom;
 ///
 /// # Details
 /// This corresponds to `TPM2_ECC_CURVE`
-#[derive(FromPrimitive, ToPrimitive, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(FromPrimitive, ToPrimitive, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(u16)]
 pub enum EccCurveIdentifier {
     NistP192 = TPM2_ECC_NIST_P192,


### PR DESCRIPTION
Following feedback from #322, this reintroduces customization for AK
public objects in the abstraction layer.
`Hash` is also added to the derive list of `EccCurveIdentifier`.

Fixes #322 
cc @rshearman 