### PR TITLE
Implement ref conversions from TKC to Context

### DIFF
--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -37,7 +37,7 @@ use crate::{
 use log::error;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
+use std::convert::{AsMut, AsRef, TryFrom, TryInto};
 use zeroize::Zeroize;
 
 mod key_attestation;
@@ -525,6 +525,18 @@ impl TransientKeyContext {
     /// Get a builder for the structure
     pub fn builder() -> TransientKeyContextBuilder {
         TransientKeyContextBuilder::new()
+    }
+}
+
+impl AsRef<Context> for TransientKeyContext {
+    fn as_ref(&self) -> &Context {
+        &self.context
+    }
+}
+
+impl AsMut<Context> for TransientKeyContext {
+    fn as_mut(&mut self) -> &mut Context {
+        &mut self.context
     }
 }
 

--- a/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
@@ -852,3 +852,13 @@ fn activate_credential_wrong_data() {
         panic!("Got crate error ({}) when expecting an error from TPM.", e);
     }
 }
+
+#[test]
+fn get_random_from_tkc() {
+    // Check that we can convert a reference from TKC to Context
+    let mut ctx = create_ctx();
+    let _rand_bytes = ctx
+        .as_mut()
+        .execute_without_session(|ctx| ctx.get_random(16))
+        .expect("Failed to get random bytes");
+}


### PR DESCRIPTION
Adding a way to call methods straight on the wrapped context of
a `TransientKeyContext` by implementing `AsRef` and `AsMut` to
`Context`.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>