### PR TITLE
Fixes errors reported by linter in rust 1.63.

### DIFF
--- a/tss-esapi/src/error.rs
+++ b/tss-esapi/src/error.rs
@@ -15,7 +15,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Main error type used by the crate to return issues with a method call. The value can either be
 /// a TSS-generated response code or a wrapper error - marking an issue caught within the wrapping
 /// layer.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Error {
     WrapperError(WrapperErrorKind),
     TssError(ReturnCode),

--- a/tss-esapi/src/error/return_code.rs
+++ b/tss-esapi/src/error/return_code.rs
@@ -29,7 +29,7 @@ pub use tpm::{
 
 /// Enum representing return codes and response codes
 /// from the TSS and the TPM that indicates an error.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ReturnCode {
     Tpm(TpmResponseCode),
     Fapi(FapiReturnCode),

--- a/tss-esapi/src/error/return_code/tpm/format_zero.rs
+++ b/tss-esapi/src/error/return_code/tpm/format_zero.rs
@@ -91,7 +91,7 @@ impl std::fmt::Display for TpmFormatZeroResponseCode {
 }
 
 bitfield! {
-    #[derive(PartialEq, Copy, Clone)]
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct FormatZeroResponseCodeStructure(u16);
     impl Debug;
     u8, error_number, set_error_number: 6, 0;

--- a/tss-esapi/src/error/wrapper.rs
+++ b/tss-esapi/src/error/wrapper.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 /// List of error types that might occur in the wrapper.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum WrapperErrorKind {
     /// Returned when a size or length-defined parameter does not conform with the size

--- a/tss-esapi/src/structures/lists/ecc_curves.rs
+++ b/tss-esapi/src/structures/lists/ecc_curves.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 ///
 /// # Details
 /// This corresponds to `TPML_ECC_CURVE`.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EccCurveList {
     ecc_curves: Vec<EccCurveIdentifier>,
 }

--- a/tss-esapi/src/structures/lists/handles.rs
+++ b/tss-esapi/src/structures/lists/handles.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 ///
 /// # Details
 /// This corresponds to `TPML_HANDLE`.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct HandleList {
     handles: Vec<TpmHandle>,
 }

--- a/tss-esapi/src/tcti_ldr.rs
+++ b/tss-esapi/src/tcti_ldr.rs
@@ -125,7 +125,7 @@ impl Drop for TctiInfo {
 
 /// Placeholder TCTI types that can be used when initialising a `Context` to determine which
 /// interface will be used to communicate with the TPM.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TctiNameConf {
     /// Connect to a TPM available as a device node on the system
     ///
@@ -313,7 +313,7 @@ fn validate_from_str_tcti() {
 ///
 /// The default configuration uses the library default of
 /// `/dev/tpm0`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeviceConfig {
     /// Path to the device node to connect to
     ///
@@ -355,7 +355,7 @@ fn validate_from_str_device_config() {
 /// Configuration for an Mssim TCTI context
 ///
 /// The default configuration will point to `localhost:2321`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NetworkTPMConfig {
     /// Address of the server to connect to
     ///
@@ -455,7 +455,7 @@ fn validate_from_str_networktpm_config() {
 /// Address of a TPM server
 ///
 /// The default value is `localhost`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ServerAddress {
     /// IPv4 or IPv6 address
     Ip(IpAddr),
@@ -498,7 +498,7 @@ impl Default for ServerAddress {
 }
 
 /// Configuration for a TABRMD TCTI context
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TabrmdConfig {
     /// Bus name to be used by TABRMD
     ///
@@ -555,7 +555,7 @@ impl FromStr for TabrmdConfig {
 }
 
 /// DBus type for usage with TABRMD
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum BusType {
     System,
     Session,


### PR DESCRIPTION
- Derives Eq for all types that currently only derives PartialEq.
  In version 1.63 of rust Clippy reports a lint error
  when PartialEq has been derived without deriving Eq as well.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>