### PR TITLE
Adds SensitiveCreate amd SensitiveCreateBuffer native types.

### DIFF
--- a/tss-esapi/src/structures/algorithm.rs
+++ b/tss-esapi/src/structures/algorithm.rs
@@ -1,0 +1,3 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+pub mod symmetric;

--- a/tss-esapi/src/structures/algorithm/symmetric.rs
+++ b/tss-esapi/src/structures/algorithm/symmetric.rs
@@ -1,0 +1,3 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+pub mod sensitive_create;

--- a/tss-esapi/src/structures/algorithm/symmetric/sensitive_create.rs
+++ b/tss-esapi/src/structures/algorithm/symmetric/sensitive_create.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use log::error;
 use std::convert::{TryFrom, TryInto};
+use zeroize::Zeroize;
 
 /// Structure that defines the values to be placed in the sensitive
 /// area of a created object.
@@ -18,7 +19,7 @@ use std::convert::{TryFrom, TryInto};
 ///
 /// There is a corresponding buffer type [SensitiveCreateBuffer](crate::structures::SensitiveCreateBuffer)
 /// that holds the data in a marshalled form.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Zeroize)]
 pub struct SensitiveCreate {
     user_auth: Auth,
     data: SensitiveData,

--- a/tss-esapi/src/structures/algorithm/symmetric/sensitive_create.rs
+++ b/tss-esapi/src/structures/algorithm/symmetric/sensitive_create.rs
@@ -1,0 +1,171 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    structures::{Auth, SensitiveData},
+    traits::{Marshall, UnMarshall},
+    tss2_esys::{TPM2B_SENSITIVE_CREATE, TPMS_SENSITIVE_CREATE},
+    Error, Result, ReturnCode, WrapperErrorKind,
+};
+use log::error;
+use std::convert::{TryFrom, TryInto};
+
+/// Structure that defines the values to be placed in the sensitive
+/// area of a created object.
+///
+/// # Details
+/// This corresponds to the TPMS_SENSITIVE_CREATE
+/// structure.
+///
+/// There is a corresponding buffer type [SensitiveCreateBuffer](crate::structures::SensitiveCreateBuffer)
+/// that holds the data in a marshalled form.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SensitiveCreate {
+    user_auth: Auth,
+    data: SensitiveData,
+}
+
+impl SensitiveCreate {
+    /// Creates new SensitiveCreate.
+    pub const fn new(user_auth: Auth, data: SensitiveData) -> Self {
+        SensitiveCreate { user_auth, data }
+    }
+
+    /// Returns the user auth
+    pub const fn user_auth(&self) -> &Auth {
+        &self.user_auth
+    }
+
+    /// Returns the sensitive data
+    pub const fn data(&self) -> &SensitiveData {
+        &self.data
+    }
+}
+
+impl From<SensitiveCreate> for TPMS_SENSITIVE_CREATE {
+    fn from(sensitive_create: SensitiveCreate) -> Self {
+        TPMS_SENSITIVE_CREATE {
+            userAuth: sensitive_create.user_auth.into(),
+            data: sensitive_create.data.into(),
+        }
+    }
+}
+
+impl TryFrom<TPMS_SENSITIVE_CREATE> for SensitiveCreate {
+    type Error = Error;
+
+    fn try_from(tpms_sensitive_create: TPMS_SENSITIVE_CREATE) -> Result<Self> {
+        Ok(SensitiveCreate {
+            user_auth: tpms_sensitive_create.userAuth.try_into()?,
+            data: tpms_sensitive_create.data.try_into()?,
+        })
+    }
+}
+
+impl Marshall for SensitiveCreate {
+    const BUFFER_SIZE: usize = std::mem::size_of::<TPMS_SENSITIVE_CREATE>();
+
+    /// Produce a marshalled [TPMS_SENSITIVE_CREATE]
+    ///
+    /// Note: for [TPM2B_SENSITIVE_CREATE] marshalling use [SensitiveCreateBuffer][`crate::structures::SensitiveCreateBuffer]
+    fn marshall(&self) -> Result<Vec<u8>> {
+        let mut buffer = vec![0; Self::BUFFER_SIZE];
+        let mut offset = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPMS_SENSITIVE_CREATE_Marshal(
+                    &self.clone().into(),
+                    buffer.as_mut_ptr(),
+                    Self::BUFFER_SIZE.try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    &mut offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshal SensitiveCreate: {}", ret);
+            },
+        )?;
+
+        let checked_offset = usize::try_from(offset).map_err(|e| {
+            error!("Failed to parse offset as usize: {}", e);
+            Error::local_error(WrapperErrorKind::InvalidParam)
+        })?;
+
+        buffer.truncate(checked_offset);
+
+        Ok(buffer)
+    }
+}
+
+impl UnMarshall for SensitiveCreate {
+    /// Unmarshall the structure from [`TPMS_SENSITIVE_CREATE`]
+    ///
+    /// Note: for [TPM2B_SENSITIVE_CREATE] unmarshalling use [SensitiveCreateBuffer][`crate::structures::SensitiveCreateBuffer]
+    fn unmarshall(marshalled_data: &[u8]) -> Result<Self> {
+        let mut dest = TPMS_SENSITIVE_CREATE::default();
+        let mut offset = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPMS_SENSITIVE_CREATE_Unmarshal(
+                    marshalled_data.as_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert length of marshalled data: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    &mut offset,
+                    &mut dest,
+                )
+            },
+            |ret| error!("Failed to unmarshal SensitiveCreate: {}", ret),
+        )?;
+
+        SensitiveCreate::try_from(dest)
+    }
+}
+
+impl TryFrom<TPM2B_SENSITIVE_CREATE> for SensitiveCreate {
+    type Error = Error;
+
+    fn try_from(tpm2b_sensitive_create: TPM2B_SENSITIVE_CREATE) -> Result<Self> {
+        SensitiveCreate::try_from(tpm2b_sensitive_create.sensitive)
+    }
+}
+
+impl TryFrom<SensitiveCreate> for TPM2B_SENSITIVE_CREATE {
+    type Error = Error;
+
+    fn try_from(sensitive_create: SensitiveCreate) -> Result<Self> {
+        let mut buffer = vec![0; SensitiveCreate::BUFFER_SIZE];
+        let mut size = 0;
+        let sensitive = TPMS_SENSITIVE_CREATE::from(sensitive_create);
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPMS_SENSITIVE_CREATE_Marshal(
+                    &sensitive,
+                    buffer.as_mut_ptr(),
+                    SensitiveCreate::BUFFER_SIZE.try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    &mut size,
+                )
+            },
+            |ret| error!("Failed to marshal SensitiveCreate: {}", ret),
+        )?;
+
+        Ok(TPM2B_SENSITIVE_CREATE {
+            size: size.try_into().map_err(|e| {
+                error!(
+                    "Failed to convert size of buffer from TSS size_t type: {}",
+                    e
+                );
+                Error::local_error(WrapperErrorKind::InvalidParam)
+            })?,
+            sensitive,
+        })
+    }
+}

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -95,6 +95,7 @@ macro_rules! buffer_type {
 pub mod attest;
 pub mod public;
 pub mod sensitive;
+pub mod sensitive_create;
 
 pub mod auth {
     buffer_type!(Auth, 64, TPM2B_AUTH);

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -9,9 +9,9 @@ macro_rules! named_field_buffer_type {
         use log::error;
         use std::convert::TryFrom;
         use std::ops::Deref;
-        use zeroize::Zeroizing;
+        use zeroize::{Zeroize, Zeroizing};
 
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
         pub struct $native_type(Zeroizing<Vec<u8>>);
 
         impl Default for $native_type {

--- a/tss-esapi/src/structures/buffers/sensitive_create.rs
+++ b/tss-esapi/src/structures/buffers/sensitive_create.rs
@@ -1,0 +1,172 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    structures::SensitiveCreate,
+    traits::{Marshall, UnMarshall},
+    tss2_esys::{TPM2B_SENSITIVE_CREATE, TPMS_SENSITIVE_CREATE},
+    Error, Result, ReturnCode, WrapperErrorKind,
+};
+use log::error;
+use std::{
+    convert::{TryFrom, TryInto},
+    ops::Deref,
+};
+use zeroize::Zeroize;
+
+/// The [SensitiveCreate] buffer type.
+///
+/// # Details
+/// The SensitiveCreateBuffer contains [SensitiveCreate] in marshalled
+/// form. It can be unmarshalled into [SensitiveCreate] or [TPM2B_SENSITIVE_CREATE].
+/// structure.
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
+#[zeroize(drop)]
+pub struct SensitiveCreateBuffer(Vec<u8>);
+
+impl SensitiveCreateBuffer {
+    pub const MAX_SIZE: usize = std::mem::size_of::<TPMS_SENSITIVE_CREATE>();
+    pub const MIN_SIZE: usize = 4;
+
+    /// Returns the content of the buffer.
+    pub fn value(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Private function for ensuring that a buffer size is valid.
+    fn ensure_valid_buffer_size(buffer_size: usize, container_name: &str) -> Result<()> {
+        if (Self::MIN_SIZE..=Self::MAX_SIZE).contains(&buffer_size) {
+            Ok(())
+        } else {
+            error!(
+                "Error: Invalid {} size ({} >= {} >= {})",
+                container_name,
+                Self::MAX_SIZE,
+                buffer_size,
+                Self::MIN_SIZE,
+            );
+            Err(Error::local_error(WrapperErrorKind::WrongParamSize))
+        }
+    }
+}
+
+impl Deref for SensitiveCreateBuffer {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TryFrom<Vec<u8>> for SensitiveCreateBuffer {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self> {
+        Self::ensure_valid_buffer_size(bytes.len(), "Vec<u8>")?;
+        Ok(SensitiveCreateBuffer(bytes))
+    }
+}
+
+impl TryFrom<&[u8]> for SensitiveCreateBuffer {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::ensure_valid_buffer_size(bytes.len(), "&[u8]")?;
+        Ok(SensitiveCreateBuffer(bytes.to_vec()))
+    }
+}
+
+impl TryFrom<TPM2B_SENSITIVE_CREATE> for SensitiveCreateBuffer {
+    type Error = Error;
+
+    fn try_from(tss: TPM2B_SENSITIVE_CREATE) -> Result<Self> {
+        Self::ensure_valid_buffer_size(tss.size as usize, "buffer")?;
+        let sensitive_create = SensitiveCreate::try_from(tss.sensitive)?;
+        Ok(SensitiveCreateBuffer(sensitive_create.marshall()?))
+    }
+}
+
+impl TryFrom<SensitiveCreateBuffer> for TPM2B_SENSITIVE_CREATE {
+    type Error = Error;
+
+    fn try_from(native: SensitiveCreateBuffer) -> Result<Self> {
+        SensitiveCreate::unmarshall(&native.0).map(|sensitive_create| TPM2B_SENSITIVE_CREATE {
+            size: native.0.len() as u16,
+            sensitive: sensitive_create.into(),
+        })
+    }
+}
+
+impl TryFrom<SensitiveCreateBuffer> for SensitiveCreate {
+    type Error = Error;
+
+    fn try_from(buf: SensitiveCreateBuffer) -> Result<Self> {
+        SensitiveCreate::unmarshall(&buf.0)
+    }
+}
+
+impl TryFrom<SensitiveCreate> for SensitiveCreateBuffer {
+    type Error = Error;
+
+    fn try_from(sensitve_create: SensitiveCreate) -> Result<SensitiveCreateBuffer> {
+        Ok(SensitiveCreateBuffer(sensitve_create.marshall()?))
+    }
+}
+
+impl Marshall for SensitiveCreateBuffer {
+    const BUFFER_SIZE: usize = std::mem::size_of::<TPM2B_SENSITIVE_CREATE>();
+
+    /// Produce a marshalled [TPM2B_SENSITIVE_CREATE]
+    fn marshall(&self) -> Result<Vec<u8>> {
+        let mut buffer = vec![0; Self::BUFFER_SIZE];
+        let mut offset = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2B_SENSITIVE_CREATE_Marshal(
+                    &self.clone().try_into()?,
+                    buffer.as_mut_ptr(),
+                    Self::BUFFER_SIZE.try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    &mut offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshal SensitiveCreateBuffer: {}", ret);
+            },
+        )?;
+
+        let checked_offset = usize::try_from(offset).map_err(|e| {
+            error!("Failed to parse offset as usize: {}", e);
+            Error::local_error(WrapperErrorKind::InvalidParam)
+        })?;
+        buffer.truncate(checked_offset);
+        Ok(buffer)
+    }
+}
+
+impl UnMarshall for SensitiveCreateBuffer {
+    /// Unmarshall the structure from [TPM2B_SENSITIVE_CREATE]
+    fn unmarshall(marshalled_data: &[u8]) -> Result<Self> {
+        let mut dest = TPM2B_SENSITIVE_CREATE::default();
+        let mut offset = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2B_SENSITIVE_CREATE_Unmarshal(
+                    marshalled_data.as_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert length of marshalled data: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    &mut offset,
+                    &mut dest,
+                )
+            },
+            |ret| error!("Failed to unmarshal SensitiveCreateBuffer: {}", ret),
+        )?;
+
+        SensitiveCreateBuffer::try_from(dest)
+    }
+}

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -40,7 +40,8 @@ pub use self::buffers::{
     max_buffer::MaxBuffer, max_nv_buffer::MaxNvBuffer, nonce::Nonce, private::Private,
     private_key_rsa::PrivateKeyRsa, private_vendor_specific::PrivateVendorSpecific,
     public::PublicBuffer, public_key_rsa::PublicKeyRsa, sensitive::SensitiveBuffer,
-    sensitive_data::SensitiveData, symmetric_key::SymmetricKey, timeout::Timeout,
+    sensitive_create::SensitiveCreateBuffer, sensitive_data::SensitiveData,
+    symmetric_key::SymmetricKey, timeout::Timeout,
 };
 /////////////////////////////////////////////////////////
 /// The creation section
@@ -206,3 +207,8 @@ pub use property::{
 /////////////////////////////////////////////////////////
 mod nv;
 pub use nv::storage::{NvPublic, NvPublicBuilder};
+/////////////////////////////////////////////////////////
+/// Algorithm Structures
+/////////////////////////////////////////////////////////
+mod algorithm;
+pub use algorithm::symmetric::sensitive_create::SensitiveCreate;

--- a/tss-esapi/tests/integration_tests/common/mod.rs
+++ b/tss-esapi/tests/integration_tests/common/mod.rs
@@ -32,11 +32,13 @@ use tss_esapi::{
 };
 
 mod marshall;
+mod tpm2b_types_equality_checks;
 mod tpma_types_equality_checks;
 mod tpml_types_equality_checks;
 mod tpms_types_equality_checks;
 mod tpmt_types_equality_checks;
 pub use marshall::*;
+pub use tpm2b_types_equality_checks::*;
 pub use tpma_types_equality_checks::*;
 pub use tpml_types_equality_checks::*;
 pub use tpms_types_equality_checks::*;

--- a/tss-esapi/tests/integration_tests/common/tpm2b_types_equality_checks.rs
+++ b/tss-esapi/tests/integration_tests/common/tpm2b_types_equality_checks.rs
@@ -1,6 +1,9 @@
 // Copyright 2022 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use tss_esapi::tss2_esys::{TPM2B_DATA, TPM2B_DIGEST, TPM2B_MAX_NV_BUFFER, TPM2B_NAME};
+use tss_esapi::tss2_esys::{
+    TPM2B_AUTH, TPM2B_DATA, TPM2B_DIGEST, TPM2B_MAX_NV_BUFFER, TPM2B_NAME, TPM2B_SENSITIVE_CREATE,
+    TPM2B_SENSITIVE_DATA,
+};
 
 macro_rules! ensure_sized_buffer_equality {
     ($expected:ident, $actual:ident, $buffer_field_name:ident, $tss_type:ident) => {
@@ -32,9 +35,28 @@ pub fn ensure_tpm2b_data_equality(expected: &TPM2B_DATA, actual: &TPM2B_DATA) {
     ensure_sized_buffer_equality!(expected, actual, buffer, TPM2B_DATA);
 }
 
+pub fn ensure_tpm2b_auth_equality(expected: &TPM2B_AUTH, actual: &TPM2B_AUTH) {
+    ensure_sized_buffer_equality!(expected, actual, buffer, TPM2B_AUTH);
+}
+
+pub fn ensure_tpm2b_sensitive_data(expected: &TPM2B_SENSITIVE_DATA, actual: &TPM2B_SENSITIVE_DATA) {
+    ensure_sized_buffer_equality!(expected, actual, buffer, TPM2B_SENSITIVE_DATA);
+}
+
 pub fn ensure_tpm2b_max_nv_buffer_equality(
     expected: &TPM2B_MAX_NV_BUFFER,
     actual: &TPM2B_MAX_NV_BUFFER,
 ) {
     ensure_sized_buffer_equality!(expected, actual, buffer, TPM2B_MAX_NV_BUFFER);
+}
+
+pub fn ensure_tpm2b_sensitive_create_equality(
+    expected: &TPM2B_SENSITIVE_CREATE,
+    actual: &TPM2B_SENSITIVE_CREATE,
+) {
+    assert_eq!(
+        expected.size, actual.size,
+        "'size' value in TPM2B_SENSITIVE_CREATE, mismatch between actual and expected",
+    );
+    crate::common::ensure_tpms_sensitive_create(&expected.sensitive, &actual.sensitive);
 }

--- a/tss-esapi/tests/integration_tests/common/tpm2b_types_equality_checks.rs
+++ b/tss-esapi/tests/integration_tests/common/tpm2b_types_equality_checks.rs
@@ -1,0 +1,40 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use tss_esapi::tss2_esys::{TPM2B_DATA, TPM2B_DIGEST, TPM2B_MAX_NV_BUFFER, TPM2B_NAME};
+
+macro_rules! ensure_sized_buffer_equality {
+    ($expected:ident, $actual:ident, $buffer_field_name:ident, $tss_type:ident) => {
+        assert_eq!(
+            $expected.size,
+            $actual.size,
+            "'size' value in {}, mismatch between actual and expected",
+            stringify!($tss_type),
+        );
+        assert_eq!(
+            $expected.$buffer_field_name,
+            $actual.$buffer_field_name,
+            "'{}' value in {}, mismatch between actual and expected",
+            stringify!($buffer_field_name),
+            stringify!($tss_type),
+        );
+    };
+}
+
+pub fn ensure_tpm2b_name_equality(expected: &TPM2B_NAME, actual: &TPM2B_NAME) {
+    ensure_sized_buffer_equality!(expected, actual, name, TPM2B_NAME);
+}
+
+pub fn ensure_tpm2b_digest_equality(expected: &TPM2B_DIGEST, actual: &TPM2B_DIGEST) {
+    ensure_sized_buffer_equality!(expected, actual, buffer, TPM2B_DIGEST);
+}
+
+pub fn ensure_tpm2b_data_equality(expected: &TPM2B_DATA, actual: &TPM2B_DATA) {
+    ensure_sized_buffer_equality!(expected, actual, buffer, TPM2B_DATA);
+}
+
+pub fn ensure_tpm2b_max_nv_buffer_equality(
+    expected: &TPM2B_MAX_NV_BUFFER,
+    actual: &TPM2B_MAX_NV_BUFFER,
+) {
+    ensure_sized_buffer_equality!(expected, actual, buffer, TPM2B_MAX_NV_BUFFER);
+}

--- a/tss-esapi/tests/integration_tests/common/tpms_types_equality_checks.rs
+++ b/tss-esapi/tests/integration_tests/common/tpms_types_equality_checks.rs
@@ -10,8 +10,8 @@ use tss_esapi::{
         TPMS_COMMAND_AUDIT_INFO, TPMS_CREATION_INFO, TPMS_ECC_PARMS, TPMS_KEYEDHASH_PARMS,
         TPMS_NV_CERTIFY_INFO, TPMS_PCR_SELECTION, TPMS_QUOTE_INFO, TPMS_RSA_PARMS,
         TPMS_SCHEME_ECDAA, TPMS_SCHEME_HASH, TPMS_SCHEME_HMAC, TPMS_SCHEME_XOR,
-        TPMS_SESSION_AUDIT_INFO, TPMS_SYMCIPHER_PARMS, TPMS_TAGGED_PCR_SELECT,
-        TPMS_TAGGED_PROPERTY, TPMS_TIME_ATTEST_INFO, TPMS_TIME_INFO,
+        TPMS_SENSITIVE_CREATE, TPMS_SESSION_AUDIT_INFO, TPMS_SYMCIPHER_PARMS,
+        TPMS_TAGGED_PCR_SELECT, TPMS_TAGGED_PROPERTY, TPMS_TIME_ATTEST_INFO, TPMS_TIME_INFO,
     },
 };
 
@@ -300,4 +300,12 @@ pub fn ensure_tpms_symcipher_parms_equality(
     actual: &TPMS_SYMCIPHER_PARMS,
 ) {
     crate::common::ensure_tpmt_sym_def_object_equality(&expected.sym, &actual.sym)
+}
+
+pub fn ensure_tpms_sensitive_create(
+    expected: &TPMS_SENSITIVE_CREATE,
+    actual: &TPMS_SENSITIVE_CREATE,
+) {
+    crate::common::ensure_tpm2b_auth_equality(&expected.userAuth, &actual.userAuth);
+    crate::common::ensure_tpm2b_sensitive_data(&expected.data, &actual.data);
 }

--- a/tss-esapi/tests/integration_tests/common/tpms_types_equality_checks.rs
+++ b/tss-esapi/tests/integration_tests/common/tpms_types_equality_checks.rs
@@ -15,29 +15,9 @@ use tss_esapi::{
     },
 };
 
-macro_rules! ensure_sized_buffer_field_equality {
-    ($expected:ident, $actual:ident, $field_name:ident, $buffer_field_name:ident, $tss_type:ident) => {
-        assert_eq!(
-            $expected.$field_name.size,
-            $actual.$field_name.size,
-            "'size' value for {} field in {}, mismatch between actual and expected",
-            stringify!($field_name),
-            stringify!($tss_type),
-        );
-        assert_eq!(
-            $expected.$field_name.$buffer_field_name,
-            $actual.$field_name.$buffer_field_name,
-            "'{}' value for {} field in {}, mismatch between actual and expected",
-            stringify!($buffer_field_name),
-            stringify!($field_name),
-            stringify!($tss_type),
-        );
-    };
-}
-
 pub fn ensure_tpms_certify_info_equality(expected: &TPMS_CERTIFY_INFO, actual: &TPMS_CERTIFY_INFO) {
-    ensure_sized_buffer_field_equality!(expected, actual, name, name, TPM2B_NAME);
-    ensure_sized_buffer_field_equality!(expected, actual, qualifiedName, name, TPM2B_NAME);
+    crate::common::ensure_tpm2b_name_equality(&expected.name, &actual.name);
+    crate::common::ensure_tpm2b_name_equality(&expected.qualifiedName, &actual.qualifiedName);
 }
 
 pub fn ensure_tpms_clock_info_equality(expected: &TPMS_CLOCK_INFO, actual: &TPMS_CLOCK_INFO) {
@@ -60,7 +40,7 @@ pub fn ensure_tpms_clock_info_equality(expected: &TPMS_CLOCK_INFO, actual: &TPMS
 }
 
 pub fn ensure_tpms_quote_info_equality(expected: &TPMS_QUOTE_INFO, actual: &TPMS_QUOTE_INFO) {
-    ensure_sized_buffer_field_equality!(expected, actual, pcrDigest, buffer, TPM2B_DIGEST);
+    crate::common::ensure_tpm2b_digest_equality(&expected.pcrDigest, &actual.pcrDigest);
     crate::common::ensure_tpml_pcr_selection_equality(&expected.pcrSelect, &actual.pcrSelect);
 }
 
@@ -113,8 +93,8 @@ pub fn ensure_tpms_command_audit_info_equality(
         expected.digestAlg, actual.digestAlg,
         "'digestAlg' value in TPMS_COMMAND_AUDIT_INFO, mismatch between actual and expected",
     );
-    ensure_sized_buffer_field_equality!(expected, actual, auditDigest, buffer, TPM2B_DIGEST);
-    ensure_sized_buffer_field_equality!(expected, actual, commandDigest, buffer, TPM2B_DIGEST);
+    crate::common::ensure_tpm2b_digest_equality(&expected.auditDigest, &actual.auditDigest);
+    crate::common::ensure_tpm2b_digest_equality(&expected.commandDigest, &actual.commandDigest);
 }
 
 pub fn ensure_tpms_session_audit_info_equality(
@@ -125,27 +105,27 @@ pub fn ensure_tpms_session_audit_info_equality(
         expected.exclusiveSession, actual.exclusiveSession,
         "'exclusiveSession' value in TPMS_SESSION_AUDIT_INFO, mismatch between actual and expected",
     );
-    ensure_sized_buffer_field_equality!(expected, actual, sessionDigest, buffer, TPM2B_DIGEST);
+    crate::common::ensure_tpm2b_digest_equality(&expected.sessionDigest, &actual.sessionDigest);
 }
 
 pub fn ensure_tpms_creation_info_equality(
     expected: &TPMS_CREATION_INFO,
     actual: &TPMS_CREATION_INFO,
 ) {
-    ensure_sized_buffer_field_equality!(expected, actual, objectName, name, TPM2B_NAME);
-    ensure_sized_buffer_field_equality!(expected, actual, creationHash, buffer, TPM2B_DIGEST);
+    crate::common::ensure_tpm2b_name_equality(&expected.objectName, &actual.objectName);
+    crate::common::ensure_tpm2b_digest_equality(&expected.creationHash, &actual.creationHash);
 }
 
 pub fn ensure_tpms_nv_certify_info_equality(
     expected: &TPMS_NV_CERTIFY_INFO,
     actual: &TPMS_NV_CERTIFY_INFO,
 ) {
-    ensure_sized_buffer_field_equality!(expected, actual, indexName, name, TPM2B_NAME);
+    crate::common::ensure_tpm2b_name_equality(&expected.indexName, &actual.indexName);
     assert_eq!(
         expected.offset, actual.offset,
         "'offset' value in TPMS_NV_CERTIFY_INFO, mismatch between actual and expected",
     );
-    ensure_sized_buffer_field_equality!(expected, actual, nvContents, buffer, TPM2B_MAX_NV_BUFFER);
+    crate::common::ensure_tpm2b_max_nv_buffer_equality(&expected.nvContents, &actual.nvContents);
 }
 
 pub fn ensure_tpms_attest_equality(expected: &TPMS_ATTEST, actual: &TPMS_ATTEST) {
@@ -157,8 +137,8 @@ pub fn ensure_tpms_attest_equality(expected: &TPMS_ATTEST, actual: &TPMS_ATTEST)
         expected.type_, actual.type_,
         "'type_' value in TPMS_ATTEST, mismatch between actual and expected",
     );
-    ensure_sized_buffer_field_equality!(expected, actual, qualifiedSigner, name, TPM2B_NAME);
-    ensure_sized_buffer_field_equality!(expected, actual, extraData, buffer, TPM2B_DATA);
+    crate::common::ensure_tpm2b_name_equality(&expected.qualifiedSigner, &actual.qualifiedSigner);
+    crate::common::ensure_tpm2b_data_equality(&expected.extraData, &actual.extraData);
     ensure_tpms_clock_info_equality(&expected.clockInfo, &actual.clockInfo);
     assert_eq!(
         expected.firmwareVersion, actual.firmwareVersion,

--- a/tss-esapi/tests/integration_tests/structures_tests/algorithm_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/algorithm_tests/mod.rs
@@ -1,0 +1,3 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+mod symmetric_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/algorithm_tests/symmetric_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/algorithm_tests/symmetric_tests/mod.rs
@@ -1,0 +1,3 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+mod sensitive_create_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/algorithm_tests/symmetric_tests/sensitive_create_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/algorithm_tests/symmetric_tests/sensitive_create_tests.rs
@@ -1,0 +1,92 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use std::convert::TryFrom;
+use tss_esapi::{
+    structures::{Auth, SensitiveCreate, SensitiveData},
+    tss2_esys::{TPM2B_SENSITIVE_CREATE, TPMS_SENSITIVE_CREATE},
+};
+
+#[test]
+fn test_apis() {
+    let expected_auth =
+        Auth::try_from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]).expect("Failed to create Auth value");
+    let expect_sensitive_data =
+        SensitiveData::try_from(vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+            .expect("Failed to create sensitive data");
+    let sensitive_create =
+        SensitiveCreate::new(expected_auth.clone(), expect_sensitive_data.clone());
+    assert_eq!(
+        &expected_auth,
+        sensitive_create.user_auth(),
+        "user_auth() did not return expected value"
+    );
+    assert_eq!(
+        &expect_sensitive_data,
+        sensitive_create.data(),
+        "data() did not return expected value"
+    );
+}
+
+#[test]
+fn test_tpms_sensitive_create_conversions() {
+    let expected_auth =
+        Auth::try_from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]).expect("Failed to create Auth value");
+    let expect_sensitive_data =
+        SensitiveData::try_from(vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+            .expect("Failed to create sensitive data");
+    let expected_tpms_sensitive_create = TPMS_SENSITIVE_CREATE {
+        userAuth: expected_auth.clone().into(),
+        data: expect_sensitive_data.clone().into(),
+    };
+    let sensitive_create = SensitiveCreate::try_from(expected_tpms_sensitive_create)
+        .expect("Failed to convert TPMS_SENSITIVE_CREATE to SensitiveCreate");
+    assert_eq!(
+        &expected_auth,
+        sensitive_create.user_auth(),
+        "user_auth() did not return expected value"
+    );
+    assert_eq!(
+        &expect_sensitive_data,
+        sensitive_create.data(),
+        "data() did not return expected value"
+    );
+    let actual_tpms_sensitive_create: TPMS_SENSITIVE_CREATE = sensitive_create.into();
+    crate::common::ensure_tpms_sensitive_create(
+        &expected_tpms_sensitive_create,
+        &actual_tpms_sensitive_create,
+    );
+}
+
+#[test]
+fn test_tpm2b_senestive_create_conversions() {
+    let expected_auth =
+        Auth::try_from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).expect("Failed to create Auth value");
+    let expect_sensitive_data =
+        SensitiveData::try_from(vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+            .expect("Failed to create sensitive data");
+    let expected_sensitive_create =
+        SensitiveCreate::new(expected_auth.clone(), expect_sensitive_data.clone());
+    let expected_tpm2b_sensitive_create = TPM2B_SENSITIVE_CREATE {
+        size: 2 + expected_auth.len() as u16 + 2 + expect_sensitive_data.len() as u16,
+        sensitive: expected_sensitive_create.clone().into(),
+    };
+    let actual_sensitive_create = SensitiveCreate::try_from(expected_tpm2b_sensitive_create)
+        .expect("Failed to convert TPM2B_SENSITIVE_CREATE into SensitiveCreate");
+    assert_eq!(expected_sensitive_create, actual_sensitive_create, "The SensitiveCreate converted from the TPM2b_SENSITIVE_CREATE did not contain the expected values");
+    let actual_tpm2b_sensitive_create = TPM2B_SENSITIVE_CREATE::try_from(actual_sensitive_create)
+        .expect("Failed to create TPM2b_SENSITIVE_CREATE from SensitiveCreate");
+    crate::common::ensure_tpm2b_sensitive_create_equality(
+        &expected_tpm2b_sensitive_create,
+        &actual_tpm2b_sensitive_create,
+    );
+}
+
+#[test]
+fn test_marhsall_unmarshall() {
+    let sensitive_create = SensitiveCreate::new(
+        Auth::try_from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).expect("Failed to create Auth value"),
+        SensitiveData::try_from(vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+            .expect("Failed to create sensitive data"),
+    );
+    crate::common::check_marshall_unmarshall(&sensitive_create);
+}

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/mod.rs
@@ -8,3 +8,4 @@ mod max_buffer_tests;
 mod nonce_tests;
 mod public;
 mod sensitive;
+mod sensitive_create_buffer_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/sensitive_create_buffer_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/sensitive_create_buffer_tests.rs
@@ -1,0 +1,126 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use std::{convert::TryFrom, ops::Deref};
+use tss_esapi::{
+    structures::{Auth, SensitiveCreate, SensitiveCreateBuffer, SensitiveData},
+    tss2_esys::TPM2B_SENSITIVE_CREATE,
+    Error, WrapperErrorKind,
+};
+
+// TPM2B_AUTH = TPM2B_DIGEST = u16 + [u8;64] = 2 + 64 = 66
+// TPM2B_SENSITIVE_DATA = u16 + [u8; 256] = 2 + 256 = 258
+// TPMS_SENSITIVE_CREATE = TPM2B_AUTH + TPM2B_SENSITIVE_DATA = std::mem::size_of::<TPMS_SENSITIVE_CREATE>() = 324
+const SENSITIVE_CREATE_BUFFER_MAX_SIZE: usize = 324;
+
+#[test]
+fn test_byte_conversions() {
+    let expected_buffer = vec![0xffu8; SENSITIVE_CREATE_BUFFER_MAX_SIZE];
+    let sensitive_create_buffer_from_slice =
+        SensitiveCreateBuffer::try_from(expected_buffer.as_slice())
+            .expect("Failed to create SensitiveCreateBuffer from byte slice");
+    assert_eq!(
+        &expected_buffer,
+        sensitive_create_buffer_from_slice.value(),
+        "SensitiveCreateBuffer converted from slice did not produce the expected value"
+    );
+    let sensitive_create_buffer_from_vec = SensitiveCreateBuffer::try_from(expected_buffer.clone())
+        .expect("Failed to create SensitiveCreateBuffer from byte slice");
+    assert_eq!(
+        &expected_buffer,
+        sensitive_create_buffer_from_vec.value(),
+        "SensitiveCreateBuffer converted from Vec did not produce the expected value"
+    );
+}
+
+#[test]
+fn test_conversions_of_over_sized_byte_data() {
+    let over_sized_buffer = vec![0xffu8; SENSITIVE_CREATE_BUFFER_MAX_SIZE + 1];
+
+    assert_eq!(
+        SensitiveCreateBuffer::try_from(over_sized_buffer.as_slice())
+            .expect_err("Converting a slice that is to large did not produce an error"),
+        Error::WrapperError(WrapperErrorKind::WrongParamSize),
+        "Wrong kind of error when converting a slice with size {} to SensitiveCreateBuffer",
+        SENSITIVE_CREATE_BUFFER_MAX_SIZE + 1
+    );
+
+    assert_eq!(
+        SensitiveCreateBuffer::try_from(over_sized_buffer)
+            .expect_err("Converting a Vec that is to large did not produce an error"),
+        Error::WrapperError(WrapperErrorKind::WrongParamSize),
+        "Wrong kind of error when converting a Vec with size {} to SensitiveCreateBuffer",
+        SENSITIVE_CREATE_BUFFER_MAX_SIZE + 1
+    );
+}
+
+#[test]
+fn test_deref() {
+    let expected_buffer = vec![0x0fu8; SENSITIVE_CREATE_BUFFER_MAX_SIZE];
+    let sensitive_create_buffer_from_slice =
+        SensitiveCreateBuffer::try_from(expected_buffer.as_slice())
+            .expect("Failed to create SensitiveCreateBuffer from byte slice");
+    assert_eq!(
+        &expected_buffer,
+        sensitive_create_buffer_from_slice.deref(),
+        "Calling deref() on a SensitiveCreateBuffer converted from slice did not produce the expected value"
+    );
+    let sensitive_create_buffer_from_vec = SensitiveCreateBuffer::try_from(expected_buffer.clone())
+        .expect("Failed to create SensitiveCreateBuffer from byte slice");
+    assert_eq!(
+        &expected_buffer,
+        sensitive_create_buffer_from_vec.deref(),
+        "Calling deref() on a SensitiveCreateBuffer converted from Vec did not produce the expected value"
+    );
+}
+
+#[test]
+fn test_tpm_types_conversions() {
+    let expected_auth = Auth::default();
+    let expected_sensitive_data = SensitiveData::default();
+    let expected_sensitive_create = SensitiveCreate::new(expected_auth, expected_sensitive_data);
+    let expected_tpm2b_sensitive_create = TPM2B_SENSITIVE_CREATE {
+        size: 2 + 2, // both auth and sensitive data is empty so only the size parameters contributes.
+        sensitive: expected_sensitive_create.clone().into(),
+    };
+    let actual_sensitive_create_buffer =
+        SensitiveCreateBuffer::try_from(expected_tpm2b_sensitive_create)
+            .expect("Failed to create SensitiveCreateBuffer from TPM2B_SENSITIVE_CREATE");
+    assert_eq!(
+        actual_sensitive_create_buffer.value().len(),
+        2 + 2,
+        "Unexpected size of the SensitiveCreateBuffer"
+    );
+    let actual_sensitive_create = SensitiveCreate::try_from(actual_sensitive_create_buffer.clone())
+        .expect("Failed to create SensitiveCreate from SensitiveCreateBuffer");
+    assert_eq!(
+        expected_sensitive_create, actual_sensitive_create,
+        "SensitiveCreate converted from SensiticeCreateBuffer did not contain expected values."
+    );
+    let actual_tpm2b_senstive_create_buffer =
+        TPM2B_SENSITIVE_CREATE::try_from(actual_sensitive_create_buffer)
+            .expect("Failed to create TPM2B_SENSITIVE_CREATE from SensitiveCreateBuffer");
+    crate::common::ensure_tpm2b_sensitive_create_equality(
+        &expected_tpm2b_sensitive_create,
+        &actual_tpm2b_senstive_create_buffer,
+    );
+}
+
+#[test]
+fn test_marshall_unmarshall() {
+    let expected_auth =
+        Auth::try_from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).expect("Failed to create auth value");
+    let expected_sensitive_data =
+        SensitiveData::try_from(vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+            .expect("Failed to create sensitive data");
+    let expected_sensitive_create = SensitiveCreate::new(expected_auth, expected_sensitive_data);
+    let expected_sensitive_create_buffer =
+        SensitiveCreateBuffer::try_from(expected_sensitive_create.clone())
+            .expect("Failed to create SensitiveCreateBuffer");
+    crate::common::check_marshall_unmarshall(&expected_sensitive_create_buffer);
+    assert_eq!(
+        expected_sensitive_create,
+        SensitiveCreate::try_from(expected_sensitive_create_buffer)
+            .expect("Failed to convert from SensitiveCreateBuffer to SensitiveCreate"),
+        "SensitiveCreate converted from SenstiveCreateBuffer did not contain the expected values"
+    );
+}

--- a/tss-esapi/tests/integration_tests/structures_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod algorithm_property_tests;
+mod algorithm_tests;
 mod attest_info_test;
 mod attest_tests;
 mod buffers_tests;


### PR DESCRIPTION
This fixes  #338 by adding native types for ```SensitiveCreate``` and ```SensitiveCreateBuffer```.