### PR TITLE
Removes from slice conversions for buffer types.

### DIFF
--- a/tss-esapi/src/abstraction/nv.rs
+++ b/tss-esapi/src/abstraction/nv.rs
@@ -213,8 +213,7 @@ impl std::io::Write for NvReaderWriter<'_> {
         let desired_size = std::cmp::min(buf.len(), self.data_size - self.offset);
         let size = std::cmp::min(self.buffer_size, desired_size) as u16;
 
-        let data = buf[0..size.into()]
-            .try_into()
+        let data = MaxNvBuffer::from_bytes(&buf[0..size.into()])
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         self.context
             .nv_write(self.auth_handle, self.nv_idx, data, self.offset as u16)

--- a/tss-esapi/src/abstraction/pcr/data.rs
+++ b/tss-esapi/src/abstraction/pcr/data.rs
@@ -125,7 +125,7 @@ impl From<PcrData> for Vec<TPML_DIGEST> {
                     tpml_digest.count += 1;
                     tpml_digest.digests[index].size = digest.len() as u16;
                     tpml_digest.digests[index].buffer[..digest.len()]
-                        .copy_from_slice(digest.value());
+                        .copy_from_slice(digest.as_bytes());
                 }
                 tpml_digest
             })

--- a/tss-esapi/src/abstraction/public.rs
+++ b/tss-esapi/src/abstraction/public.rs
@@ -84,13 +84,13 @@ fn public_to_decoded_key(public: &Public) -> Result<DecodedKey, Error> {
             }
             .to_be_bytes();
             Ok(DecodedKey::RsaPublicKey(RsaPublicKey {
-                modulus: IntegerAsn1::from_bytes_be_unsigned(unique.value().to_vec()),
+                modulus: IntegerAsn1::from_bytes_be_unsigned(unique.as_bytes().to_vec()),
                 public_exponent: IntegerAsn1::from_bytes_be_signed(exponent.to_vec()),
             }))
         }
         Public::Ecc { unique, .. } => {
-            let x = unique.x().value().to_vec();
-            let y = unique.y().value().to_vec();
+            let x = unique.x().as_bytes().to_vec();
+            let y = unique.y().as_bytes().to_vec();
             Ok(DecodedKey::EcPoint(OctetStringAsn1(
                 elliptic_curve_point_to_octet_string(x, y),
             )))

--- a/tss-esapi/src/abstraction/transient/key_attestation.rs
+++ b/tss-esapi/src/abstraction/transient/key_attestation.rs
@@ -53,7 +53,7 @@ impl TransientKeyContext {
     /// the credential
     ///
     /// **Note**: If no `key` is given, the default Endorsement Key
-    /// will be used.  
+    /// will be used.
     pub fn get_make_cred_params(
         &mut self,
         object: ObjectWrapper,
@@ -131,7 +131,7 @@ impl TransientKeyContext {
         self.context.flush_context(key_handle.into())?;
         self.context
             .flush_context(SessionHandle::from(session_2).into())?;
-        Ok(credential.value().to_vec())
+        Ok(credential.as_bytes().to_vec())
     }
 
     // No key was given, use the EK. This requires using a Policy session

--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -149,7 +149,7 @@ impl TransientKeyContext {
         let key_auth = if auth_size > 0 {
             self.set_session_attrs()?;
             let random_bytes = self.context.get_random(auth_size)?;
-            Some(Auth::try_from(random_bytes.value().to_vec())?)
+            Some(Auth::from_bytes(random_bytes.as_bytes())?)
         } else {
             None
         };
@@ -170,7 +170,7 @@ impl TransientKeyContext {
 
         let key_material = KeyMaterial {
             public: out_public.try_into()?,
-            private: out_private.value().to_vec(),
+            private: out_private.as_bytes().to_vec(),
         };
         Ok((key_material, key_auth))
     }
@@ -390,7 +390,7 @@ impl TransientKeyContext {
 
         let key_material = KeyMaterial {
             public: public.try_into()?,
-            private: private.value().to_vec(),
+            private: private.as_bytes().to_vec(),
         };
 
         self.context.flush_context(key_handle.into())?;
@@ -670,7 +670,7 @@ impl TransientKeyContextBuilder {
 
         let root_key_auth = if self.root_key_auth_size > 0 {
             let random = context.get_random(self.root_key_auth_size)?;
-            Some(Auth::try_from(random.value().to_vec())?)
+            Some(Auth::from_bytes(random.as_bytes())?)
         } else {
             None
         };

--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -128,7 +128,7 @@ impl Context {
     /// #     .expect("Failed to set attributes on session");
     /// # context.set_sessions((Some(session), None, None));
     /// # let random_digest = context.get_random(16).unwrap();
-    /// # let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+    /// # let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
     /// #
     /// // Create a key suitable for ECDH key generation
     /// let ecc_parms = PublicEccParametersBuilder::new()
@@ -263,7 +263,7 @@ impl Context {
     /// #     .expect("Failed to set attributes on session");
     /// # context.set_sessions((Some(session), None, None));
     /// # let random_digest = context.get_random(16).unwrap();
-    /// # let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+    /// # let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
     /// #
     /// // Create a key suitable for ECDH key generation
     /// let ecc_parms = PublicEccParametersBuilder::new()
@@ -313,7 +313,7 @@ impl Context {
     /// // Generate ephemeral key pair and a shared secret
     /// let (z_point, pub_point) = context.ecdh_key_gen(key_handle).unwrap();
     /// let z_point_gen = context.ecdh_z_gen(key_handle, pub_point).unwrap();
-    /// assert_eq!(z_point.x().value(), z_point_gen.x().value());
+    /// assert_eq!(z_point.x().as_bytes(), z_point_gen.x().as_bytes());
     /// ```
     pub fn ecdh_z_gen(&mut self, key_handle: KeyHandle, in_point: EccPoint) -> Result<EccPoint> {
         let mut out_point_ptr = null_mut();

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -114,7 +114,7 @@ impl Context {
     /// context.execute_with_session(Some(session), |ctx| {
     ///     let random_digest = ctx.get_random(16)
     ///         .expect("Call to get_random failed");
-    ///     let key_auth = Auth::try_from(random_digest.value().to_vec())
+    ///     let key_auth = Auth::from_bytes(random_digest.as_bytes())
     ///         .expect("Failed to create Auth");
     ///     let key_handle = ctx
     ///         .create_primary(

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -60,7 +60,7 @@ impl Context {
     /// #     context
     /// #         .get_random(16)
     /// #         .expect("get_rand call failed")
-    /// #         .value()
+    /// #         .as_bytes()
     /// #         .to_vec(),
     /// # )
     /// # .expect("Failed to create primary key auth");
@@ -107,7 +107,7 @@ impl Context {
     /// #     context
     /// #         .get_random(16)
     /// #         .expect("get_rand call failed")
-    /// #         .value()
+    /// #         .as_bytes()
     /// #         .to_vec(),
     /// # )
     /// # .expect("Failed to create symmetric key auth");

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -168,6 +168,38 @@ pub mod digest {
             Ok(result)
         }
     }
+
+    impl From<[u8; 20]> for Digest {
+        fn from(mut value: [u8; 20]) -> Self {
+            let value_as_vec = value.to_vec();
+            value.zeroize();
+            Digest(value_as_vec.into())
+        }
+    }
+
+    impl From<[u8; 32]> for Digest {
+        fn from(mut value: [u8; 32]) -> Self {
+            let value_as_vec = value.to_vec();
+            value.zeroize();
+            Digest(value_as_vec.into())
+        }
+    }
+
+    impl From<[u8; 48]> for Digest {
+        fn from(mut value: [u8; 48]) -> Self {
+            let value_as_vec = value.to_vec();
+            value.zeroize();
+            Digest(value_as_vec.into())
+        }
+    }
+
+    impl From<[u8; 64]> for Digest {
+        fn from(mut value: [u8; 64]) -> Self {
+            let value_as_vec = value.to_vec();
+            value.zeroize();
+            Digest(value_as_vec.into())
+        }
+    }
 }
 
 pub mod ecc_parameter {

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -23,8 +23,15 @@ macro_rules! named_field_buffer_type {
         impl $native_type {
             pub const MAX_SIZE: usize = $MAX;
 
-            pub fn value(&self) -> &[u8] {
-                &self.0
+            pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+                Self::ensure_valid_buffer_size(bytes.len(), "bytes(&[u8])")?;
+                Ok($native_type(bytes.to_vec().into()))
+            }
+
+            /// Returns the content of the buffer type as
+            /// a slice of bytes.
+            pub fn as_bytes(&self) -> &[u8] {
+                self.0.as_slice()
             }
 
             /// Private function for ensuring that a buffer size is valid.
@@ -50,15 +57,6 @@ macro_rules! named_field_buffer_type {
             fn try_from(bytes: Vec<u8>) -> Result<Self> {
                 Self::ensure_valid_buffer_size(bytes.len(), "Vec<u8>")?;
                 Ok($native_type(bytes.into()))
-            }
-        }
-
-        impl TryFrom<&[u8]> for $native_type {
-            type Error = Error;
-
-            fn try_from(bytes: &[u8]) -> Result<Self> {
-                Self::ensure_valid_buffer_size(bytes.len(), "&[u8]")?;
-                Ok($native_type(bytes.to_vec().into()))
             }
         }
 
@@ -119,7 +117,7 @@ pub mod digest {
 
         fn try_from(value: Digest) -> Result<Self> {
             value
-                .value()
+                .as_bytes()
                 .try_into()
                 .map_err(|_| Error::local_error(WrapperErrorKind::WrongParamSize))
         }
@@ -130,7 +128,7 @@ pub mod digest {
 
         fn try_from(value: Digest) -> Result<Self> {
             value
-                .value()
+                .as_bytes()
                 .try_into()
                 .map_err(|_| Error::local_error(WrapperErrorKind::WrongParamSize))
         }
@@ -141,13 +139,13 @@ pub mod digest {
         type Error = Error;
 
         fn try_from(value: Digest) -> Result<Self> {
-            if value.value().len() != 48 {
+            if value.len() != 48 {
                 return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
             }
 
             let mut result = [0; 48];
 
-            result.copy_from_slice(value.value());
+            result.copy_from_slice(value.as_bytes());
 
             Ok(result)
         }
@@ -157,13 +155,13 @@ pub mod digest {
         type Error = Error;
 
         fn try_from(value: Digest) -> Result<Self> {
-            if value.value().len() != 64 {
+            if value.len() != 64 {
                 return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
             }
 
             let mut result = [0; 64];
 
-            result.copy_from_slice(value.value());
+            result.copy_from_slice(value.as_bytes());
 
             Ok(result)
         }
@@ -300,12 +298,12 @@ pub mod public_key_rsa {
         type Error = Error;
 
         fn try_from(public_key_rsa: PublicKeyRsa) -> Result<Self> {
-            if public_key_rsa.value().len() > 128 {
+            if public_key_rsa.len() > 128 {
                 return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
             }
 
             let mut value = [0u8; 128];
-            value.copy_from_slice(public_key_rsa.value());
+            value.copy_from_slice(public_key_rsa.as_bytes());
             Ok(value)
         }
     }
@@ -314,12 +312,12 @@ pub mod public_key_rsa {
         type Error = Error;
 
         fn try_from(public_key_rsa: PublicKeyRsa) -> Result<Self> {
-            if public_key_rsa.value().len() > 256 {
+            if public_key_rsa.len() > 256 {
                 return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
             }
 
             let mut value = [0u8; 256];
-            value.copy_from_slice(public_key_rsa.value());
+            value.copy_from_slice(public_key_rsa.as_bytes());
             Ok(value)
         }
     }
@@ -328,12 +326,12 @@ pub mod public_key_rsa {
         type Error = Error;
 
         fn try_from(public_key_rsa: PublicKeyRsa) -> Result<Self> {
-            if public_key_rsa.value().len() > 384 {
+            if public_key_rsa.len() > 384 {
                 return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
             }
 
             let mut value = [0u8; 384];
-            value.copy_from_slice(public_key_rsa.value());
+            value.copy_from_slice(public_key_rsa.as_bytes());
             Ok(value)
         }
     }
@@ -342,12 +340,12 @@ pub mod public_key_rsa {
         type Error = Error;
 
         fn try_from(public_key_rsa: PublicKeyRsa) -> Result<Self> {
-            if public_key_rsa.value().len() > 512 {
+            if public_key_rsa.len() > 512 {
                 return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
             }
 
             let mut value = [0u8; 512];
-            value.copy_from_slice(public_key_rsa.value());
+            value.copy_from_slice(public_key_rsa.as_bytes());
             Ok(value)
         }
     }

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -26,6 +26,15 @@ macro_rules! named_field_buffer_type {
             pub fn value(&self) -> &[u8] {
                 &self.0
             }
+
+            /// Private function for ensuring that a buffer size is valid.
+            fn ensure_valid_buffer_size(buffer_size: usize, container_name: &str) -> Result<()> {
+                if buffer_size > Self::MAX_SIZE {
+                    error!("Invalid {} size(> {})", container_name, Self::MAX_SIZE);
+                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+                }
+                Ok(())
+            }
         }
 
         impl Deref for $native_type {
@@ -39,10 +48,7 @@ macro_rules! named_field_buffer_type {
             type Error = Error;
 
             fn try_from(bytes: Vec<u8>) -> Result<Self> {
-                if bytes.len() > Self::MAX_SIZE {
-                    error!("Invalid Vec<u8> size(> {})", Self::MAX_SIZE);
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
+                Self::ensure_valid_buffer_size(bytes.len(), "Vec<u8>")?;
                 Ok($native_type(bytes.into()))
             }
         }
@@ -51,10 +57,7 @@ macro_rules! named_field_buffer_type {
             type Error = Error;
 
             fn try_from(bytes: &[u8]) -> Result<Self> {
-                if bytes.len() > Self::MAX_SIZE {
-                    error!("Invalid &[u8] size(> {})", Self::MAX_SIZE);
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
+                Self::ensure_valid_buffer_size(bytes.len(), "&[u8]")?;
                 Ok($native_type(bytes.to_vec().into()))
             }
         }
@@ -64,10 +67,7 @@ macro_rules! named_field_buffer_type {
 
             fn try_from(tss: $tss_type) -> Result<Self> {
                 let size = tss.size as usize;
-                if size > Self::MAX_SIZE {
-                    error!("Invalid buffer size(> {})", Self::MAX_SIZE);
-                    return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-                }
+                Self::ensure_valid_buffer_size(size, "buffer")?;
                 Ok($native_type(tss.$buffer_field_name[..size].to_vec().into()))
             }
         }

--- a/tss-esapi/src/structures/buffers/attest.rs
+++ b/tss-esapi/src/structures/buffers/attest.rs
@@ -30,6 +30,15 @@ impl AttestBuffer {
     pub fn value(&self) -> &[u8] {
         &self.0
     }
+
+    /// Private function for ensuring that a buffer size is valid.
+    fn ensure_valid_buffer_size(buffer_size: usize, container_name: &str) -> Result<()> {
+        if buffer_size > Self::MAX_SIZE {
+            error!("Invalid {} size(> {})", container_name, Self::MAX_SIZE);
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        Ok(())
+    }
 }
 
 impl Deref for AttestBuffer {
@@ -44,10 +53,7 @@ impl TryFrom<Vec<u8>> for AttestBuffer {
     type Error = Error;
 
     fn try_from(bytes: Vec<u8>) -> Result<Self> {
-        if bytes.len() > Self::MAX_SIZE {
-            error!("Invalid Vec<u8> size(> {})", Self::MAX_SIZE);
-            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-        }
+        Self::ensure_valid_buffer_size(bytes.len(), "Vec<u8>")?;
         Ok(AttestBuffer(bytes.into()))
     }
 }
@@ -56,10 +62,7 @@ impl TryFrom<&[u8]> for AttestBuffer {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() > Self::MAX_SIZE {
-            error!("Invalid &[u8] size(> {})", Self::MAX_SIZE);
-            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-        }
+        Self::ensure_valid_buffer_size(bytes.len(), "&[u8]")?;
         Ok(AttestBuffer(bytes.to_vec().into()))
     }
 }
@@ -69,10 +72,7 @@ impl TryFrom<TPM2B_ATTEST> for AttestBuffer {
 
     fn try_from(tss: TPM2B_ATTEST) -> Result<Self> {
         let size = tss.size as usize;
-        if size > Self::MAX_SIZE {
-            error!("Invalid buffer size(> {})", Self::MAX_SIZE);
-            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
-        }
+        Self::ensure_valid_buffer_size(size, "buffer")?;
         Ok(AttestBuffer(tss.attestationData[..size].to_vec().into()))
     }
 }

--- a/tss-esapi/src/structures/buffers/sensitive_create.rs
+++ b/tss-esapi/src/structures/buffers/sensitive_create.rs
@@ -80,8 +80,9 @@ impl TryFrom<TPM2B_SENSITIVE_CREATE> for SensitiveCreateBuffer {
 
     fn try_from(tss: TPM2B_SENSITIVE_CREATE) -> Result<Self> {
         Self::ensure_valid_buffer_size(tss.size as usize, "buffer")?;
-        let sensitive_create = SensitiveCreate::try_from(tss.sensitive)?;
-        Ok(SensitiveCreateBuffer(sensitive_create.marshall()?))
+        SensitiveCreate::try_from(tss.sensitive)
+            .and_then(|sensitive_create| sensitive_create.marshall())
+            .map(SensitiveCreateBuffer)
     }
 }
 

--- a/tss-esapi/src/structures/capability_data.rs
+++ b/tss-esapi/src/structures/capability_data.rs
@@ -13,7 +13,7 @@ use log::error;
 use std::convert::{TryFrom, TryInto};
 use std::mem::size_of;
 
-/// A representation of all the capabilites that can be associated
+/// A representation of all the capabilities that can be associated
 /// with a TPM.
 ///
 /// # Details

--- a/tss-esapi/src/structures/hash/agile.rs
+++ b/tss-esapi/src/structures/hash/agile.rs
@@ -55,13 +55,11 @@ impl TryFrom<TPMT_HA> for HashAgile {
         Ok(HashAgile {
             algorithm,
             digest: match algorithm {
-                HashingAlgorithm::Sha1 => unsafe { tpmt_ha.digest.sha1 }.as_ref().try_into()?,
-                HashingAlgorithm::Sha256 => unsafe { tpmt_ha.digest.sha256 }.as_ref().try_into()?,
-                HashingAlgorithm::Sha384 => unsafe { tpmt_ha.digest.sha384 }.as_ref().try_into()?,
-                HashingAlgorithm::Sha512 => unsafe { tpmt_ha.digest.sha512 }.as_ref().try_into()?,
-                HashingAlgorithm::Sm3_256 => {
-                    unsafe { tpmt_ha.digest.sm3_256 }.as_ref().try_into()?
-                }
+                HashingAlgorithm::Sha1 => unsafe { tpmt_ha.digest.sha1 }.into(),
+                HashingAlgorithm::Sha256 => unsafe { tpmt_ha.digest.sha256 }.into(),
+                HashingAlgorithm::Sha384 => unsafe { tpmt_ha.digest.sha384 }.into(),
+                HashingAlgorithm::Sha512 => unsafe { tpmt_ha.digest.sha512 }.into(),
+                HashingAlgorithm::Sm3_256 => unsafe { tpmt_ha.digest.sm3_256 }.into(),
                 _ => return Err(Error::local_error(WrapperErrorKind::WrongValueFromTpm)),
             },
         })

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -15,7 +15,7 @@
 /// Chapter 10: Structure Definitions
 
 /////////////////////////////////////////////////////////
-/// The capabilitydata section
+/// The capability data section
 /////////////////////////////////////////////////////////
 mod capability_data;
 pub use self::capability_data::CapabilityData;

--- a/tss-esapi/src/structures/tagged/public/ecc.rs
+++ b/tss-esapi/src/structures/tagged/public/ecc.rs
@@ -94,7 +94,7 @@ impl PublicEccParametersBuilder {
     /// for signing to the [PublicEccParametersBuilder].
     ///
     /// # Arguments
-    /// * `set` - `true` inidcates that the key is going to be used for signing operations.
+    /// * `set` - `true` indicates that the key is going to be used for signing operations.
     ///           `false` indicates that the key is not going to be used for signing operations.
     pub const fn with_is_signing_key(mut self, set: bool) -> Self {
         self.is_signing_key = set;
@@ -112,7 +112,7 @@ impl PublicEccParametersBuilder {
         self
     }
 
-    /// Adds a flag that inidcates if the key is going to be restrictied to
+    /// Adds a flag that indicates if the key is going to be restricted to
     /// the [PublicEccParametersBuilder].
     ///
     /// # Arguments

--- a/tss-esapi/src/structures/tagged/public/rsa.rs
+++ b/tss-esapi/src/structures/tagged/public/rsa.rs
@@ -36,7 +36,7 @@ impl PublicRsaParametersBuilder {
     }
 
     /// Creates a [PublicRsaParametersBuilder] that is setup
-    /// to build a restructed decryption key.
+    /// to build a restricted decryption key.
     pub const fn new_restricted_decryption_key(
         symmetric: SymmetricDefinitionObject,
         key_bits: RsaKeyBits,
@@ -99,7 +99,7 @@ impl PublicRsaParametersBuilder {
     /// for signing to the [PublicRsaParametersBuilder].
     ///
     /// # Arguments
-    /// * `set` - `true` inidcates that the key is going to be used for signing operations.
+    /// * `set` - `true` indicates that the key is going to be used for signing operations.
     ///           `false` indicates that the key is not going to be used for signing operations.
     pub const fn with_is_signing_key(mut self, set: bool) -> Self {
         self.is_signing_key = set;
@@ -117,7 +117,7 @@ impl PublicRsaParametersBuilder {
         self
     }
 
-    /// Adds a flag that inidcates if the key is going to be restrictied to
+    /// Adds a flag that indicates if the key is going to be restricted to
     /// the [PublicRsaParametersBuilder].
     ///
     /// # Arguments

--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -294,10 +294,10 @@ impl TryFrom<Public> for PublicKey {
 
     fn try_from(public: Public) -> Result<Self> {
         match public {
-            Public::Rsa { unique, .. } => Ok(PublicKey::Rsa(unique.value().to_vec())),
+            Public::Rsa { unique, .. } => Ok(PublicKey::Rsa(unique.as_bytes().to_vec())),
             Public::Ecc { unique, .. } => Ok(PublicKey::Ecc {
-                x: unique.x().value().to_vec(),
-                y: unique.y().value().to_vec(),
+                x: unique.x().as_bytes().to_vec(),
+                y: unique.y().as_bytes().to_vec(),
             }),
             _ => Err(Error::local_error(WrapperErrorKind::WrongValueFromTpm)),
         }

--- a/tss-esapi/tests/integration_tests/abstraction_tests/pcr_data_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/pcr_data_tests.rs
@@ -6,8 +6,6 @@ use tss_esapi::{
     Error, WrapperErrorKind,
 };
 
-use std::convert::TryFrom;
-
 #[test]
 fn test_valid_to_tpml_digest_conversion() {
     let pcr_selection_list_1 = PcrSelectionListBuilder::new()
@@ -31,7 +29,7 @@ fn test_valid_to_tpml_digest_conversion() {
     for i in 0u8..8u8 {
         let value: [u8; 1] = [i];
         pcr_digest_list_1
-            .add(Digest::try_from(&value[..]).expect("Failed to create digest value"))
+            .add(Digest::from_bytes(&value[..]).expect("Failed to create digest value"))
             .expect("Failed to add value to digest");
     }
 
@@ -56,7 +54,7 @@ fn test_valid_to_tpml_digest_conversion() {
     for i in 8u8..16u8 {
         let value: [u8; 1] = [i];
         pcr_digest_list_2
-            .add(Digest::try_from(&value[..]).expect("Failed to create digest value"))
+            .add(Digest::from_bytes(&value[..]).expect("Failed to create digest value"))
             .expect("Failed to add value to digest");
     }
 
@@ -116,7 +114,7 @@ fn test_invalid_to_tpml_digest_conversion() {
     for i in 0u8..7u8 {
         let value: [u8; 1] = [i];
         pcr_digest_list_1
-            .add(Digest::try_from(&value[..]).expect("Failed to create digest value"))
+            .add(Digest::from_bytes(&value[..]).expect("Failed to create digest value"))
             .expect("Failed to add value to digest");
     }
 

--- a/tss-esapi/tests/integration_tests/abstraction_tests/public_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/public_tests.rs
@@ -60,7 +60,7 @@ mod public_rsa_test {
                 .expect("Failed to create rsa parameters for public structure"),
             )
             .with_rsa_unique_identifier(
-                PublicKeyRsa::try_from(&RSA_KEY[..])
+                PublicKeyRsa::from_bytes(&RSA_KEY[..])
                     .expect("Failed to create Public RSA key from buffer"),
             )
             .build()
@@ -129,9 +129,9 @@ mod public_ecc_test {
 
     pub fn get_ecc_point() -> EccPoint {
         let x =
-            EccParameter::try_from(&EC_POINT[1..33]).expect("Failed to construct x EccParameter");
+            EccParameter::from_bytes(&EC_POINT[1..33]).expect("Failed to construct x EccParameter");
         let y: EccParameter =
-            EccParameter::try_from(&EC_POINT[33..]).expect("Failed to construct y EccParameter");
+            EccParameter::from_bytes(&EC_POINT[33..]).expect("Failed to construct y EccParameter");
         EccPoint::new(x, y)
     }
 

--- a/tss-esapi/tests/integration_tests/common/mod.rs
+++ b/tss-esapi/tests/integration_tests/common/mod.rs
@@ -298,13 +298,13 @@ pub fn get_pcr_policy_digest(
             .unwrap()
             .get_digest(PcrSlot::Slot0)
             .unwrap()
-            .value(),
+            .as_bytes(),
         pcr_data
             .pcr_bank(HashingAlgorithm::Sha256)
             .unwrap()
             .get_digest(PcrSlot::Slot1)
             .unwrap()
-            .value(),
+            .as_bytes(),
     ]
     .concat();
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
@@ -20,7 +20,7 @@ mod test_rsa_encrypt_decrypt {
     fn test_encrypt_decrypt() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -47,20 +47,20 @@ mod test_rsa_encrypt_decrypt {
             .rsa_encrypt(key_handle, plaintext, scheme, Data::default())
             .unwrap();
 
-        assert_ne!(plaintext_bytes, ciphertext.value());
+        assert_ne!(plaintext_bytes, ciphertext.as_bytes());
 
         let decrypted = context
             .rsa_decrypt(key_handle, ciphertext, scheme, Data::default())
             .unwrap();
 
-        assert_eq!(plaintext_bytes, decrypted.value());
+        assert_eq!(plaintext_bytes, decrypted.as_bytes());
     }
 
     #[test]
     fn test_ecdh() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let ecc_parms = PublicEccParametersBuilder::new()
             .with_ecc_scheme(EccScheme::EcDh(HashScheme::new(HashingAlgorithm::Sha256)))
@@ -101,6 +101,6 @@ mod test_rsa_encrypt_decrypt {
 
         let param = context.ecdh_z_gen(key_handle, pub_point).unwrap();
 
-        assert_eq!(z_point.x().value(), param.x().value());
+        assert_eq!(z_point.x().as_bytes(), param.x().as_bytes());
     }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
@@ -123,7 +123,7 @@ mod test_quote {
 
         assert_eq!(attest.attestation_type(), AttestationType::Certify);
         assert!(matches!(attest.attested(), AttestInfo::Certify { .. }));
-        assert_eq!(attest.extra_data().value(), qualifying_data);
+        assert_eq!(attest.extra_data().as_bytes(), qualifying_data);
     }
 
     #[test]

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 mod test_ctx_save {
     use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
-    use std::convert::TryFrom;
     use tss_esapi::{interface_types::resource_handles::Hierarchy, structures::Auth};
 
     #[test]
     fn test_ctx_save() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -29,7 +28,7 @@ mod test_ctx_save {
     fn test_ctx_save_leaf() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let prim_key_handle = context
             .create_primary(
@@ -64,7 +63,6 @@ mod test_ctx_save {
 
 mod test_ctx_load {
     use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
-    use std::convert::TryFrom;
     use tss_esapi::{
         handles::KeyHandle, interface_types::resource_handles::Hierarchy, structures::Auth,
     };
@@ -78,7 +76,7 @@ mod test_ctx_load {
             .create_primary(
                 Hierarchy::Owner,
                 decryption_key_pub(),
-                Some(Auth::try_from(key_auth.value().to_vec()).unwrap()),
+                Some(Auth::from_bytes(key_auth.as_bytes()).unwrap()),
                 None,
                 None,
                 None,
@@ -90,7 +88,7 @@ mod test_ctx_load {
             .create(
                 prim_key_handle,
                 signing_key_pub(),
-                Some(Auth::try_from(key_auth.value().to_vec()).unwrap()),
+                Some(Auth::from_bytes(key_auth.as_bytes()).unwrap()),
                 None,
                 None,
                 None,
@@ -109,14 +107,13 @@ mod test_ctx_load {
 
 mod test_flush_context {
     use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
-    use std::convert::TryFrom;
     use tss_esapi::{interface_types::resource_handles::Hierarchy, structures::Auth};
 
     #[test]
     fn test_flush_ctx() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -137,7 +134,7 @@ mod test_flush_context {
     fn test_flush_parent_ctx() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let prim_key_handle = context
             .create_primary(

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -267,13 +267,13 @@ mod test_policy_pcr {
                     .unwrap()
                     .get_digest(PcrSlot::Slot0)
                     .unwrap()
-                    .value(),
+                    .as_bytes(),
                 pcr_data
                     .pcr_bank(HashingAlgorithm::Sha256)
                     .unwrap()
                     .get_digest(PcrSlot::Slot1)
                     .unwrap()
-                    .value(),
+                    .as_bytes(),
             ]
             .concat()
             .to_vec(),
@@ -541,7 +541,7 @@ mod test_policy_authorize {
     fn test_policy_authorize() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -562,7 +562,7 @@ mod test_policy_authorize {
         // aHash ≔ H_{aHashAlg}(approvedPolicy || policyRef)
         let ahash = context
             .hash(
-                MaxBuffer::try_from(policy_digest.value().to_vec()).unwrap(),
+                MaxBuffer::from_bytes(policy_digest.as_bytes()).unwrap(),
                 HashingAlgorithm::Sha256,
                 Hierarchy::Null,
             )
@@ -763,13 +763,13 @@ mod test_policy_get_digest {
                     .unwrap()
                     .get_digest(PcrSlot::Slot0)
                     .unwrap()
-                    .value(),
+                    .as_bytes(),
                 pcr_data
                     .pcr_bank(HashingAlgorithm::Sha256)
                     .unwrap()
                     .get_digest(PcrSlot::Slot1)
                     .unwrap()
-                    .value(),
+                    .as_bytes(),
             ]
             .concat()
             .to_vec(),
@@ -792,7 +792,7 @@ mod test_policy_get_digest {
         let retrieved_policy_digest = context.policy_get_digest(trial_policy_session).unwrap();
 
         // The algorithm is SHA256 so the expected size of the digest should be 32.
-        assert_eq!(retrieved_policy_digest.value().len(), 32);
+        assert_eq!(retrieved_policy_digest.as_bytes().len(), 32);
     }
 }
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 mod test_create_primary {
     use crate::common::{create_ctx_with_session, decryption_key_pub};
-    use std::convert::TryFrom;
     use tss_esapi::{
         handles::ObjectHandle, interface_types::resource_handles::Hierarchy, structures::Auth,
     };
@@ -11,7 +10,7 @@ mod test_create_primary {
     fn test_create_primary() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -57,7 +56,6 @@ mod test_clear_control {
 
 mod test_change_auth {
     use crate::common::{create_ctx_with_session, decryption_key_pub};
-    use std::convert::TryFrom;
     use tss_esapi::{
         handles::AuthHandle, interface_types::resource_handles::Hierarchy, structures::Auth,
     };
@@ -96,7 +94,7 @@ mod test_change_auth {
             .unwrap();
 
         let random_digest = context.get_random(16).unwrap();
-        let new_key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let new_key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let new_private = context
             .object_change_auth(loaded_key.into(), prim_key_handle.into(), new_key_auth)
@@ -111,7 +109,7 @@ mod test_change_auth {
         let mut context = create_ctx_with_session();
 
         let random_digest = context.get_random(16).unwrap();
-        let new_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let new_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         // NOTE: If this test failed on your system, you are probably running it against a
         //  real (hardware) TPM or one that is provisioned. This hierarchy is supposed to be

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
@@ -41,10 +41,10 @@ mod test_pcr_extend_reset {
             .for_each(|(pcr_selection, digest)| {
                 if pcr_selection.hashing_algorithm() == HashingAlgorithm::Sha1 {
                     assert_eq!(digest.len(), 20);
-                    assert_eq!(digest.value(), [0; 20]);
+                    assert_eq!(digest.as_bytes(), [0; 20]);
                 } else if pcr_selection.hashing_algorithm() == HashingAlgorithm::Sha256 {
                     assert_eq!(digest.len(), 32);
-                    assert_eq!(digest.value(), [0; 32]);
+                    assert_eq!(digest.as_bytes(), [0; 32]);
                 } else {
                     panic!("Read pcr selections contained unexpected HashingAlgorithm");
                 }
@@ -96,7 +96,7 @@ mod test_pcr_extend_reset {
                 if pcr_selection.hashing_algorithm() == HashingAlgorithm::Sha1 {
                     assert_eq!(digest.len(), 20);
                     assert_eq!(
-                        digest.value(),
+                        digest.as_bytes(),
                         [
                             0x5f, 0x42, 0x0e, 0x04, 0x95, 0x8b, 0x2e, 0x3f, 0x18, 0x07, 0x39, 0x1e,
                             0x99, 0xd9, 0x49, 0x2c, 0x67, 0xaa, 0xef, 0xfd
@@ -105,7 +105,7 @@ mod test_pcr_extend_reset {
                 } else if pcr_selection.hashing_algorithm() == HashingAlgorithm::Sha256 {
                     assert_eq!(digest.len(), 32);
                     assert_eq!(
-                        digest.value(),
+                        digest.as_bytes(),
                         [
                             0x0b, 0x8f, 0x4c, 0x5b, 0x6a, 0xdc, 0x4c, 0x08, 0x7a, 0xb9, 0xf4, 0x3a,
                             0xae, 0xb6, 0x00, 0x70, 0x84, 0xc2, 0x64, 0xad, 0xca, 0xa3, 0xcb, 0x07,
@@ -141,8 +141,8 @@ mod test_pcr_extend_reset {
         let pcr_sha1_value = pcr_sha1_bank.get_digest(PcrSlot::Slot16).unwrap();
         let pcr_sha256_value = pcr_sha256_bank.get_digest(PcrSlot::Slot16).unwrap();
         // Needs to have the length of associated with the hashing algorithm
-        assert_eq!(pcr_sha1_value.value(), [0; 20]);
-        assert_eq!(pcr_sha256_value.value(), [0; 32]);
+        assert_eq!(pcr_sha1_value.as_bytes(), [0; 20]);
+        assert_eq!(pcr_sha256_value.as_bytes(), [0; 32]);
     }
 }
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/object_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/object_commands_tests.rs
@@ -9,7 +9,7 @@ mod test_create {
     fn test_create() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
         let prim_key_handle = context
             .create_primary(
@@ -45,7 +45,7 @@ mod test_load {
     fn test_load() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
         let prim_key_handle = context
             .create_primary(
@@ -78,7 +78,6 @@ mod test_load {
 
 mod test_load_external_public {
     use crate::common::{create_ctx_with_session, KEY};
-    use std::convert::TryFrom;
     use tss_esapi::{
         attributes::ObjectAttributesBuilder,
         interface_types::{
@@ -113,7 +112,7 @@ mod test_load_external_public {
                 .expect("Failed to create rsa parameters for public structure"),
             )
             .with_rsa_unique_identifier(
-                PublicKeyRsa::try_from(&KEY[..256])
+                PublicKeyRsa::from_bytes(&KEY[..256])
                     .expect("Failed to create Public RSA key from buffer"),
             )
             .build()
@@ -133,7 +132,7 @@ mod test_load_external_public {
 
 mod test_load_external {
     use crate::common::create_ctx_with_session;
-    use std::convert::{TryFrom, TryInto};
+    use std::convert::TryInto;
     use tss_esapi::{
         attributes::ObjectAttributesBuilder,
         interface_types::{
@@ -211,7 +210,7 @@ mod test_load_external {
                 .expect("Failed to create rsa parameters for public structure"),
             )
             .with_rsa_unique_identifier(
-                PublicKeyRsa::try_from(&KEY[..])
+                PublicKeyRsa::from_bytes(&KEY[..])
                     .expect("Failed to create Public RSA key from buffer"),
             )
             .build()
@@ -233,14 +232,13 @@ mod test_load_external {
 
 mod test_read_public {
     use crate::common::{create_ctx_with_session, signing_key_pub};
-    use std::convert::TryFrom;
     use tss_esapi::{interface_types::resource_handles::Hierarchy, structures::Auth};
 
     #[test]
     fn test_read_public() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_bytes()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -424,7 +422,7 @@ mod test_unseal {
             .load(key_handle_unseal, result.out_private, result.out_public)
             .unwrap();
         let unsealed = context.unseal(loaded_key.into()).unwrap();
-        let unsealed = unsealed.value();
+        let unsealed = unsealed.as_bytes();
         assert!(unsealed == testbytes);
     }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
@@ -14,7 +14,7 @@ mod test_verify_signature {
     fn test_verify_signature() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -55,7 +55,7 @@ mod test_verify_signature {
     fn test_verify_wrong_signature() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -84,7 +84,7 @@ mod test_verify_signature {
             .unwrap();
 
         if let Signature::RsaSsa(rsa_signature) = &mut signature {
-            let mut key_data: Vec<u8> = rsa_signature.signature().value().to_vec();
+            let mut key_data: Vec<u8> = rsa_signature.signature().as_bytes().to_vec();
             key_data.reverse();
             *rsa_signature = RsaSignature::create(
                 rsa_signature.hashing_algorithm(),
@@ -106,7 +106,7 @@ mod test_verify_signature {
     fn test_verify_wrong_signature_2() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -142,7 +142,7 @@ mod test_verify_signature {
     fn test_verify_wrong_signature_3() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -188,7 +188,7 @@ mod test_sign {
     fn test_sign() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -221,7 +221,7 @@ mod test_sign {
     fn test_sign_empty_digest() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
         let key_handle = context
             .create_primary(
@@ -254,7 +254,7 @@ mod test_sign {
     fn test_sign_large_digest() {
         let mut context = create_ctx_with_session();
         let random_digest = context.get_random(16).unwrap();
-        let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+        let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
         let key_handle = context
             .create_primary(

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/symmetric_primitives_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/symmetric_primitives_tests.rs
@@ -29,7 +29,7 @@ mod test_encrypt_decrypt_2 {
             context
                 .get_random(16)
                 .expect("get_rand call failed")
-                .value()
+                .as_bytes()
                 .to_vec(),
         )
         .expect("Failed to create primary key auth");
@@ -82,7 +82,7 @@ mod test_encrypt_decrypt_2 {
             context
                 .get_random(16)
                 .expect("get_rand call failed")
-                .value()
+                .as_bytes()
                 .to_vec(),
         )
         .expect("Failed to create symmetric key auth");

--- a/tss-esapi/tests/integration_tests/error_tests/return_code_tests/esapi_tests.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/return_code_tests/esapi_tests.rs
@@ -154,7 +154,7 @@ fn test_esapi_error_from_context_method() {
         .expect("Failed to set attributes for second session");
 
     // Creating primary with two sessions that both have encrypt set.
-    // This is expected to result in 'mutiple encrypt sessions' ESAPI error.
+    // This is expected to result in 'multiple encrypt sessions' ESAPI error.
     let result =
         context.execute_with_sessions((Some(first_session), Some(second_session), None), |ctx| {
             ctx.create_primary(
@@ -173,10 +173,10 @@ fn test_esapi_error_from_context_method() {
                 assert_eq!(
                 esapi_return_code.base_error(),
                 BaseError::MultipleEncryptSessions,
-                "Calling 'create_primary' with two encrypt session did not result in the expected ESPI TSS error",
+                "Calling 'create_primary' with two encrypt session did not result in the expected ESAPI TSS error",
             );
             } else {
-                panic!("Calling 'create_primary' with two encrypt session did not result in an ESPI TSS error");
+                panic!("Calling 'create_primary' with two encrypt session did not result in an ESAPI TSS error");
             }
         } else {
             panic!(

--- a/tss-esapi/tests/integration_tests/error_tests/return_code_tests/esapi_tests.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/return_code_tests/esapi_tests.rs
@@ -129,7 +129,7 @@ fn test_invalid_conversions() {
 fn test_esapi_error_from_context_method() {
     let mut context = create_ctx_with_session();
     let random_digest = context.get_random(16).unwrap();
-    let key_auth = Auth::try_from(random_digest.value().to_vec()).unwrap();
+    let key_auth = Auth::try_from(random_digest.as_bytes().to_vec()).unwrap();
 
     let first_session = context.sessions().0.expect("Missing first session");
     let second_session = context

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/digest_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/digest_list_tests.rs
@@ -24,7 +24,7 @@ fn test_conversion_from_tss_digest_list() {
     for actual_digest in digest_list.value().iter() {
         match expected_digests
             .iter()
-            .position(|v| v.value() == actual_digest.value())
+            .position(|v| v.as_bytes() == actual_digest.as_bytes())
         {
             Some(pos) => {
                 expected_digests.remove(pos);


### PR DESCRIPTION
This PR fixes #353.


- Replaces the ```value``` API with a ```as_bytes``` API for buffer types. As this name makes more sense in this context.
- Replaces the implementation of ```TryFrom<&[u8]>``` for buffer types with a ```from_bytes``` API.