### PR TITLE
Conditionally expose `Esys_TR_GetTpmHandle`

### DIFF
--- a/tss-esapi/build.rs
+++ b/tss-esapi/build.rs
@@ -37,4 +37,12 @@ fn main() {
     if has_tss_base_rc_values_52_to_53_req.matches(&tss_version) {
         println!("cargo:rustc-cfg=has_tss_base_rc_values_52_to_53")
     }
+
+    #[cfg(feature = "generate-bindings")]
+    {
+        let has_esys_tr_get_tpm_handle_req = VersionReq::parse(">=2.4.0").unwrap();
+        if has_esys_tr_get_tpm_handle_req.matches(&tss_version) {
+            println!("cargo:rustc-cfg=has_esys_tr_get_tpm_handle")
+        }
+    }
 }

--- a/tss-esapi/src/context/general_esys_tr.rs
+++ b/tss-esapi/src/context/general_esys_tr.rs
@@ -85,6 +85,22 @@ impl Context {
         Ok(())
     }
 
+    #[cfg(has_esys_tr_get_tpm_handle)]
+    /// Retrieve the `TpmHandle` stored in the given object.
+    pub fn tr_get_tpm_handle(&mut self, object_handle: ObjectHandle) -> Result<TpmHandle> {
+        use crate::{constants::tss::TPM2_RH_UNASSIGNED, tss2_esys::Esys_TR_GetTpmHandle};
+        let mut tpm_handle = TPM2_RH_UNASSIGNED;
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_TR_GetTpmHandle(self.mut_context(), object_handle.into(), &mut tpm_handle)
+            },
+            |ret| {
+                error!("Error when getting TPM handle from ESYS handle: {}", ret);
+            },
+        )?;
+        TpmHandle::try_from(tpm_handle)
+    }
+
     // Missing function: Esys_TR_Serialize
     // Missing function: Esys_TR_Deserialize
 }


### PR DESCRIPTION
Exposed the Esys_TR_GetTpmHandle function as a new `Context` method called `tr_get_tpm_handle`.

This is conditionally compiled if `has_esys_tr_get_tpm_handle` is defined, which is the case if the `generate-bindings` feature is enabled and the TSS library the bindings are generated for has version >= 2.4.0.