### PR TITLE
Fixes build problems related to compilers and editions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check formatting
         run: cargo fmt --all -- --check
-  # Check that it builds with the Minimum Supported Rust Version      
+  # Check that it builds with the Minimum Supported Rust Version
   msrv:
     name: Check minimum supported rust version (MSRV)
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu
       - name: Run the container
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env RUST_TOOLCHAIN_VERSION=1.53.0 ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env RUST_TOOLCHAIN_VERSION=1.56.0 ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
   # All in one job as I think it is a big overhead to build and run the Docker
   # container?
   tests-ubuntu:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ At the moment we test (via CI) and support the following Rust compiler versions:
 
 * On Ubuntu we test with:
     - The latest stable compiler version, as accessible through `rustup`.
-    - The 1.53 compiler version.
+    - The 1.56 compiler version.
 * On Fedora we test with the compiler version included with the Fedora 35 release.
 
 If you need support for other versions of the compiler, get in touch with us to see what we can do!

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -552,7 +552,7 @@ impl Context {
                     self.optional_session_1(),
                     self.optional_session_2(),
                     self.optional_session_3(),
-                    if written_set { 1 } else { 0 },
+                    written_set.into(),
                 )
             },
             |ret| {


### PR DESCRIPTION
- Changes bool conversion to u8 by using the solution suggested by Clippy when it reported this issue.
- Changed MSRV to 1.56

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>