### PR TITLE
Expand documentation around TransientKeyContext

### DIFF
--- a/tss-esapi/src/structures/signatures.rs
+++ b/tss-esapi/src/structures/signatures.rs
@@ -10,6 +10,9 @@ use log::error;
 use std::convert::{TryFrom, TryInto};
 
 /// Type holding RSA signature information.
+///
+/// For more information about the contents of `signature` see Annex B
+/// in the Architecture spec.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RsaSignature {
     hashing_algorithm: HashingAlgorithm,
@@ -70,6 +73,9 @@ impl TryFrom<TPMS_SIGNATURE_RSA> for RsaSignature {
 }
 
 /// Type holding ECC signature information.
+///
+/// For more information about the contents of `signature_r` and `signature_s`
+/// see Annex B in the Architecture spec (or Annex D for SM2 signatures).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EccSignature {
     hashing_algorithm: HashingAlgorithm,

--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -272,9 +272,20 @@ pub fn create_unrestricted_signing_ecc_public(
         .build()
 }
 
+/// Container for public key values
 #[derive(Debug, Clone, Serialize, Deserialize, Zeroize, PartialEq, Eq)]
 pub enum PublicKey {
+    /// RSA public modulus (see 27.5.3.4 in Architecture spec)
+    ///
+    /// This is the value extracted from the `unique` part of `TPMT_PUBLIC`.
+    /// The exponent is not included here as the expectation is that the
+    /// exponent is always pinned to 65537 (2^16 + 1).
+    ///
+    /// The modulus is in Big-Endian format.
     Rsa(Vec<u8>),
+    /// Public elliptic curve point (see 27.5.3.5 in Architecture spec)
+    ///
+    /// The x and y coordinates are given uncompressed.
     Ecc { x: Vec<u8>, y: Vec<u8> },
 }
 


### PR DESCRIPTION
Expanding the documentation of structures present in the interface of
`TransientKeyContext` to allow developers to more easily understand
their contents, or to at least know to which sections of the spec to
refer to.

cc @bootstrap-prime