### PR TITLE
Fixes potential memory leaks from the ffi types.

### DIFF
--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -388,25 +388,25 @@ impl Context {
             .unwrap() // will only fail if called from Drop after .take()
     }
 
-    /// Internal function for retrieving the ESYS session handle for
+    /// Private method for retrieving the ESYS session handle for
     /// the optional session 1.
     fn optional_session_1(&self) -> ESYS_TR {
         SessionHandle::from(self.sessions.0).into()
     }
 
-    /// Internal function for retrieving the ESYS session handle for
+    /// Private method for retrieving the ESYS session handle for
     /// the optional session 2.
     fn optional_session_2(&self) -> ESYS_TR {
         SessionHandle::from(self.sessions.1).into()
     }
 
-    /// Internal function for retrieving the ESYS session handle for
+    /// Private method for retrieving the ESYS session handle for
     /// the optional session 3.
     fn optional_session_3(&self) -> ESYS_TR {
         SessionHandle::from(self.sessions.2).into()
     }
 
-    /// Function that returns the required
+    /// Private method that returns the required
     /// session handle 1 if it is available else
     /// returns an error.
     fn required_session_1(&self) -> Result<ESYS_TR> {
@@ -419,7 +419,7 @@ impl Context {
             })
     }
 
-    /// Function that returns the required
+    /// Private method that returns the required
     /// session handle 2 if it is available else
     /// returns an error.
     fn required_session_2(&self) -> Result<ESYS_TR> {

--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -431,6 +431,12 @@ impl Context {
                 Error::local_error(ErrorKind::MissingAuthSession)
             })
     }
+
+    /// Private function for handling that has been allocated with
+    /// C memory allocation functions in TSS.
+    fn ffi_data_to_owned<T>(data_ptr: *mut T) -> T {
+        MBox::into_inner(unsafe { MBox::from_raw(data_ptr) })
+    }
 }
 
 impl Drop for Context {

--- a/tss-esapi/src/context/general_esys_tr.rs
+++ b/tss-esapi/src/context/general_esys_tr.rs
@@ -6,10 +6,7 @@ use crate::{
     handles::{handle_conversion::TryIntoNotNone, TpmHandle},
     structures::Auth,
     structures::Name,
-    tss2_esys::{
-        Esys_TR_Close, Esys_TR_FromTPMPublic, Esys_TR_GetName, Esys_TR_SetAuth, ESYS_TR,
-        ESYS_TR_NONE, TPM2B_NAME,
-    },
+    tss2_esys::{Esys_TR_Close, Esys_TR_FromTPMPublic, Esys_TR_GetName, Esys_TR_SetAuth},
     Context, Error, Result,
 };
 use log::error;
@@ -21,9 +18,9 @@ use zeroize::Zeroize;
 impl Context {
     /// Set the authentication value for a given object handle in the ESYS context.
     pub fn tr_set_auth(&mut self, object_handle: ObjectHandle, auth: Auth) -> Result<()> {
-        let mut tss_auth = auth.into();
-        let ret = unsafe { Esys_TR_SetAuth(self.mut_context(), object_handle.into(), &tss_auth) };
-        tss_auth.buffer.zeroize();
+        let mut auth_value = auth.into();
+        let ret = unsafe { Esys_TR_SetAuth(self.mut_context(), object_handle.into(), &auth_value) };
+        auth_value.buffer.zeroize();
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
             Ok(())
@@ -35,12 +32,13 @@ impl Context {
 
     /// Retrieve the name of an object from the object handle
     pub fn tr_get_name(&mut self, object_handle: ObjectHandle) -> Result<Name> {
-        let mut name = null_mut();
-        let ret = unsafe { Esys_TR_GetName(self.mut_context(), object_handle.into(), &mut name) };
+        let mut name_ptr = null_mut();
+        let ret =
+            unsafe { Esys_TR_GetName(self.mut_context(), object_handle.into(), &mut name_ptr) };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let tss_name = unsafe { MBox::<TPM2B_NAME>::from_raw(name) };
-            Ok(Name::try_from(*tss_name)?)
+            let name = unsafe { MBox::from_raw(name_ptr) };
+            Ok(Name::try_from(*name)?)
         } else {
             error!("Error in getting name: {}", ret);
             Err(ret)
@@ -49,7 +47,7 @@ impl Context {
 
     /// Used to construct an esys object from the resources inside the TPM.
     pub fn tr_from_tpm_public(&mut self, tpm_handle: TpmHandle) -> Result<ObjectHandle> {
-        let mut esys_object_handle: ESYS_TR = ESYS_TR_NONE;
+        let mut object = ObjectHandle::None.into();
         let ret = unsafe {
             Esys_TR_FromTPMPublic(
                 self.mut_context(),
@@ -57,21 +55,20 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &mut esys_object_handle,
+                &mut object,
             )
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let object_handle = ObjectHandle::from(esys_object_handle);
             self.handle_manager.add_handle(
-                object_handle,
+                object.into(),
                 if tpm_handle.may_be_flushed() {
                     HandleDropAction::Flush
                 } else {
                     HandleDropAction::Close
                 },
             )?;
-            Ok(object_handle)
+            Ok(object.into())
         } else {
             error!("Error when getting ESYS handle from TPM handle: {}", ret);
             Err(ret)
@@ -82,12 +79,12 @@ impl Context {
     ///
     /// This is useful for cleaning up handles for which the context cannot be flushed.
     pub fn tr_close(&mut self, object_handle: &mut ObjectHandle) -> Result<()> {
-        let mut tss_esys_object_handle = object_handle.try_into_not_none()?;
-        let ret = unsafe { Esys_TR_Close(self.mut_context(), &mut tss_esys_object_handle) };
+        let mut rsrc_handle = object_handle.try_into_not_none()?;
+        let ret = unsafe { Esys_TR_Close(self.mut_context(), &mut rsrc_handle) };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
             self.handle_manager.set_as_closed(*object_handle)?;
-            *object_handle = ObjectHandle::from(tss_esys_object_handle);
+            *object_handle = ObjectHandle::from(rsrc_handle);
             Ok(())
         } else {
             error!("Error when closing an ESYS handle: {}", ret);

--- a/tss-esapi/src/context/general_esys_tr.rs
+++ b/tss-esapi/src/context/general_esys_tr.rs
@@ -10,7 +10,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::TryFrom;
 use std::ptr::null_mut;
 use zeroize::Zeroize;
@@ -37,8 +36,7 @@ impl Context {
             unsafe { Esys_TR_GetName(self.mut_context(), object_handle.into(), &mut name_ptr) };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let name = unsafe { MBox::from_raw(name_ptr) };
-            Ok(Name::try_from(*name)?)
+            Name::try_from(Context::ffi_data_to_owned(name_ptr))
         } else {
             error!("Error in getting name: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/session_administration.rs
+++ b/tss-esapi/src/context/session_administration.rs
@@ -4,7 +4,7 @@ use crate::{
     attributes::{SessionAttributes, SessionAttributesMask},
     handles::SessionHandle,
     interface_types::session_handles::AuthSession,
-    tss2_esys::{Esys_TRSess_GetAttributes, Esys_TRSess_SetAttributes, TPMA_SESSION},
+    tss2_esys::{Esys_TRSess_GetAttributes, Esys_TRSess_SetAttributes},
     Context, Error, Result,
 };
 use log::error;
@@ -36,7 +36,7 @@ impl Context {
 
     /// Get session attribute flags.
     pub fn tr_sess_get_attributes(&mut self, session: AuthSession) -> Result<SessionAttributes> {
-        let mut flags: TPMA_SESSION = 0;
+        let mut flags = 0;
         let ret = unsafe {
             Esys_TRSess_GetAttributes(
                 self.mut_context(),

--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -7,7 +7,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::TryFrom;
 use std::ptr::null_mut;
 
@@ -142,11 +141,11 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let certify_info = unsafe { MBox::from_raw(certify_info_ptr) };
-            let signature = unsafe { MBox::from_raw(signature_ptr) };
+            let certify_info = Context::ffi_data_to_owned(certify_info_ptr);
+            let signature = Context::ffi_data_to_owned(signature_ptr);
             Ok((
-                Attest::try_from(AttestBuffer::try_from(*certify_info)?)?,
-                Signature::try_from(*signature)?,
+                Attest::try_from(AttestBuffer::try_from(certify_info)?)?,
+                Signature::try_from(signature)?,
             ))
         } else {
             error!("Error in certifying: {}", ret);
@@ -186,11 +185,11 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let quoted = unsafe { MBox::from_raw(quoted_ptr) };
-            let signature = unsafe { MBox::from_raw(signature_ptr) };
+            let quoted = Context::ffi_data_to_owned(quoted_ptr);
+            let signature = Context::ffi_data_to_owned(signature_ptr);
             Ok((
-                Attest::try_from(AttestBuffer::try_from(*quoted)?)?,
-                Signature::try_from(*signature)?,
+                Attest::try_from(AttestBuffer::try_from(quoted)?)?,
+                Signature::try_from(signature)?,
             ))
         } else {
             error!("Error in quoting PCR: {}", ret);

--- a/tss-esapi/src/context/tpm_commands/capability_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/capability_commands.rs
@@ -8,7 +8,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::{error, warn};
-use mbox::MBox;
 use std::convert::TryFrom;
 use std::ptr::null_mut;
 
@@ -66,9 +65,10 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let capability_data = unsafe { MBox::from_raw(capability_data_ptr) };
-            let capabilities = CapabilityData::try_from(*capability_data)?;
-            Ok((capabilities, YesNo::try_from(more_data)?.into()))
+            Ok((
+                CapabilityData::try_from(Context::ffi_data_to_owned(capability_data_ptr))?,
+                YesNo::try_from(more_data)?.into(),
+            ))
         } else {
             error!("Error when getting capabilities: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -9,8 +9,7 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::ptr::null_mut;
 
 impl Context {
@@ -24,8 +23,7 @@ impl Context {
         let ret = unsafe { Esys_ContextSave(self.mut_context(), handle.into(), &mut context_ptr) };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let context = unsafe { MBox::from_raw(context_ptr) };
-            Ok((*context).try_into()?)
+            TpmsContext::try_from(Context::ffi_data_to_owned(context_ptr))
         } else {
             error!("Error in saving context: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -4,13 +4,13 @@ use crate::{
     context::handle_manager::HandleDropAction,
     handles::{handle_conversion::TryIntoNotNone, AuthHandle, ObjectHandle, PersistentTpmHandle},
     interface_types::{dynamic_handles::Persistent, resource_handles::Provision},
-    tss2_esys::*,
+    tss2_esys::{Esys_ContextLoad, Esys_ContextSave, Esys_EvictControl, Esys_FlushContext},
     utils::TpmsContext,
     Context, Error, Result,
 };
 use log::error;
 use mbox::MBox;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 use std::ptr::null_mut;
 
 impl Context {
@@ -20,12 +20,11 @@ impl Context {
     /// * if conversion from `TPMS_CONTEXT` to `TpmsContext` fails, a `WrongParamSize` error will
     /// be returned
     pub fn context_save(&mut self, handle: ObjectHandle) -> Result<TpmsContext> {
-        let mut context = null_mut();
-        let ret = unsafe { Esys_ContextSave(self.mut_context(), handle.into(), &mut context) };
-
+        let mut context_ptr = null_mut();
+        let ret = unsafe { Esys_ContextSave(self.mut_context(), handle.into(), &mut context_ptr) };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let context = unsafe { MBox::<TPMS_CONTEXT>::from_raw(context) };
+            let context = unsafe { MBox::from_raw(context_ptr) };
             Ok((*context).try_into()?)
         } else {
             error!("Error in saving context: {}", ret);
@@ -39,21 +38,15 @@ impl Context {
     /// * if conversion from `TpmsContext` to the native `TPMS_CONTEXT` fails, a `WrongParamSize`
     /// error will be returned
     pub fn context_load(&mut self, context: TpmsContext) -> Result<ObjectHandle> {
-        let mut esys_handle = ESYS_TR_NONE;
+        let mut loaded_handle = ObjectHandle::None.into();
         let ret = unsafe {
-            Esys_ContextLoad(
-                self.mut_context(),
-                &TPMS_CONTEXT::try_from(context)?,
-                &mut esys_handle,
-            )
+            Esys_ContextLoad(self.mut_context(), &context.try_into()?, &mut loaded_handle)
         };
-
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let object_handle = ObjectHandle::from(esys_handle);
             self.handle_manager
-                .add_handle(object_handle, HandleDropAction::Flush)?;
-            Ok(object_handle)
+                .add_handle(loaded_handle.into(), HandleDropAction::Flush)?;
+            Ok(loaded_handle.into())
         } else {
             error!("Error in loading context: {}", ret);
             Err(ret)
@@ -423,7 +416,7 @@ impl Context {
         object_handle: ObjectHandle,
         persistent: Persistent,
     ) -> Result<ObjectHandle> {
-        let mut esys_object_handle: ESYS_TR = ESYS_TR_NONE;
+        let mut new_object_handle = ObjectHandle::None.into();
         let ret = unsafe {
             Esys_EvictControl(
                 self.mut_context(),
@@ -433,22 +426,21 @@ impl Context {
                 self.optional_session_2(),
                 self.optional_session_3(),
                 PersistentTpmHandle::from(persistent).into(),
-                &mut esys_object_handle,
+                &mut new_object_handle,
             )
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let new_object_handle = ObjectHandle::from(esys_object_handle);
+            let new_object_handle = ObjectHandle::from(new_object_handle);
             // If you look at the specification and see that it says ESYS_TR_NULL
             // then that is an error in the spec. ESYS_TR_NULL was renamed to
             // ESYS_TR NONE.
-            if !new_object_handle.is_none() {
+            if new_object_handle.is_none() {
+                self.handle_manager.set_as_closed(object_handle)?;
+            } else {
                 self.handle_manager
                     .add_handle(new_object_handle, HandleDropAction::Close)?;
-            } else {
-                self.handle_manager.set_as_closed(object_handle)?;
             }
-
             Ok(new_object_handle)
         } else {
             error!("Error in evict control: {}", ret);

--- a/tss-esapi/src/context/tpm_commands/duplication_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/duplication_commands.rs
@@ -323,10 +323,11 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let encryption_key_out = unsafe { Data::try_from(*encryption_key_out_ptr)? };
-            let duplicate = unsafe { Private::try_from(*duplicate_ptr)? };
-            let out_sym_seed = unsafe { EncryptedSecret::try_from(*out_sym_seed_ptr)? };
-            Ok((encryption_key_out, duplicate, out_sym_seed))
+            Ok((
+                Data::try_from(Context::ffi_data_to_owned(encryption_key_out_ptr))?,
+                Private::try_from(Context::ffi_data_to_owned(duplicate_ptr))?,
+                EncryptedSecret::try_from(Context::ffi_data_to_owned(out_sym_seed_ptr))?,
+            ))
         } else {
             error!("Error when performing duplication: {}", ret);
             Err(ret)
@@ -681,7 +682,7 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            Ok(unsafe { Private::try_from(*out_private_ptr)? })
+            Private::try_from(Context::ffi_data_to_owned(out_private_ptr))
         } else {
             error!("Error when performing import: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/duplication_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/duplication_commands.rs
@@ -4,7 +4,7 @@ use crate::Context;
 use crate::{
     handles::ObjectHandle,
     structures::{Data, EncryptedSecret, Private, Public, SymmetricDefinitionObject},
-    tss2_esys::*,
+    tss2_esys::{Esys_Duplicate, Esys_Import},
     Error, Result,
 };
 use log::error;
@@ -302,9 +302,9 @@ impl Context {
         encryption_key_in: Option<Data>,
         symmetric_alg: SymmetricDefinitionObject,
     ) -> Result<(Data, Private, EncryptedSecret)> {
-        let mut encryption_key_out = null_mut();
-        let mut duplicate = null_mut();
-        let mut out_sym_seed = null_mut();
+        let mut encryption_key_out_ptr = null_mut();
+        let mut duplicate_ptr = null_mut();
+        let mut out_sym_seed_ptr = null_mut();
         let ret = unsafe {
             Esys_Duplicate(
                 self.mut_context(),
@@ -315,17 +315,17 @@ impl Context {
                 self.optional_session_3(),
                 &encryption_key_in.unwrap_or_default().into(),
                 &symmetric_alg.into(),
-                &mut encryption_key_out,
-                &mut duplicate,
-                &mut out_sym_seed,
+                &mut encryption_key_out_ptr,
+                &mut duplicate_ptr,
+                &mut out_sym_seed_ptr,
             )
         };
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let encryption_key_out = unsafe { Data::try_from(*encryption_key_out)? };
-            let duplicate = unsafe { Private::try_from(*duplicate)? };
-            let out_sym_seed = unsafe { EncryptedSecret::try_from(*out_sym_seed)? };
+            let encryption_key_out = unsafe { Data::try_from(*encryption_key_out_ptr)? };
+            let duplicate = unsafe { Private::try_from(*duplicate_ptr)? };
+            let out_sym_seed = unsafe { EncryptedSecret::try_from(*out_sym_seed_ptr)? };
             Ok((encryption_key_out, duplicate, out_sym_seed))
         } else {
             error!("Error when performing duplication: {}", ret);
@@ -662,7 +662,7 @@ impl Context {
         encrypted_secret: EncryptedSecret,
         symmetric_alg: SymmetricDefinitionObject,
     ) -> Result<Private> {
-        let mut out_private = null_mut();
+        let mut out_private_ptr = null_mut();
         let ret = unsafe {
             Esys_Import(
                 self.mut_context(),
@@ -675,13 +675,13 @@ impl Context {
                 &duplicate.into(),
                 &encrypted_secret.into(),
                 &symmetric_alg.into(),
-                &mut out_private,
+                &mut out_private_ptr,
             )
         };
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            Ok(unsafe { Private::try_from(*out_private)? })
+            Ok(unsafe { Private::try_from(*out_private_ptr)? })
         } else {
             error!("Error when performing import: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -4,12 +4,18 @@ use crate::{
     attributes::LocalityAttributes,
     constants::CommandCode,
     handles::{AuthHandle, ObjectHandle, SessionHandle},
-    interface_types::session_handles::PolicySession,
+    interface_types::{session_handles::PolicySession, YesNo},
     structures::{
         AuthTicket, Digest, DigestList, Name, Nonce, PcrSelectionList, Signature, Timeout,
         VerifiedTicket,
     },
-    tss2_esys::*,
+    tss2_esys::{
+        Esys_PolicyAuthValue, Esys_PolicyAuthorize, Esys_PolicyCommandCode, Esys_PolicyCpHash,
+        Esys_PolicyDuplicationSelect, Esys_PolicyGetDigest, Esys_PolicyLocality,
+        Esys_PolicyNameHash, Esys_PolicyNvWritten, Esys_PolicyOR, Esys_PolicyPCR,
+        Esys_PolicyPassword, Esys_PolicyPhysicalPresence, Esys_PolicySecret, Esys_PolicySigned,
+        Esys_PolicyTemplate,
+    },
     Context, Error, Result, WrapperErrorKind as ErrorKind,
 };
 use log::error;
@@ -31,16 +37,8 @@ impl Context {
         expiration: Option<Duration>,
         signature: Signature,
     ) -> Result<(Timeout, AuthTicket)> {
-        let mut out_timeout = null_mut();
-        let mut out_policy_ticket = null_mut();
-        let expiration = match expiration {
-            None => 0,
-            Some(val) => match i32::try_from(val.as_secs()) {
-                Ok(val) => val,
-                Err(_) => return Err(Error::local_error(ErrorKind::InvalidParam)),
-            },
-        };
-
+        let mut out_timeout_ptr = null_mut();
+        let mut out_policy_ticket_ptr = null_mut();
         let ret = unsafe {
             Esys_PolicySigned(
                 self.mut_context(),
@@ -52,17 +50,20 @@ impl Context {
                 &nonce_tpm.into(),
                 &cp_hash_a.into(),
                 &policy_ref.into(),
-                expiration,
+                i32::try_from(expiration.map_or(0, |v| v.as_secs())).map_err(|e| {
+                    error!("Unable to convert duration to i32: {}", e);
+                    Error::local_error(ErrorKind::InvalidParam)
+                })?,
                 &signature.try_into()?,
-                &mut out_timeout,
-                &mut out_policy_ticket,
+                &mut out_timeout_ptr,
+                &mut out_policy_ticket_ptr,
             )
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let out_timeout = unsafe { MBox::from_raw(out_timeout) };
+            let out_timeout = unsafe { MBox::from_raw(out_timeout_ptr) };
             let out_timeout = Timeout::try_from(*out_timeout)?;
-            let out_policy_ticket = unsafe { MBox::from_raw(out_policy_ticket) };
+            let out_policy_ticket = unsafe { MBox::from_raw(out_policy_ticket_ptr) };
             let out_policy_ticket = AuthTicket::try_from(*out_policy_ticket)?;
 
             Ok((out_timeout, out_policy_ticket))
@@ -82,16 +83,8 @@ impl Context {
         policy_ref: Nonce,
         expiration: Option<Duration>,
     ) -> Result<(Timeout, AuthTicket)> {
-        let mut out_timeout = null_mut();
-        let mut out_policy_ticket = null_mut();
-        let expiration = match expiration {
-            None => 0,
-            Some(val) => match i32::try_from(val.as_secs()) {
-                Ok(val) => val,
-                Err(_) => return Err(Error::local_error(ErrorKind::InvalidParam)),
-            },
-        };
-
+        let mut out_timeout_ptr = null_mut();
+        let mut out_policy_ticket_ptr = null_mut();
         let ret = unsafe {
             Esys_PolicySecret(
                 self.mut_context(),
@@ -103,16 +96,19 @@ impl Context {
                 &nonce_tpm.into(),
                 &cp_hash_a.into(),
                 &policy_ref.into(),
-                expiration,
-                &mut out_timeout,
-                &mut out_policy_ticket,
+                i32::try_from(expiration.map_or(0, |v| v.as_secs())).map_err(|e| {
+                    error!("Unable to convert duration to i32: {}", e);
+                    Error::local_error(ErrorKind::InvalidParam)
+                })?,
+                &mut out_timeout_ptr,
+                &mut out_policy_ticket_ptr,
             )
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let out_timeout = unsafe { MBox::from_raw(out_timeout) };
+            let out_timeout = unsafe { MBox::from_raw(out_timeout_ptr) };
             let out_timeout = Timeout::try_from(*out_timeout)?;
-            let out_policy_ticket = unsafe { MBox::from_raw(out_policy_ticket) };
+            let out_policy_ticket = unsafe { MBox::from_raw(out_policy_ticket_ptr) };
             let out_policy_ticket = AuthTicket::try_from(*out_policy_ticket)?;
 
             Ok((out_timeout, out_policy_ticket))
@@ -156,7 +152,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &TPML_DIGEST::try_from(digest_list)?,
+                &digest_list.try_into()?,
             )
         };
         let ret = Error::from_tss_rc(ret);
@@ -466,7 +462,6 @@ impl Context {
         key_sign: &Name,
         check_ticket: VerifiedTicket,
     ) -> Result<()> {
-        let check_ticket = TPMT_TK_VERIFIED::try_from(check_ticket)?;
         let ret = unsafe {
             Esys_PolicyAuthorize(
                 self.mut_context(),
@@ -477,7 +472,7 @@ impl Context {
                 &approved_policy.into(),
                 &policy_ref.into(),
                 key_sign.as_ref(),
-                &check_ticket,
+                &check_ticket.try_into()?,
             )
         };
         let ret = Error::from_tss_rc(ret);
@@ -551,7 +546,7 @@ impl Context {
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let policy_digest = unsafe { MBox::<TPM2B_DIGEST>::from_raw(policy_digest_ptr) };
+            let policy_digest = unsafe { MBox::from_raw(policy_digest_ptr) };
             Ok(Digest::try_from(*policy_digest)?)
         } else {
             error!(
@@ -577,7 +572,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                if written_set { 1 } else { 0 },
+                YesNo::from(written_set).into(),
             )
         };
         let ret = Error::from_tss_rc(ret);

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -19,7 +19,6 @@ use crate::{
     Context, Error, Result, WrapperErrorKind as ErrorKind,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::{TryFrom, TryInto};
 use std::ptr::null_mut;
 use std::time::Duration;
@@ -61,12 +60,10 @@ impl Context {
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let out_timeout = unsafe { MBox::from_raw(out_timeout_ptr) };
-            let out_timeout = Timeout::try_from(*out_timeout)?;
-            let out_policy_ticket = unsafe { MBox::from_raw(out_policy_ticket_ptr) };
-            let out_policy_ticket = AuthTicket::try_from(*out_policy_ticket)?;
-
-            Ok((out_timeout, out_policy_ticket))
+            Ok((
+                Timeout::try_from(Context::ffi_data_to_owned(out_timeout_ptr))?,
+                AuthTicket::try_from(Context::ffi_data_to_owned(out_policy_ticket_ptr))?,
+            ))
         } else {
             error!("Error when sending policy signed: {}", ret);
             Err(ret)
@@ -106,12 +103,10 @@ impl Context {
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let out_timeout = unsafe { MBox::from_raw(out_timeout_ptr) };
-            let out_timeout = Timeout::try_from(*out_timeout)?;
-            let out_policy_ticket = unsafe { MBox::from_raw(out_policy_ticket_ptr) };
-            let out_policy_ticket = AuthTicket::try_from(*out_policy_ticket)?;
-
-            Ok((out_timeout, out_policy_ticket))
+            Ok((
+                Timeout::try_from(Context::ffi_data_to_owned(out_timeout_ptr))?,
+                AuthTicket::try_from(Context::ffi_data_to_owned(out_policy_ticket_ptr))?,
+            ))
         } else {
             error!("Error when sending policy secret: {}", ret);
             Err(ret)
@@ -546,8 +541,7 @@ impl Context {
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let policy_digest = unsafe { MBox::from_raw(policy_digest_ptr) };
-            Ok(Digest::try_from(*policy_digest)?)
+            Digest::try_from(Context::ffi_data_to_owned(policy_digest_ptr))
         } else {
             error!(
                 "Error failed to perform policy get digest operation: {}.",

--- a/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
@@ -15,7 +15,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::{TryFrom, TryInto};
 use std::ptr::null_mut;
 
@@ -77,20 +76,20 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_public_owned = unsafe { MBox::from_raw(out_public_ptr) };
-            let creation_data_owned = unsafe { MBox::from_raw(creation_data_ptr) };
-            let creation_hash_owned = unsafe { MBox::from_raw(creation_hash_ptr) };
-            let creation_ticket_owned = unsafe { MBox::from_raw(creation_ticket_ptr) };
-
+            let out_public_owned = Context::ffi_data_to_owned(out_public_ptr);
+            let creation_data_owned = Context::ffi_data_to_owned(creation_data_ptr);
+            let creation_hash_owned = Context::ffi_data_to_owned(creation_hash_ptr);
+            let creation_ticket_owned = Context::ffi_data_to_owned(creation_ticket_ptr);
             let primary_key_handle = KeyHandle::from(object_handle);
             self.handle_manager
                 .add_handle(primary_key_handle.into(), HandleDropAction::Flush)?;
+
             Ok(CreatePrimaryKeyResult {
                 key_handle: primary_key_handle,
-                out_public: Public::try_from(*out_public_owned)?,
-                creation_data: CreationData::try_from(*creation_data_owned)?,
-                creation_hash: Digest::try_from(*creation_hash_owned)?,
-                creation_ticket: CreationTicket::try_from(*creation_ticket_owned)?,
+                out_public: Public::try_from(out_public_owned)?,
+                creation_data: CreationData::try_from(creation_data_owned)?,
+                creation_hash: Digest::try_from(creation_hash_owned)?,
+                creation_ticket: CreationTicket::try_from(creation_ticket_owned)?,
             })
         } else {
             error!("Error in creating primary key: {}", ret);

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -7,7 +7,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::{TryFrom, TryInto};
 use std::ptr::null_mut;
 
@@ -174,12 +173,10 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let pcr_selection_out = unsafe { MBox::from_raw(pcr_selection_out_ptr) };
-            let pcr_values = unsafe { MBox::from_raw(pcr_values_ptr) };
             Ok((
                 pcr_update_counter,
-                PcrSelectionList::try_from(*pcr_selection_out)?,
-                DigestList::try_from(*pcr_values)?,
+                PcrSelectionList::try_from(Context::ffi_data_to_owned(pcr_selection_out_ptr))?,
+                DigestList::try_from(Context::ffi_data_to_owned(pcr_values_ptr))?,
             ))
         } else {
             error!("Error when reading PCR: {}", ret);

--- a/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
+++ b/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
@@ -11,7 +11,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::{TryFrom, TryInto};
 use std::ptr::null_mut;
 
@@ -115,9 +114,10 @@ impl Context {
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let nv_public = unsafe { MBox::from_raw(nv_public_ptr) };
-            let nv_name = unsafe { MBox::from_raw(nv_name_ptr) };
-            Ok((NvPublic::try_from(*nv_public)?, Name::try_from(*nv_name)?))
+            Ok((
+                NvPublic::try_from(Context::ffi_data_to_owned(nv_public_ptr))?,
+                Name::try_from(Context::ffi_data_to_owned(nv_name_ptr))?,
+            ))
         } else {
             error!("Error when reading NV public: {}", ret);
             Err(ret)
@@ -191,8 +191,7 @@ impl Context {
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let data = unsafe { MBox::from_raw(data_ptr) };
-            Ok(MaxNvBuffer::try_from(*data)?)
+            MaxNvBuffer::try_from(Context::ffi_data_to_owned(data_ptr))
         } else {
             error!("Error when reading NV: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -16,7 +16,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::{TryFrom, TryInto};
 use std::ptr::{null, null_mut};
 
@@ -88,17 +87,17 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_private_owned = unsafe { MBox::from_raw(out_private_ptr) };
-            let out_public_owned = unsafe { MBox::from_raw(out_public_ptr) };
-            let creation_data_owned = unsafe { MBox::from_raw(creation_data_ptr) };
-            let creation_hash_owned = unsafe { MBox::from_raw(creation_hash_ptr) };
-            let creation_ticket_owned = unsafe { MBox::from_raw(creation_ticket_ptr) };
+            let out_private_owned = Context::ffi_data_to_owned(out_private_ptr);
+            let out_public_owned = Context::ffi_data_to_owned(out_public_ptr);
+            let creation_data_owned = Context::ffi_data_to_owned(creation_data_ptr);
+            let creation_hash_owned = Context::ffi_data_to_owned(creation_hash_ptr);
+            let creation_ticket_owned = Context::ffi_data_to_owned(creation_ticket_ptr);
             Ok(CreateKeyResult {
-                out_private: Private::try_from(*out_private_owned)?,
-                out_public: Public::try_from(*out_public_owned)?,
-                creation_data: CreationData::try_from(*creation_data_owned)?,
-                creation_hash: Digest::try_from(*creation_hash_owned)?,
-                creation_ticket: CreationTicket::try_from(*creation_ticket_owned)?,
+                out_private: Private::try_from(out_private_owned)?,
+                out_public: Public::try_from(out_public_owned)?,
+                creation_data: CreationData::try_from(creation_data_owned)?,
+                creation_hash: Digest::try_from(creation_hash_owned)?,
+                creation_ticket: CreationTicket::try_from(creation_ticket_owned)?,
             })
         } else {
             error!("Error in creating derived key: {}", ret);
@@ -233,14 +232,10 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_name_owned = unsafe { MBox::from_raw(name_ptr) };
-            let out_qualified_name_owned = unsafe { MBox::from_raw(qualified_name_ptr) };
-            let out_public_owned = unsafe { MBox::from_raw(out_public_ptr) };
-
             Ok((
-                Public::try_from(*out_public_owned)?,
-                Name::try_from(*out_name_owned)?,
-                Name::try_from(*out_qualified_name_owned)?,
+                Public::try_from(Context::ffi_data_to_owned(out_public_ptr))?,
+                Name::try_from(Context::ffi_data_to_owned(name_ptr))?,
+                Name::try_from(Context::ffi_data_to_owned(qualified_name_ptr))?,
             ))
         } else {
             error!("Error in reading public part of object: {}", ret);
@@ -274,9 +269,7 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_cert_info_owned = unsafe { MBox::from_raw(cert_info_ptr) };
-
-            Ok(Digest::try_from(*out_cert_info_owned)?)
+            Digest::try_from(Context::ffi_data_to_owned(cert_info_ptr))
         } else {
             error!("Error when activating credential: {}", ret);
             Err(ret)
@@ -311,12 +304,9 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_credential_blob = unsafe { MBox::from_raw(credential_blob_ptr) };
-            let out_secret = unsafe { MBox::from_raw(secret_ptr) };
-
             Ok((
-                IdObject::try_from(*out_credential_blob)?,
-                EncryptedSecret::try_from(*out_secret)?,
+                IdObject::try_from(Context::ffi_data_to_owned(credential_blob_ptr))?,
+                EncryptedSecret::try_from(Context::ffi_data_to_owned(secret_ptr))?,
             ))
         } else {
             error!("Error when making credential: {}", ret);
@@ -341,8 +331,7 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_data = unsafe { MBox::from_raw(out_data_ptr) };
-            Ok(SensitiveData::try_from(*out_data)?)
+            SensitiveData::try_from(Context::ffi_data_to_owned(out_data_ptr))
         } else {
             error!("Error in unsealing: {}", ret);
             Err(ret)
@@ -371,9 +360,7 @@ impl Context {
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let out_private = unsafe { MBox::from_raw(out_private_ptr) };
-            let out_private = Private::try_from(*out_private)?;
-            Ok(out_private)
+            Private::try_from(Context::ffi_data_to_owned(out_private_ptr))
         } else {
             error!("Error changing object auth: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/random_number_generator.rs
+++ b/tss-esapi/src/context/tpm_commands/random_number_generator.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     structures::{Digest, SensitiveData},
-    tss2_esys::*,
+    tss2_esys::{Esys_GetRandom, Esys_StirRandom},
     Context, Error, Result, WrapperErrorKind as ErrorKind,
 };
 use log::error;
@@ -16,7 +16,7 @@ impl Context {
     /// # Errors
     /// * if converting `num_bytes` to `u16` fails, a `WrongParamSize` will be returned
     pub fn get_random(&mut self, num_bytes: usize) -> Result<Digest> {
-        let mut buffer = null_mut();
+        let mut random_bytes_ptr = null_mut();
         let ret = unsafe {
             Esys_GetRandom(
                 self.mut_context(),
@@ -26,13 +26,13 @@ impl Context {
                 num_bytes
                     .try_into()
                     .map_err(|_| Error::local_error(ErrorKind::WrongParamSize))?,
-                &mut buffer,
+                &mut random_bytes_ptr,
             )
         };
 
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let buffer = unsafe { MBox::from_raw(buffer) };
+            let buffer = unsafe { MBox::from_raw(random_bytes_ptr) };
             let mut random = buffer.buffer.to_vec();
             random.truncate(buffer.size.try_into().unwrap()); // should not panic given the TryInto above
             Ok(Digest::try_from(random)?)

--- a/tss-esapi/src/context/tpm_commands/random_number_generator.rs
+++ b/tss-esapi/src/context/tpm_commands/random_number_generator.rs
@@ -6,7 +6,6 @@ use crate::{
     Context, Error, Result, WrapperErrorKind as ErrorKind,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::{TryFrom, TryInto};
 use std::ptr::null_mut;
 
@@ -32,10 +31,7 @@ impl Context {
 
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let buffer = unsafe { MBox::from_raw(random_bytes_ptr) };
-            let mut random = buffer.buffer.to_vec();
-            random.truncate(buffer.size.try_into().unwrap()); // should not panic given the TryInto above
-            Ok(Digest::try_from(random)?)
+            Digest::try_from(Context::ffi_data_to_owned(random_bytes_ptr))
         } else {
             error!("Error in getting random bytes: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
+++ b/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
@@ -7,7 +7,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::{TryFrom, TryInto};
 use std::ptr::null_mut;
 
@@ -35,9 +34,7 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let validation = unsafe { MBox::from_raw(validation_ptr) };
-            let validation = VerifiedTicket::try_from(*validation)?;
-            Ok(validation)
+            VerifiedTicket::try_from(Context::ffi_data_to_owned(validation_ptr))
         } else {
             error!("Error when verifying signature: {}", ret);
             Err(ret)
@@ -69,8 +66,7 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let signature = unsafe { MBox::from_raw(signature_ptr) };
-            Ok(Signature::try_from(*signature)?)
+            Signature::try_from(Context::ffi_data_to_owned(signature_ptr))
         } else {
             error!("Error when signing: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -11,7 +11,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::TryFrom;
 use std::ptr::null_mut;
 
@@ -212,11 +211,9 @@ impl Context {
 
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let data_out = unsafe { MBox::from_raw(out_data_ptr) };
-            let iv_out = unsafe { MBox::from_raw(iv_out_ptr) };
             Ok((
-                MaxBuffer::try_from(*data_out)?,
-                InitialValue::try_from(*iv_out)?,
+                MaxBuffer::try_from(Context::ffi_data_to_owned(out_data_ptr))?,
+                InitialValue::try_from(Context::ffi_data_to_owned(iv_out_ptr))?,
             ))
         } else {
             error!(
@@ -293,11 +290,9 @@ impl Context {
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let out_hash = unsafe { MBox::from_raw(out_hash_ptr) };
-            let validation = unsafe { MBox::from_raw(validation_ptr) };
             Ok((
-                Digest::try_from(*out_hash)?,
-                HashcheckTicket::try_from(*validation)?,
+                Digest::try_from(Context::ffi_data_to_owned(out_hash_ptr))?,
+                HashcheckTicket::try_from(Context::ffi_data_to_owned(validation_ptr))?,
             ))
         } else {
             error!("Error failed to perform hash operation: {}", ret);
@@ -377,8 +372,7 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_hmac = unsafe { MBox::from_raw(out_hmac_ptr) };
-            Ok(Digest::try_from(*out_hmac)?)
+            Digest::try_from(Context::ffi_data_to_owned(out_hmac_ptr))
         } else {
             error!("Error in hmac: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -7,7 +7,7 @@ use crate::{
         resource_handles::Hierarchy,
     },
     structures::{Digest, HashcheckTicket, InitialValue, MaxBuffer},
-    tss2_esys::*,
+    tss2_esys::{Esys_EncryptDecrypt2, Esys_HMAC, Esys_Hash},
     Context, Error, Result,
 };
 use log::error;
@@ -192,8 +192,8 @@ impl Context {
         in_data: MaxBuffer,
         initial_value_in: InitialValue,
     ) -> Result<(MaxBuffer, InitialValue)> {
-        let mut data_out_ptr = null_mut();
-        let mut initial_value_out_ptr = null_mut();
+        let mut out_data_ptr = null_mut();
+        let mut iv_out_ptr = null_mut();
         let ret = unsafe {
             Esys_EncryptDecrypt2(
                 self.mut_context(),
@@ -205,19 +205,18 @@ impl Context {
                 decrypt.into(),
                 mode.into(),
                 &initial_value_in.into(),
-                &mut data_out_ptr,
-                &mut initial_value_out_ptr,
+                &mut out_data_ptr,
+                &mut iv_out_ptr,
             )
         };
 
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let tss_data_out = unsafe { MBox::<TPM2B_MAX_BUFFER>::from_raw(data_out_ptr) };
-            let tss_initial_value_out =
-                unsafe { MBox::<TPM2B_IV>::from_raw(initial_value_out_ptr) };
+            let data_out = unsafe { MBox::from_raw(out_data_ptr) };
+            let iv_out = unsafe { MBox::from_raw(iv_out_ptr) };
             Ok((
-                MaxBuffer::try_from(*tss_data_out)?,
-                InitialValue::try_from(*tss_initial_value_out)?,
+                MaxBuffer::try_from(*data_out)?,
+                InitialValue::try_from(*iv_out)?,
             ))
         } else {
             error!(
@@ -294,8 +293,8 @@ impl Context {
         };
         let ret = Error::from_tss_rc(ret);
         if ret.is_success() {
-            let out_hash = unsafe { MBox::<TPM2B_DIGEST>::from_raw(out_hash_ptr) };
-            let validation = unsafe { MBox::<TPMT_TK_HASHCHECK>::from_raw(validation_ptr) };
+            let out_hash = unsafe { MBox::from_raw(out_hash_ptr) };
+            let validation = unsafe { MBox::from_raw(validation_ptr) };
             Ok((
                 Digest::try_from(*out_hash)?,
                 HashcheckTicket::try_from(*validation)?,
@@ -362,8 +361,7 @@ impl Context {
         buffer: MaxBuffer,
         alg_hash: HashingAlgorithm,
     ) -> Result<Digest> {
-        let mut out_digest = null_mut();
-
+        let mut out_hmac_ptr = null_mut();
         let ret = unsafe {
             Esys_HMAC(
                 self.mut_context(),
@@ -373,14 +371,14 @@ impl Context {
                 self.optional_session_3(),
                 &buffer.into(),
                 alg_hash.into(),
-                &mut out_digest,
+                &mut out_hmac_ptr,
             )
         };
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_digest = unsafe { MBox::from_raw(out_digest) };
-            Ok(Digest::try_from(*out_digest)?)
+            let out_hmac = unsafe { MBox::from_raw(out_hmac_ptr) };
+            Ok(Digest::try_from(*out_hmac)?)
         } else {
             error!("Error in hmac: {}", ret);
             Err(ret)

--- a/tss-esapi/src/context/tpm_commands/testing.rs
+++ b/tss-esapi/src/context/tpm_commands/testing.rs
@@ -7,7 +7,6 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use mbox::MBox;
 use std::convert::TryFrom;
 use std::ptr::null_mut;
 
@@ -55,8 +54,7 @@ impl Context {
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_data = unsafe { MBox::from_raw(out_data_ptr) };
-            let out_data = MaxBuffer::try_from(*out_data)?;
+            let out_data = MaxBuffer::try_from(Context::ffi_data_to_owned(out_data_ptr))?;
             let test_result_rc = Error::from_tss_rc(test_result);
             let test_result_rc = if test_result_rc.is_success() {
                 Ok(())

--- a/tss-esapi/src/context/tpm_commands/testing.rs
+++ b/tss-esapi/src/context/tpm_commands/testing.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
+    interface_types::YesNo,
     structures::MaxBuffer,
     tss2_esys::{Esys_GetTestResult, Esys_SelfTest},
     Context, Error, Result,
@@ -19,7 +20,7 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                if full_test { 1 } else { 0 },
+                YesNo::from(full_test).into(),
             )
         };
         let ret = Error::from_tss_rc(ret);
@@ -38,8 +39,8 @@ impl Context {
     ///
     /// The returned buffer data is manufacturer-specific information.
     pub fn get_test_result(&mut self) -> Result<(MaxBuffer, Result<()>)> {
-        let mut out_data = null_mut();
-        let mut out_rc: u32 = 0;
+        let mut out_data_ptr = null_mut();
+        let mut test_result: u32 = 0;
 
         let ret = unsafe {
             Esys_GetTestResult(
@@ -47,22 +48,22 @@ impl Context {
                 self.optional_session_1(),
                 self.optional_session_2(),
                 self.optional_session_3(),
-                &mut out_data,
-                &mut out_rc,
+                &mut out_data_ptr,
+                &mut test_result,
             )
         };
         let ret = Error::from_tss_rc(ret);
 
         if ret.is_success() {
-            let out_data = unsafe { MBox::from_raw(out_data) };
+            let out_data = unsafe { MBox::from_raw(out_data_ptr) };
             let out_data = MaxBuffer::try_from(*out_data)?;
-            let out_rc = Error::from_tss_rc(out_rc);
-            let out_rc = if out_rc.is_success() {
+            let test_result_rc = Error::from_tss_rc(test_result);
+            let test_result_rc = if test_result_rc.is_success() {
                 Ok(())
             } else {
-                Err(out_rc)
+                Err(test_result_rc)
             };
-            Ok((out_data, out_rc))
+            Ok((out_data, test_result_rc))
         } else {
             error!("Error getting test result: {}", ret);
             Err(ret)


### PR DESCRIPTION
Fixes potential memory leaks where the FFI types are not properly
handled by context methods using MBox.

Adds a private context method 'ffi_data_to_owned' for easier handling
of data that is allocated by TSS and supposed to be freed by the
caller.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>