### PR TITLE
Improvement of FFI data zeroizing.

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -21,7 +21,7 @@ num-derive = "0.3.2"
 num-traits = "0.2.12"
 hostname-validator = "1.1.0"
 regex = "1.3.9"
-zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
+zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.3.0" }
 oid = "0.2.1"
 picky-asn1 = "0.3.0"

--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -14,8 +14,7 @@ use crate::{
 use handle_manager::HandleManager;
 use log::{error, info};
 use mbox::MBox;
-use std::collections::HashMap;
-use std::ptr::null_mut;
+use std::{collections::HashMap, ptr::null_mut};
 
 /// Safe abstraction over an ESYS_CONTEXT.
 ///

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -1,13 +1,14 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod ffi_data_handlers;
+
 use crate::{
     context::handle_manager::HandleDropAction,
     handles::{KeyHandle, ObjectHandle, TpmHandle},
     interface_types::resource_handles::Hierarchy,
     structures::{
-        Auth, CreateKeyResult, CreationData, CreationTicket, Data, Digest, EncryptedSecret,
-        IdObject, Name, PcrSelectionList, Private, Public, Sensitive, SensitiveCreate,
-        SensitiveData,
+        Auth, CreateKeyResult, Data, Digest, EncryptedSecret, IdObject, Name, PcrSelectionList,
+        Private, Public, Sensitive, SensitiveData,
     },
     tss2_esys::{
         Esys_ActivateCredential, Esys_Create, Esys_Load, Esys_LoadExternal, Esys_MakeCredential,
@@ -15,6 +16,7 @@ use crate::{
     },
     Context, Result, ReturnCode,
 };
+use ffi_data_handlers::{CreateInputHandler, CreateOutputHandler};
 use log::error;
 use std::convert::{TryFrom, TryInto};
 use std::ptr::{null, null_mut};
@@ -49,53 +51,41 @@ impl Context {
         outside_info: Option<Data>,
         creation_pcrs: Option<PcrSelectionList>,
     ) -> Result<CreateKeyResult> {
-        let sensitive_create = SensitiveCreate::new(
-            auth_value.unwrap_or_default(),
-            sensitive_data.unwrap_or_default(),
-        );
-        let creation_pcrs = PcrSelectionList::list_from_option(creation_pcrs);
+        let input_handler = CreateInputHandler::create(
+            parent_handle,
+            public,
+            auth_value,
+            sensitive_data,
+            outside_info,
+            creation_pcrs,
+        )?;
 
-        let mut out_public_ptr = null_mut();
-        let mut out_private_ptr = null_mut();
-        let mut creation_data_ptr = null_mut();
-        let mut creation_hash_ptr = null_mut();
-        let mut creation_ticket_ptr = null_mut();
+        let mut output_handler = CreateOutputHandler::new();
 
         ReturnCode::ensure_success(
             unsafe {
                 Esys_Create(
                     self.mut_context(),
-                    parent_handle.into(),
+                    input_handler.ffi_in_parent_handle(),
                     self.optional_session_1(),
                     self.optional_session_2(),
                     self.optional_session_3(),
-                    &sensitive_create.try_into()?,
-                    &public.try_into()?,
-                    &outside_info.unwrap_or_default().into(),
-                    &creation_pcrs.into(),
-                    &mut out_private_ptr,
-                    &mut out_public_ptr,
-                    &mut creation_data_ptr,
-                    &mut creation_hash_ptr,
-                    &mut creation_ticket_ptr,
+                    input_handler.ffi_in_sensitive(),
+                    input_handler.ffi_in_public(),
+                    input_handler.ffi_outside_info(),
+                    input_handler.ffi_creation_pcr(),
+                    output_handler.ffi_out_private_ptr(),
+                    output_handler.ffi_out_public_ptr(),
+                    output_handler.ffi_creation_data_ptr(),
+                    output_handler.ffi_creation_hash_ptr(),
+                    output_handler.ffi_creation_ticket_ptr(),
                 )
             },
             |ret| {
                 error!("Error in creating derived key: {}", ret);
             },
         )?;
-        let out_private_owned = Context::ffi_data_to_owned(out_private_ptr);
-        let out_public_owned = Context::ffi_data_to_owned(out_public_ptr);
-        let creation_data_owned = Context::ffi_data_to_owned(creation_data_ptr);
-        let creation_hash_owned = Context::ffi_data_to_owned(creation_hash_ptr);
-        let creation_ticket_owned = Context::ffi_data_to_owned(creation_ticket_ptr);
-        Ok(CreateKeyResult {
-            out_private: Private::try_from(out_private_owned)?,
-            out_public: Public::try_from(out_public_owned)?,
-            creation_data: CreationData::try_from(creation_data_owned)?,
-            creation_hash: Digest::try_from(creation_hash_owned)?,
-            creation_ticket: CreationTicket::try_from(creation_ticket_owned)?,
-        })
+        output_handler.try_into()
     }
 
     /// Load a previously generated key back into the TPM and return its new handle.

--- a/tss-esapi/src/context/tpm_commands/object_commands/ffi_data_handlers.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands/ffi_data_handlers.rs
@@ -1,0 +1,8 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+mod create_input;
+mod create_output;
+
+pub(crate) use create_input::CreateInputHandler;
+pub(crate) use create_output::CreateOutputHandler;

--- a/tss-esapi/src/context/tpm_commands/object_commands/ffi_data_handlers/create_input.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands/ffi_data_handlers/create_input.rs
@@ -1,0 +1,82 @@
+use crate::{
+    handles::KeyHandle,
+    structures::{
+        Auth, Data, PcrSelectionList, Public, PublicBuffer, SensitiveCreate, SensitiveCreateBuffer,
+        SensitiveData,
+    },
+    traits::InPlaceFfiDataZeroizer,
+    tss2_esys::{ESYS_TR, TPM2B_DATA, TPM2B_PUBLIC, TPM2B_SENSITIVE_CREATE, TPML_PCR_SELECTION},
+    Result,
+};
+use std::convert::TryInto;
+use zeroize::Zeroize;
+
+/// Struct that handles the input of the
+/// to the Esys_Create command and zeroizes
+/// the data when it gets dropped.
+pub struct CreateInputHandler {
+    ffi_in_parent_handle: ESYS_TR,
+    ffi_in_sensitive: TPM2B_SENSITIVE_CREATE,
+    ffi_in_public: TPM2B_PUBLIC,
+    ffi_outside_info: TPM2B_DATA,
+    ffi_creation_pcr: TPML_PCR_SELECTION,
+}
+
+impl CreateInputHandler {
+    pub(crate) fn create(
+        parent_handle: KeyHandle,
+        public: Public,
+        auth_value: Option<Auth>,
+        sensitive_data: Option<SensitiveData>,
+        outside_info: Option<Data>,
+        creation_pcrs: Option<PcrSelectionList>,
+    ) -> Result<Self> {
+        Ok(Self {
+            ffi_in_parent_handle: parent_handle.into(),
+            ffi_in_sensitive: SensitiveCreate::new(
+                auth_value.unwrap_or_default(),
+                sensitive_data.unwrap_or_default(),
+            )
+            .try_into()?,
+            ffi_in_public: public.try_into()?,
+            ffi_outside_info: outside_info.unwrap_or_default().into(),
+            ffi_creation_pcr: PcrSelectionList::list_from_option(creation_pcrs).into(),
+        })
+    }
+
+    pub const fn ffi_in_parent_handle(&self) -> ESYS_TR {
+        self.ffi_in_parent_handle
+    }
+
+    pub const fn ffi_in_sensitive(&self) -> &TPM2B_SENSITIVE_CREATE {
+        &self.ffi_in_sensitive
+    }
+
+    pub const fn ffi_in_public(&self) -> &TPM2B_PUBLIC {
+        &self.ffi_in_public
+    }
+
+    pub const fn ffi_outside_info(&self) -> &TPM2B_DATA {
+        &self.ffi_outside_info
+    }
+
+    pub const fn ffi_creation_pcr(&self) -> &TPML_PCR_SELECTION {
+        &self.ffi_creation_pcr
+    }
+}
+
+impl Zeroize for CreateInputHandler {
+    fn zeroize(&mut self) {
+        self.ffi_in_parent_handle.zeroize();
+        SensitiveCreateBuffer::zeroize_ffi_data_in_place(&mut self.ffi_in_sensitive);
+        PublicBuffer::zeroize_ffi_data_in_place(&mut self.ffi_in_public);
+        Data::zeroize_ffi_data_in_place(&mut self.ffi_outside_info);
+        PcrSelectionList::zeroize_ffi_data_in_place(&mut self.ffi_creation_pcr);
+    }
+}
+
+impl Drop for CreateInputHandler {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}

--- a/tss-esapi/src/context/tpm_commands/object_commands/ffi_data_handlers/create_output.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands/ffi_data_handlers/create_output.rs
@@ -1,0 +1,88 @@
+// Copyright 2022 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    structures::{
+        CreateKeyResult, CreationData, CreationTicket, Digest, Private, Public, PublicBuffer,
+    },
+    tss2_esys::{TPM2B_CREATION_DATA, TPM2B_DIGEST, TPM2B_PRIVATE, TPM2B_PUBLIC, TPMT_TK_CREATION},
+    Error, Result,
+};
+use std::convert::TryFrom;
+use std::ptr::null_mut;
+
+/// Struct that handles the output of the
+/// Create Esys_Create command.
+pub(crate) struct CreateOutputHandler {
+    ffi_out_public_ptr: *mut TPM2B_PUBLIC,
+    ffi_out_private_ptr: *mut TPM2B_PRIVATE,
+    ffi_creation_data_ptr: *mut TPM2B_CREATION_DATA,
+    ffi_creation_hash_ptr: *mut TPM2B_DIGEST,
+    ffi_creation_ticket_ptr: *mut TPMT_TK_CREATION,
+}
+
+impl CreateOutputHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            ffi_out_public_ptr: null_mut(),
+            ffi_out_private_ptr: null_mut(),
+            ffi_creation_data_ptr: null_mut(),
+            ffi_creation_hash_ptr: null_mut(),
+            ffi_creation_ticket_ptr: null_mut(),
+        }
+    }
+
+    pub fn ffi_out_public_ptr(&mut self) -> &mut *mut TPM2B_PUBLIC {
+        &mut self.ffi_out_public_ptr
+    }
+
+    pub fn ffi_out_private_ptr(&mut self) -> &mut *mut TPM2B_PRIVATE {
+        &mut self.ffi_out_private_ptr
+    }
+
+    pub fn ffi_creation_data_ptr(&mut self) -> &mut *mut TPM2B_CREATION_DATA {
+        &mut self.ffi_creation_data_ptr
+    }
+
+    pub fn ffi_creation_hash_ptr(&mut self) -> &mut *mut TPM2B_DIGEST {
+        &mut self.ffi_creation_hash_ptr
+    }
+
+    pub fn ffi_creation_ticket_ptr(&mut self) -> &mut *mut TPMT_TK_CREATION {
+        &mut self.ffi_creation_ticket_ptr
+    }
+}
+
+impl TryFrom<CreateOutputHandler> for CreateKeyResult {
+    type Error = Error;
+
+    fn try_from(ffi_data_handler: CreateOutputHandler) -> Result<CreateKeyResult> {
+        let out_private_owned = crate::ffi_data::to_owned_with_zeroized_source::<
+            TPM2B_PRIVATE,
+            Private,
+        >(ffi_data_handler.ffi_out_private_ptr);
+        let out_public_owned = crate::ffi_data::to_owned_with_zeroized_source::<
+            TPM2B_PUBLIC,
+            PublicBuffer,
+        >(ffi_data_handler.ffi_out_public_ptr);
+        let creation_data_owned = crate::ffi_data::to_owned_with_zeroized_source::<
+            TPM2B_CREATION_DATA,
+            CreationData,
+        >(ffi_data_handler.ffi_creation_data_ptr);
+        let creation_hash_owned = crate::ffi_data::to_owned_with_zeroized_source::<
+            TPM2B_DIGEST,
+            Digest,
+        >(ffi_data_handler.ffi_creation_hash_ptr);
+        let creation_ticket_owned = crate::ffi_data::to_owned_with_zeroized_source::<
+            TPMT_TK_CREATION,
+            CreationTicket,
+        >(ffi_data_handler.ffi_creation_ticket_ptr);
+        Ok(CreateKeyResult {
+            out_private: Private::try_from(out_private_owned)?,
+            out_public: Public::try_from(out_public_owned)?,
+            creation_data: CreationData::try_from(creation_data_owned)?,
+            creation_hash: Digest::try_from(creation_hash_owned)?,
+            creation_ticket: CreationTicket::try_from(creation_ticket_owned)?,
+        })
+    }
+}

--- a/tss-esapi/src/ffi_data.rs
+++ b/tss-esapi/src/ffi_data.rs
@@ -1,0 +1,20 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::traits::InPlaceFfiDataZeroizer;
+use mbox::MBox;
+use std::ops::DerefMut;
+
+/// Function for taking ownership of data that has been
+/// allocated with C memory allocation functions in TSS while also
+/// zeroizing the memory before freeing it.
+#[allow(dead_code)]
+pub(crate) fn to_owned_with_zeroized_source<T, U>(data_ptr: *mut T) -> T
+where
+    T: Copy,
+    U: InPlaceFfiDataZeroizer<T>,
+{
+    let mut ffi_data = unsafe { MBox::from_raw(data_ptr) };
+    let owned_ffi_data: T = *ffi_data;
+    U::zeroize_ffi_data_in_place(ffi_data.deref_mut());
+    owned_ffi_data
+}

--- a/tss-esapi/src/ffi_data.rs
+++ b/tss-esapi/src/ffi_data.rs
@@ -7,7 +7,6 @@ use std::ops::DerefMut;
 /// Function for taking ownership of data that has been
 /// allocated with C memory allocation functions in TSS while also
 /// zeroizing the memory before freeing it.
-#[allow(dead_code)]
 pub(crate) fn to_owned_with_zeroized_source<T, U>(data_ptr: *mut T) -> T
 where
     T: Copy,

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -93,6 +93,8 @@
 //!
 mod context;
 
+pub(crate) mod ffi_data;
+
 pub mod error;
 pub use tss_esapi_sys as tss2_esys;
 pub mod abstraction;

--- a/tss-esapi/src/structures/algorithm/symmetric/sensitive_create.rs
+++ b/tss-esapi/src/structures/algorithm/symmetric/sensitive_create.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     structures::{Auth, SensitiveData},
-    traits::{Marshall, UnMarshall},
+    traits::{InPlaceFfiDataZeroizer, Marshall, UnMarshall},
     tss2_esys::{TPM2B_SENSITIVE_CREATE, TPMS_SENSITIVE_CREATE},
     Error, Result, ReturnCode, WrapperErrorKind,
 };
@@ -39,6 +39,13 @@ impl SensitiveCreate {
     /// Returns the sensitive data
     pub const fn data(&self) -> &SensitiveData {
         &self.data
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_SENSITIVE_CREATE> for SensitiveCreate {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_SENSITIVE_CREATE) {
+        Auth::zeroize_ffi_data_in_place(&mut ffi_data.userAuth);
+        SensitiveData::zeroize_ffi_data_in_place(&mut ffi_data.data);
     }
 }
 

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -71,10 +71,12 @@ macro_rules! named_field_buffer_type {
         impl TryFrom<$tss_type> for $native_type {
             type Error = Error;
 
-            fn try_from(tss: $tss_type) -> Result<Self> {
+            fn try_from(mut tss: $tss_type) -> Result<Self> {
                 let size = tss.size as usize;
                 Self::ensure_valid_size(size, "buffer")?;
-                Ok($native_type(tss.$buffer_field_name[..size].to_vec().into()))
+                let native = $native_type(tss.$buffer_field_name[..size].to_vec().into());
+                Self::zeroize_ffi_data_in_place(&mut tss);
+                Ok(native)
             }
         }
 

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -4,11 +4,11 @@
 #[allow(unused_macros)]
 macro_rules! named_field_buffer_type {
     ($native_type:ident,$MAX:expr,$tss_type:ident,$buffer_field_name:ident) => {
-        use crate::tss2_esys::$tss_type;
-        use crate::{Error, Result, WrapperErrorKind};
+        use crate::{
+            traits::InPlaceFfiDataZeroizer, tss2_esys::$tss_type, Error, Result, WrapperErrorKind,
+        };
         use log::error;
-        use std::convert::TryFrom;
-        use std::ops::Deref;
+        use std::{convert::TryFrom, ops::Deref};
         use zeroize::{Zeroize, Zeroizing};
 
         #[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
@@ -40,6 +40,13 @@ macro_rules! named_field_buffer_type {
             type Target = Vec<u8>;
             fn deref(&self) -> &Self::Target {
                 &self.0
+            }
+        }
+
+        impl InPlaceFfiDataZeroizer<$tss_type> for $native_type {
+            fn zeroize_ffi_data_in_place(ffi_data: &mut $tss_type) {
+                ffi_data.size.zeroize();
+                ffi_data.$buffer_field_name.zeroize();
             }
         }
 

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -26,6 +26,14 @@ macro_rules! named_field_buffer_type {
             pub fn value(&self) -> &[u8] {
                 &self.0
             }
+
+            fn ensure_valid_size(size: usize, container_name: &str) -> Result<()> {
+                if size > Self::MAX_SIZE {
+                    error!("Invalid {} size(> {})", container_name, Self::MAX_SIZE);
+                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+                }
+                Ok(())
+            }
         }
 
         impl Deref for $native_type {
@@ -39,10 +47,7 @@ macro_rules! named_field_buffer_type {
             type Error = Error;
 
             fn try_from(bytes: Vec<u8>) -> Result<Self> {
-                if bytes.len() > Self::MAX_SIZE {
-                    error!("Invalid Vec<u8> size(> {})", Self::MAX_SIZE);
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
+                Self::ensure_valid_size(bytes.len(), "Vec<u8>")?;
                 Ok($native_type(bytes.into()))
             }
         }
@@ -51,10 +56,7 @@ macro_rules! named_field_buffer_type {
             type Error = Error;
 
             fn try_from(bytes: &[u8]) -> Result<Self> {
-                if bytes.len() > Self::MAX_SIZE {
-                    error!("Invalid &[u8] size(> {})", Self::MAX_SIZE);
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
+                Self::ensure_valid_size(bytes.len(), "&[u8]")?;
                 Ok($native_type(bytes.to_vec().into()))
             }
         }
@@ -64,10 +66,7 @@ macro_rules! named_field_buffer_type {
 
             fn try_from(tss: $tss_type) -> Result<Self> {
                 let size = tss.size as usize;
-                if size > Self::MAX_SIZE {
-                    error!("Invalid buffer size(> {})", Self::MAX_SIZE);
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
+                Self::ensure_valid_size(size, "buffer")?;
                 Ok($native_type(tss.$buffer_field_name[..size].to_vec().into()))
             }
         }

--- a/tss-esapi/src/structures/buffers/public.rs
+++ b/tss-esapi/src/structures/buffers/public.rs
@@ -12,7 +12,7 @@ use std::{
     convert::{TryFrom, TryInto},
     ops::Deref,
 };
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Public data buffer.
 ///
@@ -20,8 +20,7 @@ use zeroize::Zeroize;
 /// Corresponds to `TPM2B_PUBLIC`. The contents of
 /// the buffer can be unmarshalled into a [Public]
 /// structure.
-#[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
-#[zeroize(drop)]
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct PublicBuffer(Vec<u8>);
 
 impl PublicBuffer {

--- a/tss-esapi/src/structures/buffers/public.rs
+++ b/tss-esapi/src/structures/buffers/public.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     structures::Public,
+    traits::InPlaceFfiDataZeroizer,
     traits::{Marshall, UnMarshall},
     tss2_esys::{TPM2B_PUBLIC, TPMT_PUBLIC},
     Error, Result, ReturnCode, WrapperErrorKind,
@@ -171,5 +172,12 @@ impl UnMarshall for PublicBuffer {
         )?;
 
         PublicBuffer::try_from(dest)
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPM2B_PUBLIC> for PublicBuffer {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPM2B_PUBLIC) {
+        ffi_data.size.zeroize();
+        Public::zeroize_ffi_data_in_place(&mut ffi_data.publicArea);
     }
 }

--- a/tss-esapi/src/structures/buffers/sensitive.rs
+++ b/tss-esapi/src/structures/buffers/sensitive.rs
@@ -11,7 +11,7 @@ use std::{
     convert::{TryFrom, TryInto},
     ops::Deref,
 };
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Sensitive data buffer.
 ///
@@ -19,8 +19,7 @@ use zeroize::Zeroize;
 /// Corresponds to `TPM2B_SENSITIVE`. The contents of
 /// the buffer can be unmarshalled into a [Sensitive]
 /// structure.
-#[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
-#[zeroize(drop)]
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct SensitiveBuffer(Vec<u8>);
 
 impl SensitiveBuffer {

--- a/tss-esapi/src/structures/buffers/sensitive_create.rs
+++ b/tss-esapi/src/structures/buffers/sensitive_create.rs
@@ -11,7 +11,7 @@ use std::{
     convert::{TryFrom, TryInto},
     ops::Deref,
 };
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// The [SensitiveCreate] buffer type.
 ///
@@ -19,8 +19,7 @@ use zeroize::Zeroize;
 /// The SensitiveCreateBuffer contains [SensitiveCreate] in marshalled
 /// form. It can be unmarshalled into [SensitiveCreate] or [TPM2B_SENSITIVE_CREATE].
 /// structure.
-#[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
-#[zeroize(drop)]
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct SensitiveCreateBuffer(Vec<u8>);
 
 impl SensitiveCreateBuffer {

--- a/tss-esapi/src/structures/buffers/sensitive_create.rs
+++ b/tss-esapi/src/structures/buffers/sensitive_create.rs
@@ -37,10 +37,10 @@ impl SensitiveCreateBuffer {
             Ok(())
         } else {
             error!(
-                "Error: Invalid {} size ({} >= {} >= {})",
+                "Size {} for {} is not in valid range(({} >= ) AND ( >= {}))",
+                buffer_size,
                 container_name,
                 Self::MAX_SIZE,
-                buffer_size,
                 Self::MIN_SIZE,
             );
             Err(Error::local_error(WrapperErrorKind::WrongParamSize))

--- a/tss-esapi/src/structures/buffers/sensitive_create.rs
+++ b/tss-esapi/src/structures/buffers/sensitive_create.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     structures::SensitiveCreate,
-    traits::{Marshall, UnMarshall},
+    traits::{InPlaceFfiDataZeroizer, Marshall, UnMarshall},
     tss2_esys::{TPM2B_SENSITIVE_CREATE, TPMS_SENSITIVE_CREATE},
     Error, Result, ReturnCode, WrapperErrorKind,
 };
@@ -53,6 +53,13 @@ impl Deref for SensitiveCreateBuffer {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPM2B_SENSITIVE_CREATE> for SensitiveCreateBuffer {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPM2B_SENSITIVE_CREATE) {
+        ffi_data.size.zeroize();
+        SensitiveCreate::zeroize_ffi_data_in_place(&mut ffi_data.sensitive);
     }
 }
 

--- a/tss-esapi/src/structures/creation.rs
+++ b/tss-esapi/src/structures/creation.rs
@@ -1,11 +1,14 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
+use zeroize::Zeroize;
+
 use crate::{
     attributes::LocalityAttributes,
     constants::AlgorithmIdentifier,
     interface_types::algorithm::HashingAlgorithm,
     structures::{Data, Digest, Name, PcrSelectionList},
+    traits::InPlaceFfiDataZeroizer,
     tss2_esys::{TPM2B_CREATION_DATA, TPMS_CREATION_DATA},
     Error, Result,
 };
@@ -61,5 +64,23 @@ impl From<CreationData> for TPMS_CREATION_DATA {
             parentQualifiedName: creation_data.parent_qualified_name.into(),
             outsideInfo: creation_data.outside_info.into(),
         }
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_CREATION_DATA> for CreationData {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_CREATION_DATA) {
+        PcrSelectionList::zeroize_ffi_data_in_place(&mut ffi_data.pcrSelect);
+        Digest::zeroize_ffi_data_in_place(&mut ffi_data.pcrDigest);
+        ffi_data.locality.zeroize();
+        ffi_data.parentNameAlg.zeroize();
+        Name::zeroize_ffi_data_in_place(&mut ffi_data.parentName);
+        Name::zeroize_ffi_data_in_place(&mut ffi_data.parentQualifiedName);
+        Data::zeroize_ffi_data_in_place(&mut ffi_data.outsideInfo);
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPM2B_CREATION_DATA> for CreationData {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPM2B_CREATION_DATA) {
+        CreationData::zeroize_ffi_data_in_place(&mut ffi_data.creationData);
     }
 }

--- a/tss-esapi/src/structures/ecc/point.rs
+++ b/tss-esapi/src/structures/ecc/point.rs
@@ -2,7 +2,10 @@ use tss_esapi_sys::TPM2B_ECC_POINT;
 
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::{structures::EccParameter, tss2_esys::TPMS_ECC_POINT, Error, Result};
+use crate::{
+    structures::EccParameter, traits::InPlaceFfiDataZeroizer, tss2_esys::TPMS_ECC_POINT, Error,
+    Result,
+};
 use std::convert::{TryFrom, TryInto};
 
 /// Structure holding ecc point information
@@ -68,5 +71,12 @@ impl TryFrom<TPMS_ECC_POINT> for EccPoint {
             x: tpms_ecc_point.x.try_into()?,
             y: tpms_ecc_point.y.try_into()?,
         })
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_ECC_POINT> for EccPoint {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_ECC_POINT) {
+        EccParameter::zeroize_ffi_data_in_place(&mut ffi_data.x);
+        EccParameter::zeroize_ffi_data_in_place(&mut ffi_data.y);
     }
 }

--- a/tss-esapi/src/structures/names/name.rs
+++ b/tss-esapi/src/structures/names/name.rs
@@ -1,9 +1,11 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::tss2_esys::TPM2B_NAME;
-use crate::{Error, Result, WrapperErrorKind};
+use crate::{
+    traits::InPlaceFfiDataZeroizer, tss2_esys::TPM2B_NAME, Error, Result, WrapperErrorKind,
+};
 use log::error;
 use std::convert::TryFrom;
+use zeroize::Zeroize;
 /// Structure holding the data representing names
 #[allow(missing_copy_implementations)]
 #[derive(Debug, Clone)]
@@ -63,5 +65,12 @@ impl From<Name> for TPM2B_NAME {
 impl AsRef<TPM2B_NAME> for Name {
     fn as_ref(&self) -> &TPM2B_NAME {
         &self.value
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPM2B_NAME> for Name {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPM2B_NAME) {
+        ffi_data.size.zeroize();
+        ffi_data.name.zeroize();
     }
 }

--- a/tss-esapi/src/structures/parameters.rs
+++ b/tss-esapi/src/structures/parameters.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    structures::SymmetricDefinitionObject, tss2_esys::TPMS_SYMCIPHER_PARMS, Error, Result,
+    structures::SymmetricDefinitionObject, traits::InPlaceFfiDataZeroizer,
+    tss2_esys::TPMS_SYMCIPHER_PARMS, Error, Result,
 };
 
 use std::convert::{TryFrom, TryInto};
@@ -43,5 +44,11 @@ impl From<SymmetricCipherParameters> for TPMS_SYMCIPHER_PARMS {
                 .symmetric_definition_object
                 .into(),
         }
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_SYMCIPHER_PARMS> for SymmetricCipherParameters {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_SYMCIPHER_PARMS) {
+        SymmetricDefinitionObject::zeroize_ffi_data_in_place(&mut ffi_data.sym);
     }
 }

--- a/tss-esapi/src/structures/pcr/selection.rs
+++ b/tss-esapi/src/structures/pcr/selection.rs
@@ -3,11 +3,13 @@
 use crate::{
     interface_types::algorithm::HashingAlgorithm,
     structures::{PcrSelectSize, PcrSlot, PcrSlotCollection},
+    traits::InPlaceFfiDataZeroizer,
     tss2_esys::TPMS_PCR_SELECTION,
     Error, Result, WrapperErrorKind,
 };
 use log::error;
 use std::convert::TryFrom;
+use zeroize::Zeroize;
 /// This module contains the PcrSelection struct.
 /// The TSS counterpart of this struct is the
 /// TPMS_PCR_SELECTION.
@@ -161,5 +163,13 @@ impl From<PcrSelection> for TPMS_PCR_SELECTION {
             sizeofSelect: size_of_select,
             pcrSelect: pcr_select,
         }
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_PCR_SELECTION> for PcrSelection {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_PCR_SELECTION) {
+        ffi_data.hash.zeroize();
+        ffi_data.sizeofSelect.zeroize();
+        ffi_data.pcrSelect.zeroize();
     }
 }

--- a/tss-esapi/src/structures/schemes.rs
+++ b/tss-esapi/src/structures/schemes.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     interface_types::algorithm::{HashingAlgorithm, KeyDerivationFunction},
+    traits::InPlaceFfiDataZeroizer,
     tss2_esys::{TPMS_SCHEME_ECDAA, TPMS_SCHEME_HASH, TPMS_SCHEME_HMAC, TPMS_SCHEME_XOR},
     Error, Result,
 };
 use std::convert::{TryFrom, TryInto};
+use zeroize::Zeroize;
 /// Struct for holding the hash scheme
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HashScheme {
@@ -38,6 +40,12 @@ impl From<HashScheme> for TPMS_SCHEME_HASH {
         TPMS_SCHEME_HASH {
             hashAlg: hash_scheme.hashing_algorithm.into(),
         }
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_SCHEME_HASH> for HashScheme {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_SCHEME_HASH) {
+        ffi_data.hashAlg.zeroize();
     }
 }
 
@@ -87,6 +95,12 @@ impl From<HmacScheme> for TPMS_SCHEME_HMAC {
     }
 }
 
+impl InPlaceFfiDataZeroizer<TPMS_SCHEME_HMAC> for HmacScheme {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_SCHEME_HMAC) {
+        ffi_data.hashAlg.zeroize();
+    }
+}
+
 /// Struct for holding the xor scheme
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct XorScheme {
@@ -123,6 +137,13 @@ impl From<XorScheme> for TPMS_SCHEME_XOR {
             hashAlg: xor_scheme.hashing_algorithm.into(),
             kdf: xor_scheme.key_derivation_function.into(),
         }
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_SCHEME_XOR> for XorScheme {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_SCHEME_XOR) {
+        ffi_data.hashAlg.zeroize();
+        ffi_data.kdf.zeroize();
     }
 }
 
@@ -173,5 +194,12 @@ impl TryFrom<TPMS_SCHEME_ECDAA> for EcDaaScheme {
             hashing_algorithm: tpms_scheme_ecdaa.hashAlg.try_into()?,
             count: tpms_scheme_ecdaa.count,
         })
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_SCHEME_ECDAA> for EcDaaScheme {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_SCHEME_ECDAA) {
+        ffi_data.hashAlg.zeroize();
+        ffi_data.count.zeroize();
     }
 }

--- a/tss-esapi/src/structures/tagged/public/keyed_hash.rs
+++ b/tss-esapi/src/structures/tagged/public/keyed_hash.rs
@@ -1,6 +1,9 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::{structures::KeyedHashScheme, tss2_esys::TPMS_KEYEDHASH_PARMS, Error, Result};
+use crate::{
+    structures::KeyedHashScheme, traits::InPlaceFfiDataZeroizer, tss2_esys::TPMS_KEYEDHASH_PARMS,
+    Error, Result,
+};
 use std::convert::{TryFrom, TryInto};
 
 /// Keyed hash parameters
@@ -35,5 +38,11 @@ impl From<PublicKeyedHashParameters> for TPMS_KEYEDHASH_PARMS {
         TPMS_KEYEDHASH_PARMS {
             scheme: public_keyed_hash_prams.keyed_hash_scheme.into(),
         }
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_KEYEDHASH_PARMS> for PublicKeyedHashParameters {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_KEYEDHASH_PARMS) {
+        KeyedHashScheme::zeroize_ffi_data_in_place(&mut ffi_data.scheme);
     }
 }

--- a/tss-esapi/src/structures/tagged/public/rsa.rs
+++ b/tss-esapi/src/structures/tagged/public/rsa.rs
@@ -3,11 +3,13 @@
 use crate::{
     interface_types::{algorithm::RsaSchemeAlgorithm, key_bits::RsaKeyBits},
     structures::{RsaScheme, SymmetricDefinitionObject},
+    traits::InPlaceFfiDataZeroizer,
     tss2_esys::{TPMS_RSA_PARMS, UINT32},
     Error, Result, WrapperErrorKind,
 };
 use log::error;
 use std::convert::{TryFrom, TryInto};
+use zeroize::Zeroize;
 
 /// Builder for `TPMS_RSA_PARMS` values.
 #[derive(Copy, Clone, Default, Debug)]
@@ -350,5 +352,14 @@ impl TryFrom<TPMS_RSA_PARMS> for PublicRsaParameters {
             key_bits: tpms_rsa_parms.keyBits.try_into()?,
             exponent: tpms_rsa_parms.exponent.try_into()?,
         })
+    }
+}
+
+impl InPlaceFfiDataZeroizer<TPMS_RSA_PARMS> for PublicRsaParameters {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut TPMS_RSA_PARMS) {
+        SymmetricDefinitionObject::zeroize_ffi_data_in_place(&mut ffi_data.symmetric);
+        RsaScheme::zeroize_ffi_data_in_place(&mut ffi_data.scheme);
+        ffi_data.keyBits.zeroize();
+        ffi_data.exponent.zeroize();
     }
 }

--- a/tss-esapi/src/traits.rs
+++ b/tss-esapi/src/traits.rs
@@ -16,3 +16,9 @@ pub trait UnMarshall: Sized {
     /// Creates the type from marshalled data.
     fn unmarshall(marshalled_data: &[u8]) -> Result<Self>;
 }
+
+/// Trait for types that can zeroize their
+/// associated FFI data in place.
+pub trait InPlaceFfiDataZeroizer<T> {
+    fn zeroize_ffi_data_in_place(ffi_data: &mut T);
+}

--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -21,10 +21,9 @@ use crate::structures::{
 };
 use crate::tss2_esys::*;
 use crate::{Context, Error, Result, WrapperErrorKind};
-use zeroize::Zeroize;
-
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Rust native wrapper for `TPMS_CONTEXT` objects.
 ///
@@ -32,8 +31,7 @@ use std::convert::{TryFrom, TryInto};
 /// saving the context of an object is to be able to re-use it later, on demand, a serializable
 /// structure is most commonly needed. `TpmsContext` implements the `Serialize` and `Deserialize`
 /// defined by `serde`.
-#[derive(Debug, Serialize, Deserialize, Clone, Zeroize)]
-#[zeroize(drop)]
+#[derive(Debug, Serialize, Deserialize, Clone, Zeroize, ZeroizeOnDrop)]
 pub struct TpmsContext {
     sequence: u64,
     saved_handle: TPMI_DH_CONTEXT,


### PR DESCRIPTION
- Adds a new InPlaceFfiDataZeroizer trait that types can implement in order to provide a zeroize capabilities for their associated FFI data.
- Implements the new InPlaceFfiDataZeroizer for several types in order to improve zerozation whe calling the create context method.
- Adds CreateInputHandler type to manage the input parameters the create context method and to zeroize the FFI data when dropped.
- Adds CreateOutputHandler to manage the FFI output parameters and when converted into CreateKeyResult properly zeroize FFI data allocated by the TSS.