### PR TITLE
Remove RSA primality test

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -23,7 +23,6 @@ hostname-validator = "1.1.0"
 regex = "1.3.9"
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.3.0" }
-primal = "0.3.0"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/tss-esapi/src/structures/tagged/public/rsa.rs
+++ b/tss-esapi/src/structures/tagged/public/rsa.rs
@@ -232,17 +232,13 @@ impl RsaExponent {
 
     /// Function for creating a new RsaExponent
     ///
+    /// # Warning
+    /// Will not check whether the value is a valid exponent for RSA.
+    ///
     /// # Errors
     /// Will return an error if the value passed into the function
     /// is not a valid RSA exponent.
     pub fn create(value: u32) -> Result<Self> {
-        if !RsaExponent::is_valid(value) {
-            error!(
-                "Received invalid value {} when creating rsa exponent",
-                value,
-            );
-            return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
-        }
         Ok(RsaExponent { value })
     }
 
@@ -251,9 +247,9 @@ impl RsaExponent {
         self.value
     }
 
-    /// Function for checking if a value is valid rsa exponent.
-    pub fn is_valid(value: u32) -> bool {
-        (value > 2 && primal::is_prime(value.into())) || value == 0
+    /// No-op. Does not check whether the value is a valid exponent for RSA.
+    pub fn is_valid(_: u32) -> bool {
+        true
     }
 }
 
@@ -267,17 +263,9 @@ impl TryFrom<UINT32> for RsaExponent {
     type Error = Error;
 
     fn try_from(tpm_uint32_value: UINT32) -> Result<Self> {
-        if RsaExponent::is_valid(tpm_uint32_value) {
-            Ok(RsaExponent {
-                value: tpm_uint32_value,
-            })
-        } else {
-            error!(
-                "Received invalid rsa exponent value {}, from the TPM",
-                tpm_uint32_value,
-            );
-            Err(Error::WrapperError(WrapperErrorKind::WrongValueFromTpm))
-        }
+        Ok(RsaExponent {
+            value: tpm_uint32_value,
+        })
     }
 }
 

--- a/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/public_rsa_exponent_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/public_rsa_exponent_tests.rs
@@ -1,22 +1,6 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use tss_esapi::{structures::RsaExponent, Error, WrapperErrorKind};
-#[test]
-fn rsa_exponent_create_test() {
-    let expected_error = Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
-    // Valid values for RsaExponent are only 0 or a prime number value larger then 2.
-    assert_eq!(expected_error, RsaExponent::create(1));
-
-    // The specification says that 0 or any prime number larger then 2 should be accepted.
-    let _ = RsaExponent::create(0).expect("Failed to create a RsaExponent from the value 0");
-    let _ = RsaExponent::create(5).expect("Failed to create a RsaExponent from the value 5");
-}
-
-#[test]
-fn rsa_exponent_is_valid_test() {
-    assert!(!RsaExponent::is_valid(1));
-    assert!(RsaExponent::is_valid(17));
-}
+use tss_esapi::structures::RsaExponent;
 
 #[test]
 fn rsa_exponent_value_test() {


### PR DESCRIPTION
The "primal" dependency adds a whole slew of other dependencies, which
makes packaging tss-esapi 7.0 in Linux distributions quite difficult.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>