### PR TITLE
Fix broken link in docs

### DIFF
--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -121,8 +121,8 @@ impl Context {
     /// The provided [PcrSelectionList] contains the pcr slots in the different
     /// banks that is going to be read. It is possible to select more pcr slots
     /// then what will fit in the returned result so the method returns a [PcrSelectionList]
-    /// that indicates what values that was read. The values that was read are returned
-    /// in the [PcrData].
+    /// that indicates what values were read. The values that were read are returned
+    /// in a [DigestList].
     ///
     /// # Errors
     /// * Several different errors can occur if conversion of return


### PR DESCRIPTION
I caught this just before releasing the 7.0.0 version. I'm surprised the build worked for 7.0.0-beta

Since it's a doc change, I won't bother with releasing another beta.