### PR TITLE
Changes print of errors to hex format.

### DIFF
--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -101,7 +101,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when creating a new context: {}", ret);
+                error!("Error when creating a new context: {:#010X}", ret);
             },
         )?;
 

--- a/tss-esapi/src/context/general_esys_tr.rs
+++ b/tss-esapi/src/context/general_esys_tr.rs
@@ -41,7 +41,7 @@ impl Context {
             unsafe { Esys_TR_SetAuth(self.mut_context(), object_handle.into(), &auth_value) },
             |ret| {
                 auth_value.buffer.zeroize();
-                error!("Error when setting authentication value: {}", ret);
+                error!("Error when setting authentication value: {:#010X}", ret);
             },
         )
     }
@@ -131,7 +131,7 @@ impl Context {
         ReturnCode::ensure_success(
             unsafe { Esys_TR_GetName(self.mut_context(), object_handle.into(), &mut name_ptr) },
             |ret| {
-                error!("Error in getting name: {}", ret);
+                error!("Error in getting name: {:#010X}", ret);
             },
         )?;
         Name::try_from(Context::ffi_data_to_owned(name_ptr))
@@ -249,7 +249,10 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when getting ESYS handle from TPM handle: {}", ret);
+                error!(
+                    "Error when getting ESYS handle from TPM handle: {:#010X}",
+                    ret
+                );
             },
         )?;
         self.handle_manager.add_handle(
@@ -357,7 +360,7 @@ impl Context {
         ReturnCode::ensure_success(
             unsafe { Esys_TR_Close(self.mut_context(), &mut rsrc_handle) },
             |ret| {
-                error!("Error when closing an ESYS handle: {}", ret);
+                error!("Error when closing an ESYS handle: {:#010X}", ret);
             },
         )?;
 
@@ -376,7 +379,10 @@ impl Context {
                 Esys_TR_GetTpmHandle(self.mut_context(), object_handle.into(), &mut tpm_handle)
             },
             |ret| {
-                error!("Error when getting TPM handle from ESYS handle: {}", ret);
+                error!(
+                    "Error when getting TPM handle from ESYS handle: {:#010X}",
+                    ret
+                );
             },
         )?;
         TpmHandle::try_from(tpm_handle)

--- a/tss-esapi/src/context/session_administration.rs
+++ b/tss-esapi/src/context/session_administration.rs
@@ -27,7 +27,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when setting session attributes: {}", ret);
+                error!("Error when setting session attributes: {:#010X}", ret);
             },
         )
     }
@@ -44,7 +44,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when getting session attributes: {}", ret);
+                error!("Error when getting session attributes: {:#010X}", ret);
             },
         )?;
         Ok(SessionAttributes(flags))

--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -36,7 +36,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when performing RSA encryption: {}", ret);
+                error!("Error when performing RSA encryption: {:#010X}", ret);
             },
         )?;
         PublicKeyRsa::try_from(Context::ffi_data_to_owned(out_data_ptr))
@@ -66,7 +66,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when performing RSA decryption: {}", ret);
+                error!("Error when performing RSA decryption: {:#010X}", ret);
             },
         )?;
         PublicKeyRsa::try_from(Context::ffi_data_to_owned(message_ptr))
@@ -194,7 +194,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when generating ECDH keypair: {}", ret);
+                error!("Error when generating ECDH keypair: {:#010X}", ret);
             },
         )?;
 
@@ -330,7 +330,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when performing ECDH ZGen: {}", ret);
+                error!("Error when performing ECDH ZGen: {:#010X}", ret);
             },
         )?;
         let out_point = Context::ffi_data_to_owned(out_point_ptr);

--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -140,7 +140,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in certifying: {}", ret);
+                error!("Error in certifying: {:#010X}", ret);
             },
         )?;
 
@@ -183,7 +183,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in quoting PCR: {}", ret);
+                error!("Error in quoting PCR: {:#010X}", ret);
             },
         )?;
 

--- a/tss-esapi/src/context/tpm_commands/capability_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/capability_commands.rs
@@ -64,7 +64,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when getting capabilities: {}", ret);
+                error!("Error when getting capabilities: {:#010X}", ret);
             },
         )?;
 
@@ -91,7 +91,10 @@ impl Context {
                 )
             },
             |ret| {
-                warn!("Parameters under test could not be unmarshalled: {}", ret);
+                warn!(
+                    "Parameters under test could not be unmarshalled: {:#010X}",
+                    ret
+                );
             },
         )
     }

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -23,7 +23,7 @@ impl Context {
         ReturnCode::ensure_success(
             unsafe { Esys_ContextSave(self.mut_context(), handle.into(), &mut context_ptr) },
             |ret| {
-                error!("Error in saving context: {}", ret);
+                error!("Error in saving context: {:#010X}", ret);
             },
         )?;
         TpmsContext::try_from(Context::ffi_data_to_owned(context_ptr))
@@ -45,7 +45,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in loading context: {}", ret);
+                error!("Error in loading context: {:#010X}", ret);
             },
         )?;
         let loaded_handle = ObjectHandle::from(esys_loaded_handle);
@@ -137,7 +137,7 @@ impl Context {
         ReturnCode::ensure_success(
             unsafe { Esys_FlushContext(self.mut_context(), handle.try_into_not_none()?) },
             |ret| {
-                error!("Error in flushing context: {}", ret);
+                error!("Error in flushing context: {:#010X}", ret);
             },
         )?;
         self.handle_manager.set_as_flushed(handle)
@@ -430,7 +430,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in evict control: {}", ret);
+                error!("Error in evict control: {:#010X}", ret);
             },
         )?;
         let new_object_handle = ObjectHandle::from(new_object_handle);

--- a/tss-esapi/src/context/tpm_commands/duplication_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/duplication_commands.rs
@@ -322,7 +322,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when performing duplication: {}", ret);
+                error!("Error when performing duplication: {:#010X}", ret);
             },
         )?;
 
@@ -680,7 +680,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when performing import: {}", ret);
+                error!("Error when performing import: {:#010X}", ret);
             },
         )?;
         Private::try_from(Context::ffi_data_to_owned(out_private_ptr))

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -60,7 +60,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when sending policy signed: {}", ret);
+                error!("Error when sending policy signed: {:#010X}", ret);
             },
         )?;
         Ok((
@@ -102,7 +102,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when sending policy secret: {}", ret);
+                error!("Error when sending policy secret: {:#010X}", ret);
             },
         )?;
         Ok((
@@ -150,7 +150,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy OR: {}", ret);
+                error!("Error when computing policy OR: {:#010X}", ret);
             },
         )
     }
@@ -185,7 +185,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy PCR: {}", ret);
+                error!("Error when computing policy PCR: {:#010X}", ret);
             },
         )
     }
@@ -211,7 +211,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy locality: {}", ret);
+                error!("Error when computing policy locality: {:#010X}", ret);
             },
         )
     }
@@ -240,7 +240,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy command code: {}", ret);
+                error!("Error when computing policy command code: {:#010X}", ret);
             },
         )
     }
@@ -261,7 +261,10 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy physical presence: {}", ret);
+                error!(
+                    "Error when computing policy physical presence: {:#010X}",
+                    ret
+                );
             },
         )
     }
@@ -287,7 +290,10 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy command parameters: {}", ret);
+                error!(
+                    "Error when computing policy command parameters: {:#010X}",
+                    ret
+                );
             },
         )
     }
@@ -313,7 +319,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy name hash: {}", ret);
+                error!("Error when computing policy name hash: {:#010X}", ret);
             },
         )
     }
@@ -419,7 +425,10 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy duplication select: {}", ret);
+                error!(
+                    "Error when computing policy duplication select: {:#010X}",
+                    ret
+                );
             },
         )
     }
@@ -454,7 +463,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy authorize: {}", ret);
+                error!("Error when computing policy authorize: {:#010X}", ret);
             },
         )
     }
@@ -475,7 +484,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy auth value: {}", ret);
+                error!("Error when computing policy auth value: {:#010X}", ret);
             },
         )
     }
@@ -496,7 +505,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy password: {}", ret);
+                error!("Error when computing policy password: {:#010X}", ret);
             },
         )
     }
@@ -518,7 +527,7 @@ impl Context {
             },
             |ret| {
                 error!(
-                    "Error failed to perform policy get digest operation: {}.",
+                    "Error failed to perform policy get digest operation: {:#010X}.",
                     ret
                 );
             },
@@ -547,7 +556,10 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when computing policy NV written state: {}", ret);
+                error!(
+                    "Error when computing policy NV written state: {:#010X}",
+                    ret
+                );
             },
         )
     }
@@ -575,7 +587,7 @@ impl Context {
             },
             |ret| {
                 error!(
-                    "Failed to bind template to a specific creation template: {}",
+                    "Failed to bind template to a specific creation template: {:#010X}",
                     ret
                 );
             },

--- a/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
@@ -67,7 +67,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in creating primary key: {}", ret);
+                error!("Error in creating primary key: {:#010X}", ret);
             },
         )?;
         let out_public_owned = Context::ffi_data_to_owned(out_public_ptr);
@@ -105,7 +105,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in clearing TPM hierarchy: {}", ret);
+                error!("Error in clearing TPM hierarchy: {:#010X}", ret);
             },
         )
     }
@@ -124,7 +124,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in controlling clear command: {}", ret);
+                error!("Error in controlling clear command: {:#010X}", ret);
             },
         )
     }
@@ -143,7 +143,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error changing hierarchy auth: {}", ret);
+                error!("Error changing hierarchy auth: {:#010X}", ret);
             },
         )
     }

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -100,7 +100,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when extending PCR: {}", ret);
+                error!("Error when extending PCR: {:#010X}", ret);
             },
         )
     }
@@ -169,7 +169,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when reading PCR: {}", ret);
+                error!("Error when reading PCR: {:#010X}", ret);
             },
         )?;
 
@@ -249,7 +249,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when resetting PCR: {}", ret);
+                error!("Error when resetting PCR: {:#010X}", ret);
             },
         )
     }

--- a/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
+++ b/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
@@ -118,7 +118,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when defining NV space: {}", ret);
+                error!("Error when defining NV space: {:#010X}", ret);
             },
         )?;
 
@@ -219,7 +219,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when undefining NV space: {}", ret);
+                error!("Error when undefining NV space: {:#010X}", ret);
             },
         )?;
 
@@ -329,7 +329,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when reading NV public: {}", ret);
+                error!("Error when reading NV public: {:#010X}", ret);
             },
         )?;
 
@@ -449,7 +449,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when writing NV: {}", ret);
+                error!("Error when writing NV: {:#010X}", ret);
             },
         )
     }
@@ -552,7 +552,7 @@ impl Context {
                     self.optional_session_3(),
                 )
             },
-            |ret| error!("Error when incrementing NV: {}", ret),
+            |ret| error!("Error when incrementing NV: {:#010X}", ret),
         )
     }
 
@@ -680,7 +680,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when reading NV: {}", ret);
+                error!("Error when reading NV: {:#010X}", ret);
             },
         )?;
         MaxNvBuffer::try_from(Context::ffi_data_to_owned(data_ptr))

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -81,7 +81,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in creating derived key: {}", ret);
+                error!("Error in creating derived key: {:#010X}", ret);
             },
         )?;
         let out_private_owned = Context::ffi_data_to_owned(out_private_ptr);
@@ -120,7 +120,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in loading: {}", ret);
+                error!("Error in loading: {:#010X}", ret);
             },
         )?;
         let key_handle = KeyHandle::from(object_handle);
@@ -155,7 +155,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in loading external object: {}", ret);
+                error!("Error in loading external object: {:#010X}", ret);
             },
         )?;
 
@@ -190,7 +190,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in loading external public object: {}", ret);
+                error!("Error in loading external public object: {:#010X}", ret);
             },
         )?;
 
@@ -219,7 +219,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in reading public part of object: {}", ret);
+                error!("Error in reading public part of object: {:#010X}", ret);
             },
         )?;
         Ok((
@@ -253,7 +253,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when activating credential: {}", ret);
+                error!("Error when activating credential: {:#010X}", ret);
             },
         )?;
 
@@ -286,7 +286,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when making credential: {}", ret);
+                error!("Error when making credential: {:#010X}", ret);
             },
         )?;
         Ok((
@@ -311,7 +311,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in unsealing: {}", ret);
+                error!("Error in unsealing: {:#010X}", ret);
             },
         )?;
         SensitiveData::try_from(Context::ffi_data_to_owned(out_data_ptr))
@@ -339,7 +339,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error changing object auth: {}", ret);
+                error!("Error changing object auth: {:#010X}", ret);
             },
         )?;
         Private::try_from(Context::ffi_data_to_owned(out_private_ptr))

--- a/tss-esapi/src/context/tpm_commands/random_number_generator.rs
+++ b/tss-esapi/src/context/tpm_commands/random_number_generator.rs
@@ -30,7 +30,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in getting random bytes: {}", ret);
+                error!("Error in getting random bytes: {:#010X}", ret);
             },
         )?;
         Digest::try_from(Context::ffi_data_to_owned(random_bytes_ptr))
@@ -49,7 +49,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error stirring random: {}", ret);
+                error!("Error stirring random: {:#010X}", ret);
             },
         )
     }

--- a/tss-esapi/src/context/tpm_commands/session_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/session_commands.rs
@@ -80,7 +80,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when creating a session: {}", ret);
+                error!("Error when creating a session: {:#010X}", ret);
             },
         )?;
 
@@ -106,7 +106,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error restarting policy: {}", ret);
+                error!("Error restarting policy: {:#010X}", ret);
             },
         )
     }

--- a/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
+++ b/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
@@ -33,7 +33,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when verifying signature: {}", ret);
+                error!("Error when verifying signature: {:#010X}", ret);
             },
         )?;
         VerifiedTicket::try_from(Context::ffi_data_to_owned(validation_ptr))
@@ -63,7 +63,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error when signing: {}", ret);
+                error!("Error when signing: {:#010X}", ret);
             },
         )?;
         Signature::try_from(Context::ffi_data_to_owned(signature_ptr))

--- a/tss-esapi/src/context/tpm_commands/startup.rs
+++ b/tss-esapi/src/context/tpm_commands/startup.rs
@@ -13,7 +13,7 @@ impl Context {
         ReturnCode::ensure_success(
             unsafe { Esys_Startup(self.mut_context(), startup_type.into()) },
             |ret| {
-                error!("Error while starting up TPM: {}", ret);
+                error!("Error while starting up TPM: {:#010X}", ret);
             },
         )
     }
@@ -31,7 +31,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error while shutting down TPM: {}", ret);
+                error!("Error while shutting down TPM: {:#010X}", ret);
             },
         )
     }

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -211,7 +211,7 @@ impl Context {
             },
             |ret| {
                 error!(
-                    "Error failed to perform encrypt or decrypt operations {}",
+                    "Error failed to perform encrypt or decrypt operations {:#010X}",
                     ret
                 );
             },
@@ -288,7 +288,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error failed to perform hash operation: {}", ret);
+                error!("Error failed to perform hash operation: {:#010X}", ret);
             },
         )?;
         Ok((
@@ -368,7 +368,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in hmac: {}", ret);
+                error!("Error in hmac: {:#010X}", ret);
             },
         )?;
         Digest::try_from(Context::ffi_data_to_owned(out_hmac_ptr))

--- a/tss-esapi/src/context/tpm_commands/testing.rs
+++ b/tss-esapi/src/context/tpm_commands/testing.rs
@@ -24,7 +24,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error in self-test: {}", ret);
+                error!("Error in self-test: {:#010X}", ret);
             },
         )
     }
@@ -50,7 +50,7 @@ impl Context {
                 )
             },
             |ret| {
-                error!("Error getting test result: {}", ret);
+                error!("Error getting test result: {:#010X}", ret);
             },
         )?;
         Ok((


### PR DESCRIPTION
This fixes #369 by changes the printing of return code values to hex in the context methods when the ESAPI functions called returns an error.


Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>