### PR TITLE
Adds validation of session attributes.

### DIFF
--- a/tss-esapi/src/context/session_administration.rs
+++ b/tss-esapi/src/context/session_administration.rs
@@ -8,6 +8,7 @@ use crate::{
     Context, Result, ReturnCode,
 };
 use log::error;
+use std::convert::TryInto;
 
 impl Context {
     /// Set the given attributes on a given session.
@@ -22,8 +23,8 @@ impl Context {
                 Esys_TRSess_SetAttributes(
                     self.mut_context(),
                     SessionHandle::from(session).into(),
-                    attributes.into(),
-                    mask.into(),
+                    attributes.try_into()?,
+                    mask.try_into()?,
                 )
             },
             |ret| {


### PR DESCRIPTION
Adds validation of SessionAttributes and SessionAttributesMask that checks if the reserved bits are set because the specification specifically says they shall be clear.

This will fix #330 .