### PR TITLE
Fixed Rust 1.62 clippy errors for 6.x.y branch.

### DIFF
--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -1289,7 +1289,7 @@ impl PcrData {
     }
 }
 
-impl<'a> IntoIterator for PcrData {
+impl IntoIterator for PcrData {
     type Item = (HashingAlgorithm, PcrBank);
     type IntoIter = ::std::vec::IntoIter<(HashingAlgorithm, PcrBank)>;
 

--- a/tss-esapi/tests/abstraction_nv_tests.rs
+++ b/tss-esapi/tests/abstraction_nv_tests.rs
@@ -64,9 +64,9 @@ fn read_full() {
     // Now read it back
     let read_result = nv::read_full(&mut context, NvAuth::Owner, nv_index);
 
-    let _ = context
+    context
         .nv_undefine_space(Provision::Owner, owner_nv_index_handle)
-        .unwrap();
+        .expect("Call to nv_undefine_space failed");
 
     let read_result = read_result.unwrap();
     assert_eq!(read_result.len(), 1540);

--- a/tss-esapi/tests/context_tests/general_esys_tr_tests.rs
+++ b/tss-esapi/tests/context_tests/general_esys_tr_tests.rs
@@ -64,7 +64,9 @@ mod test_tr_from_tpm_public {
                        fn_name: &str|
          -> tss_esapi::Error {
             // Set password authorization
-            let _ = context.nv_undefine_space(Provision::Owner, handle).unwrap();
+            context
+                .nv_undefine_space(Provision::Owner, handle)
+                .expect("Call to nv_undefine_space failed");
             panic!("{} failed: {}", fn_name, e);
         };
 
@@ -114,9 +116,9 @@ mod test_tr_from_tpm_public {
             .unwrap();
         //////////////////////////////////////////////
         // Remove undefine the space
-        let _ = context
+        context
             .nv_undefine_space(Provision::Owner, new_nv_index_handle.into())
-            .unwrap();
+            .expect("Call to nv_undefine_space failed");
 
         assert_eq!(expected_name, actual_name);
     }
@@ -141,7 +143,7 @@ mod test_tr_from_tpm_public {
          -> tss_esapi::Error {
             // Set password authorization
             context.set_sessions((Some(AuthSession::Password), None, None));
-            let _ = context
+            context
                 .nv_undefine_space(Provision::Owner, handle)
                 .expect("Failed to call nv_undefine_space");
             panic!("{} failed: {}", fn_name, e);
@@ -214,7 +216,7 @@ mod test_tr_from_tpm_public {
         //
         // Set password authorization
         context.set_sessions((Some(AuthSession::Password), None, None));
-        let _ = context
+        context
             .nv_undefine_space(Provision::Owner, new_nv_index_handle.into())
             .expect("Failed to call nv_undefine_space");
         ///////////////////////////////////////////////////////////////
@@ -244,7 +246,9 @@ mod test_tr_from_tpm_public {
          -> tss_esapi::Error {
             // Set password authorization
             context.set_sessions((Some(AuthSession::Password), None, None));
-            let _ = context.nv_undefine_space(Provision::Owner, handle).unwrap();
+            context
+                .nv_undefine_space(Provision::Owner, handle)
+                .expect("Call to nv_undefine_space failed");
             panic!("{} failed: {}", fn_name, e);
         };
 
@@ -363,9 +367,9 @@ mod test_tr_from_tpm_public {
         //
         // Set password authorization
         context.set_sessions((Some(AuthSession::Password), None, None));
-        let _ = context
+        context
             .nv_undefine_space(Provision::Owner, new_nv_index_handle)
-            .unwrap();
+            .expect("Call to nv_undefine_space failed");
         ///////////////////////////////////////////////////////////////
         // The name will have changed
         //

--- a/tss-esapi/tests/context_tests/tpm_commands/non_volatile_storage_tests.rs
+++ b/tss-esapi/tests/context_tests/tpm_commands/non_volatile_storage_tests.rs
@@ -97,7 +97,7 @@ mod test_nv_define_space {
             .nv_define_space(Provision::Owner, None, &owner_nv_public)
             .expect("Call to nv_define_space failed");
 
-        let _ = context
+        context
             .nv_undefine_space(Provision::Owner, owner_nv_index_handle)
             .expect("Call to nv_undefine_space failed");
 
@@ -108,7 +108,7 @@ mod test_nv_define_space {
             .nv_define_space(Provision::Platform, None, &platform_nv_public)
             .expect("Call to nv_define_space failed");
 
-        let _ = context
+        context
             .nv_undefine_space(Provision::Platform, platform_nv_index_handle)
             .expect("Call to nv_undefine_space failed");
     }
@@ -149,7 +149,7 @@ mod test_nv_undefine_space {
             .expect("Call to nv_define_space failed");
 
         // Succedes
-        let _ = context
+        context
             .nv_undefine_space(Provision::Owner, owner_nv_index_handle)
             .expect("Call to nv_undefine_space failed");
     }
@@ -190,7 +190,7 @@ mod test_nv_read_public {
 
         let read_public_result = context.nv_read_public(nv_index_handle);
 
-        let _ = context
+        context
             .nv_undefine_space(Provision::Owner, nv_index_handle)
             .unwrap();
 
@@ -251,7 +251,7 @@ mod test_nv_write {
             0,
         );
 
-        let _ = context
+        context
             .nv_undefine_space(Provision::Owner, owner_nv_index_handle)
             .expect("Call to nv_undefine_space failed");
 
@@ -309,7 +309,7 @@ mod test_nv_read {
         // read data using owner authorization
         let read_result =
             context.nv_read(NvAuth::Owner, owner_nv_index_handle, value.len() as u16, 0);
-        let _ = context
+        context
             .nv_undefine_space(Provision::Owner, owner_nv_index_handle)
             .expect("Call to nv_undefine_space failed");
 


### PR DESCRIPTION
Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>