### PR TITLE
tcti: adds support for unix sockets

### DIFF
--- a/tss-esapi/build.rs
+++ b/tss-esapi/build.rs
@@ -12,6 +12,11 @@ fn main() {
     let supported_tss_version =
         VersionReq::parse("<4.0.0, >=2.3.3").expect("Failed to parse supported TSS version");
 
+    let has_simulator_unix_socket = VersionReq::parse(">=3.2.0").unwrap();
+    if has_simulator_unix_socket.matches(&tss_version) {
+        println!("cargo:rustc-cfg=has_simulator_unix_socket")
+    }
+
     let hierarchy_is_esys_tr_req = VersionReq::parse(">=3.0.0").unwrap();
     if hierarchy_is_esys_tr_req.matches(&tss_version) {
         println!("cargo:rustc-cfg=hierarchy_is_esys_tr")

--- a/tss-esapi/build.rs
+++ b/tss-esapi/build.rs
@@ -12,11 +12,6 @@ fn main() {
     let supported_tss_version =
         VersionReq::parse("<4.0.0, >=2.3.3").expect("Failed to parse supported TSS version");
 
-    let has_simulator_unix_socket = VersionReq::parse(">=3.2.0").unwrap();
-    if has_simulator_unix_socket.matches(&tss_version) {
-        println!("cargo:rustc-cfg=has_simulator_unix_socket")
-    }
-
     let hierarchy_is_esys_tr_req = VersionReq::parse(">=3.0.0").unwrap();
     if hierarchy_is_esys_tr_req.matches(&tss_version) {
         println!("cargo:rustc-cfg=hierarchy_is_esys_tr")

--- a/tss-esapi/src/tcti_ldr.rs
+++ b/tss-esapi/src/tcti_ldr.rs
@@ -272,13 +272,16 @@ fn validate_from_str_tcti() {
         })
     );
 
-    let tcti = TctiNameConf::from_str("mssim:path=/foo/bar").unwrap();
-    assert_eq!(
-        tcti,
-        TctiNameConf::Mssim(TpmSimulatorConfig::Unix {
-            path: "/foo/bar".to_string(),
-        })
-    );
+    #[cfg(has_simulator_unix_socket)]
+    {
+        let tcti = TctiNameConf::from_str("mssim:path=/foo/bar").unwrap();
+        assert_eq!(
+            tcti,
+            TctiNameConf::Mssim(TpmSimulatorConfig::Unix {
+                path: "/foo/bar".to_string(),
+            })
+        );
+    }
 
     let tcti = TctiNameConf::from_str("swtpm:port=1234,host=168.0.0.1").unwrap();
     assert_eq!(
@@ -298,13 +301,16 @@ fn validate_from_str_tcti() {
         })
     );
 
-    let tcti = TctiNameConf::from_str("swtpm:path=/foo/bar").unwrap();
-    assert_eq!(
-        tcti,
-        TctiNameConf::Swtpm(TpmSimulatorConfig::Unix {
-            path: "/foo/bar".to_string(),
-        })
-    );
+    #[cfg(has_simulator_unix_socket)]
+    {
+        let tcti = TctiNameConf::from_str("swtpm:path=/foo/bar").unwrap();
+        assert_eq!(
+            tcti,
+            TctiNameConf::Swtpm(TpmSimulatorConfig::Unix {
+                path: "/foo/bar".to_string(),
+            })
+        );
+    }
 
     let tcti = TctiNameConf::from_str("device:/try/this/path").unwrap();
     assert_eq!(

--- a/tss-esapi/src/tcti_ldr.rs
+++ b/tss-esapi/src/tcti_ldr.rs
@@ -379,9 +379,14 @@ fn validate_from_str_device_config() {
     assert_eq!(config.path, PathBuf::from("/dev/tpm0"));
 }
 
-/// Configuration for an Mssim TCTI context
+/// Configuration for an Mssim or Swtpm TCTI context
 ///
 /// The default configuration will point to `localhost:2321`
+///
+/// Examples:
+///  - Use of a TCP connection: `swtpm:host=localhost,port=2321`
+///  - Use of a unix socket: `swtpm:path=/path/to/sock`
+///    Available on tpm2-tss >= 3.2.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TpmSimulatorConfig {
     /// Connects to tpm over TCP

--- a/tss-esapi/src/tcti_ldr.rs
+++ b/tss-esapi/src/tcti_ldr.rs
@@ -134,11 +134,11 @@ pub enum TctiNameConf {
     /// Connect to a TPM (simulator) available as a network device via the MSSIM protocol
     ///
     /// For more information about configuration, see [this page](https://www.mankier.com/3/Tss2_Tcti_Mssim_Init)
-    Mssim(TPMSimulatorConfig),
+    Mssim(TpmSimulatorConfig),
     /// Connect to a TPM (simulator) available as a network device via the SWTPM protocol
     ///
     /// For more information about configuration, see [this page](https://www.mankier.com/3/Tss2_Tcti_Mssim_Init)
-    Swtpm(TPMSimulatorConfig),
+    Swtpm(TpmSimulatorConfig),
     /// Connect to a TPM through an Access Broker/Resource Manager daemon
     ///
     /// For more information about configuration, see [this page](https://www.mankier.com/3/Tss2_Tcti_Tabrmd_Init)
@@ -177,7 +177,7 @@ impl TryFrom<TctiNameConf> for CString {
         };
 
         let tcti_conf = match tcti {
-            TctiNameConf::Mssim(TPMSimulatorConfig::Tcp { host, port }) => {
+            TctiNameConf::Mssim(TpmSimulatorConfig::Tcp { host, port }) => {
                 if let ServerAddress::Hostname(name) = &host {
                     if !hostname_validator::is_valid(name) {
                         return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
@@ -185,7 +185,7 @@ impl TryFrom<TctiNameConf> for CString {
                 }
                 format!("host={},port={}", host, port)
             }
-            TctiNameConf::Swtpm(TPMSimulatorConfig::Tcp { host, port }) => {
+            TctiNameConf::Swtpm(TpmSimulatorConfig::Tcp { host, port }) => {
                 if let ServerAddress::Hostname(name) = &host {
                     if !hostname_validator::is_valid(name) {
                         return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
@@ -194,8 +194,8 @@ impl TryFrom<TctiNameConf> for CString {
                 format!("host={},port={}", host, port)
             }
             #[cfg(has_simulator_unix_socket)]
-            TctiNameConf::Mssim(TPMSimulatorConfig::Unix { path })
-            | TctiNameConf::Swtpm(TPMSimulatorConfig::Unix { path }) => {
+            TctiNameConf::Mssim(TpmSimulatorConfig::Unix { path })
+            | TctiNameConf::Swtpm(TpmSimulatorConfig::Unix { path }) => {
                 format!("path={}", path)
             }
             TctiNameConf::Device(DeviceConfig { path }) => path
@@ -229,14 +229,14 @@ impl FromStr for TctiNameConf {
 
         let mssim_pattern = Regex::new(r"^mssim(:(.*))?$").unwrap(); //should not fail
         if let Some(captures) = mssim_pattern.captures(config_str) {
-            return Ok(TctiNameConf::Mssim(TPMSimulatorConfig::from_str(
+            return Ok(TctiNameConf::Mssim(TpmSimulatorConfig::from_str(
                 captures.get(2).map_or("", |m| m.as_str()),
             )?));
         }
 
         let swtpm_pattern = Regex::new(r"^swtpm(:(.*))?$").unwrap(); //should not fail
         if let Some(captures) = swtpm_pattern.captures(config_str) {
-            return Ok(TctiNameConf::Swtpm(TPMSimulatorConfig::from_str(
+            return Ok(TctiNameConf::Swtpm(TpmSimulatorConfig::from_str(
                 captures.get(2).map_or("", |m| m.as_str()),
             )?));
         }
@@ -257,7 +257,7 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("mssim:port=1234,host=168.0.0.1").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Mssim(TPMSimulatorConfig::Tcp {
+        TctiNameConf::Mssim(TpmSimulatorConfig::Tcp {
             port: 1234,
             host: ServerAddress::Ip(IpAddr::V4(std::net::Ipv4Addr::new(168, 0, 0, 1)))
         })
@@ -266,8 +266,8 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("mssim").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Mssim(TPMSimulatorConfig::Tcp {
-            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG,
+        TctiNameConf::Mssim(TpmSimulatorConfig::Tcp {
+            port: TpmSimulatorConfig::DEFAULT_PORT_CONFIG,
             host: Default::default()
         })
     );
@@ -275,7 +275,7 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("mssim:path=/foo/bar").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Mssim(TPMSimulatorConfig::Unix {
+        TctiNameConf::Mssim(TpmSimulatorConfig::Unix {
             path: "/foo/bar".to_string(),
         })
     );
@@ -283,7 +283,7 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("swtpm:port=1234,host=168.0.0.1").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Swtpm(TPMSimulatorConfig::Tcp {
+        TctiNameConf::Swtpm(TpmSimulatorConfig::Tcp {
             port: 1234,
             host: ServerAddress::Ip(IpAddr::V4(std::net::Ipv4Addr::new(168, 0, 0, 1)))
         })
@@ -292,8 +292,8 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("swtpm").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Swtpm(TPMSimulatorConfig::Tcp {
-            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG,
+        TctiNameConf::Swtpm(TpmSimulatorConfig::Tcp {
+            port: TpmSimulatorConfig::DEFAULT_PORT_CONFIG,
             host: Default::default()
         })
     );
@@ -301,7 +301,7 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("swtpm:path=/foo/bar").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Swtpm(TPMSimulatorConfig::Unix {
+        TctiNameConf::Swtpm(TpmSimulatorConfig::Unix {
             path: "/foo/bar".to_string(),
         })
     );
@@ -377,7 +377,7 @@ fn validate_from_str_device_config() {
 ///
 /// The default configuration will point to `localhost:2321`
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TPMSimulatorConfig {
+pub enum TpmSimulatorConfig {
     /// Connects to tpm over TCP
     Tcp {
         /// Address of the server to connect to
@@ -394,20 +394,20 @@ pub enum TPMSimulatorConfig {
     Unix { path: String },
 }
 
-impl TPMSimulatorConfig {
+impl TpmSimulatorConfig {
     const DEFAULT_PORT_CONFIG: u16 = 2321;
 }
 
-impl Default for TPMSimulatorConfig {
+impl Default for TpmSimulatorConfig {
     fn default() -> Self {
-        TPMSimulatorConfig::Tcp {
+        TpmSimulatorConfig::Tcp {
             host: Default::default(),
-            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG,
+            port: TpmSimulatorConfig::DEFAULT_PORT_CONFIG,
         }
     }
 }
 
-impl FromStr for TPMSimulatorConfig {
+impl FromStr for TpmSimulatorConfig {
     type Err = Error;
 
     fn from_str(config_str: &str) -> Result<Self> {
@@ -423,7 +423,7 @@ impl FromStr for TPMSimulatorConfig {
                 .and_then(|c| c.get(2))
                 .map(|m| m.as_str())
             {
-                return Ok(TPMSimulatorConfig::Unix {
+                return Ok(TpmSimulatorConfig::Unix {
                     path: path.to_string(),
                 });
             }
@@ -438,85 +438,85 @@ impl FromStr for TPMSimulatorConfig {
 
         let port_pattern = Regex::new(r"(,|^)port=(.*?)(,|$)").unwrap(); // should not fail
         let port = port_pattern.captures(config_str).map_or(
-            Ok(TPMSimulatorConfig::DEFAULT_PORT_CONFIG),
+            Ok(TpmSimulatorConfig::DEFAULT_PORT_CONFIG),
             |captures| {
                 u16::from_str(captures.get(2).map_or("", |m| m.as_str()))
                     .or(Err(Error::WrapperError(WrapperErrorKind::InvalidParam)))
             },
         )?;
 
-        Ok(TPMSimulatorConfig::Tcp { host, port })
+        Ok(TpmSimulatorConfig::Tcp { host, port })
     }
 }
 
 #[test]
 fn validate_from_str_networktpm_config() {
-    let config = TPMSimulatorConfig::from_str("").unwrap();
+    let config = TpmSimulatorConfig::from_str("").unwrap();
     assert_eq!(config, Default::default());
 
-    let config = TPMSimulatorConfig::from_str("fjshd89943r=joishdf894u9r,sio0983=9u98jj").unwrap();
+    let config = TpmSimulatorConfig::from_str("fjshd89943r=joishdf894u9r,sio0983=9u98jj").unwrap();
     assert_eq!(config, Default::default());
 
-    let config = TPMSimulatorConfig::from_str("host=127.0.0.1,random=value").unwrap();
+    let config = TpmSimulatorConfig::from_str("host=127.0.0.1,random=value").unwrap();
     assert_eq!(
         config,
-        TPMSimulatorConfig::Tcp {
+        TpmSimulatorConfig::Tcp {
             host: ServerAddress::Ip(IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1))),
-            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG
+            port: TpmSimulatorConfig::DEFAULT_PORT_CONFIG
         }
     );
 
-    let config = TPMSimulatorConfig::from_str("port=1234,random=value").unwrap();
+    let config = TpmSimulatorConfig::from_str("port=1234,random=value").unwrap();
     assert_eq!(
         config,
-        TPMSimulatorConfig::Tcp {
+        TpmSimulatorConfig::Tcp {
             host: Default::default(),
             port: 1234
         }
     );
 
-    let config = TPMSimulatorConfig::from_str("host=localhost,port=1234").unwrap();
+    let config = TpmSimulatorConfig::from_str("host=localhost,port=1234").unwrap();
     assert_eq!(
         config,
-        TPMSimulatorConfig::Tcp {
+        TpmSimulatorConfig::Tcp {
             host: ServerAddress::Hostname(String::from("localhost")),
             port: 1234
         }
     );
 
-    let config = TPMSimulatorConfig::from_str("port=1234,host=localhost").unwrap();
+    let config = TpmSimulatorConfig::from_str("port=1234,host=localhost").unwrap();
     assert_eq!(
         config,
-        TPMSimulatorConfig::Tcp {
+        TpmSimulatorConfig::Tcp {
             host: ServerAddress::Hostname(String::from("localhost")),
             port: 1234
         }
     );
 
-    let config = TPMSimulatorConfig::from_str("port=1234,host=localhost,random=value").unwrap();
+    let config = TpmSimulatorConfig::from_str("port=1234,host=localhost,random=value").unwrap();
     assert_eq!(
         config,
-        TPMSimulatorConfig::Tcp {
+        TpmSimulatorConfig::Tcp {
             host: "localhost".parse::<ServerAddress>().unwrap(),
             port: 1234
         }
     );
 
-    let config = TPMSimulatorConfig::from_str("host=1234.1234.1234.1234.12445.111").unwrap();
+    let config = TpmSimulatorConfig::from_str("host=1234.1234.1234.1234.12445.111").unwrap();
     assert_eq!(
         config,
-        TPMSimulatorConfig::Tcp {
+        TpmSimulatorConfig::Tcp {
             host: ServerAddress::Hostname(String::from("1234.1234.1234.1234.12445.111")),
-            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG
+            port: TpmSimulatorConfig::DEFAULT_PORT_CONFIG
         }
     );
 
-    let _ = TPMSimulatorConfig::from_str("port=abdef").unwrap_err();
-    let _ = TPMSimulatorConfig::from_str("host=-timey-wimey").unwrap_err();
-    let _ = TPMSimulatorConfig::from_str("host=abc@def").unwrap_err();
-    let _ = TPMSimulatorConfig::from_str("host=").unwrap_err();
-    let _ = TPMSimulatorConfig::from_str("port=").unwrap_err();
-    let _ = TPMSimulatorConfig::from_str("port=,host=,yas").unwrap_err();
+    let _ = TpmSimulatorConfig::from_str("port=abdef").unwrap_err();
+    let _ = TpmSimulatorConfig::from_str("host=-timey-wimey").unwrap_err();
+    let _ = TpmSimulatorConfig::from_str("host=abc@def").unwrap_err();
+    let _ = TpmSimulatorConfig::from_str("host=").unwrap_err();
+    let _ = TpmSimulatorConfig::from_str("port=").unwrap_err();
+    let _ = TpmSimulatorConfig::from_str("port=,host=,yas").unwrap_err();
 }
 
 /// Address of a TPM server

--- a/tss-esapi/src/tcti_ldr.rs
+++ b/tss-esapi/src/tcti_ldr.rs
@@ -134,11 +134,11 @@ pub enum TctiNameConf {
     /// Connect to a TPM (simulator) available as a network device via the MSSIM protocol
     ///
     /// For more information about configuration, see [this page](https://www.mankier.com/3/Tss2_Tcti_Mssim_Init)
-    Mssim(NetworkTPMConfig),
+    Mssim(TPMSimulatorConfig),
     /// Connect to a TPM (simulator) available as a network device via the SWTPM protocol
     ///
     /// For more information about configuration, see [this page](https://www.mankier.com/3/Tss2_Tcti_Mssim_Init)
-    Swtpm(NetworkTPMConfig),
+    Swtpm(TPMSimulatorConfig),
     /// Connect to a TPM through an Access Broker/Resource Manager daemon
     ///
     /// For more information about configuration, see [this page](https://www.mankier.com/3/Tss2_Tcti_Tabrmd_Init)
@@ -177,7 +177,7 @@ impl TryFrom<TctiNameConf> for CString {
         };
 
         let tcti_conf = match tcti {
-            TctiNameConf::Mssim(NetworkTPMConfig::Tcp { host, port }) => {
+            TctiNameConf::Mssim(TPMSimulatorConfig::Tcp { host, port }) => {
                 if let ServerAddress::Hostname(name) = &host {
                     if !hostname_validator::is_valid(name) {
                         return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
@@ -185,7 +185,7 @@ impl TryFrom<TctiNameConf> for CString {
                 }
                 format!("host={},port={}", host, port)
             }
-            TctiNameConf::Swtpm(NetworkTPMConfig::Tcp { host, port }) => {
+            TctiNameConf::Swtpm(TPMSimulatorConfig::Tcp { host, port }) => {
                 if let ServerAddress::Hostname(name) = &host {
                     if !hostname_validator::is_valid(name) {
                         return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
@@ -193,8 +193,9 @@ impl TryFrom<TctiNameConf> for CString {
                 }
                 format!("host={},port={}", host, port)
             }
-            TctiNameConf::Mssim(NetworkTPMConfig::Unix { path })
-            | TctiNameConf::Swtpm(NetworkTPMConfig::Unix { path }) => {
+            #[cfg(has_simulator_unix_socket)]
+            TctiNameConf::Mssim(TPMSimulatorConfig::Unix { path })
+            | TctiNameConf::Swtpm(TPMSimulatorConfig::Unix { path }) => {
                 format!("path={}", path)
             }
             TctiNameConf::Device(DeviceConfig { path }) => path
@@ -228,14 +229,14 @@ impl FromStr for TctiNameConf {
 
         let mssim_pattern = Regex::new(r"^mssim(:(.*))?$").unwrap(); //should not fail
         if let Some(captures) = mssim_pattern.captures(config_str) {
-            return Ok(TctiNameConf::Mssim(NetworkTPMConfig::from_str(
+            return Ok(TctiNameConf::Mssim(TPMSimulatorConfig::from_str(
                 captures.get(2).map_or("", |m| m.as_str()),
             )?));
         }
 
         let swtpm_pattern = Regex::new(r"^swtpm(:(.*))?$").unwrap(); //should not fail
         if let Some(captures) = swtpm_pattern.captures(config_str) {
-            return Ok(TctiNameConf::Swtpm(NetworkTPMConfig::from_str(
+            return Ok(TctiNameConf::Swtpm(TPMSimulatorConfig::from_str(
                 captures.get(2).map_or("", |m| m.as_str()),
             )?));
         }
@@ -256,7 +257,7 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("mssim:port=1234,host=168.0.0.1").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Mssim(NetworkTPMConfig::Tcp {
+        TctiNameConf::Mssim(TPMSimulatorConfig::Tcp {
             port: 1234,
             host: ServerAddress::Ip(IpAddr::V4(std::net::Ipv4Addr::new(168, 0, 0, 1)))
         })
@@ -265,8 +266,8 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("mssim").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Mssim(NetworkTPMConfig::Tcp {
-            port: DEFAULT_SERVER_PORT,
+        TctiNameConf::Mssim(TPMSimulatorConfig::Tcp {
+            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG,
             host: Default::default()
         })
     );
@@ -274,7 +275,7 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("mssim:path=/foo/bar").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Mssim(NetworkTPMConfig::Unix {
+        TctiNameConf::Mssim(TPMSimulatorConfig::Unix {
             path: "/foo/bar".to_string(),
         })
     );
@@ -282,7 +283,7 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("swtpm:port=1234,host=168.0.0.1").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Swtpm(NetworkTPMConfig::Tcp {
+        TctiNameConf::Swtpm(TPMSimulatorConfig::Tcp {
             port: 1234,
             host: ServerAddress::Ip(IpAddr::V4(std::net::Ipv4Addr::new(168, 0, 0, 1)))
         })
@@ -291,8 +292,8 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("swtpm").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Swtpm(NetworkTPMConfig::Tcp {
-            port: DEFAULT_SERVER_PORT,
+        TctiNameConf::Swtpm(TPMSimulatorConfig::Tcp {
+            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG,
             host: Default::default()
         })
     );
@@ -300,7 +301,7 @@ fn validate_from_str_tcti() {
     let tcti = TctiNameConf::from_str("swtpm:path=/foo/bar").unwrap();
     assert_eq!(
         tcti,
-        TctiNameConf::Swtpm(NetworkTPMConfig::Unix {
+        TctiNameConf::Swtpm(TPMSimulatorConfig::Unix {
             path: "/foo/bar".to_string(),
         })
     );
@@ -376,7 +377,7 @@ fn validate_from_str_device_config() {
 ///
 /// The default configuration will point to `localhost:2321`
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum NetworkTPMConfig {
+pub enum TPMSimulatorConfig {
     /// Connects to tpm over TCP
     Tcp {
         /// Address of the server to connect to
@@ -388,37 +389,44 @@ pub enum NetworkTPMConfig {
         /// Defaults to `2321`
         port: u16,
     },
+    #[cfg(has_simulator_unix_socket)]
     /// Connects to tpm over Unix socket
     Unix { path: String },
 }
 
-const DEFAULT_SERVER_PORT: u16 = 2321;
+impl TPMSimulatorConfig {
+    const DEFAULT_PORT_CONFIG: u16 = 2321;
+}
 
-impl Default for NetworkTPMConfig {
+impl Default for TPMSimulatorConfig {
     fn default() -> Self {
-        NetworkTPMConfig::Tcp {
+        TPMSimulatorConfig::Tcp {
             host: Default::default(),
-            port: DEFAULT_SERVER_PORT,
+            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG,
         }
     }
 }
 
-impl FromStr for NetworkTPMConfig {
+impl FromStr for TPMSimulatorConfig {
     type Err = Error;
 
     fn from_str(config_str: &str) -> Result<Self> {
         if config_str.is_empty() {
             return Ok(Default::default());
         }
-        let path_pattern = Regex::new(r"(,|^)path=(.*?)(,|$)").unwrap(); // should not fail
-        if let Some(path) = path_pattern
-            .captures(config_str)
-            .and_then(|c| c.get(2))
-            .map(|m| m.as_str())
+
+        #[cfg(has_simulator_unix_socket)]
         {
-            return Ok(NetworkTPMConfig::Unix {
-                path: path.to_string(),
-            });
+            let path_pattern = Regex::new(r"(,|^)path=(.*?)(,|$)").unwrap(); // should not fail
+            if let Some(path) = path_pattern
+                .captures(config_str)
+                .and_then(|c| c.get(2))
+                .map(|m| m.as_str())
+            {
+                return Ok(TPMSimulatorConfig::Unix {
+                    path: path.to_string(),
+                });
+            }
         }
 
         let host_pattern = Regex::new(r"(,|^)host=(.*?)(,|$)").unwrap(); // should not fail
@@ -429,86 +437,86 @@ impl FromStr for NetworkTPMConfig {
             })?;
 
         let port_pattern = Regex::new(r"(,|^)port=(.*?)(,|$)").unwrap(); // should not fail
-        let port =
-            port_pattern
-                .captures(config_str)
-                .map_or(Ok(DEFAULT_SERVER_PORT), |captures| {
-                    u16::from_str(captures.get(2).map_or("", |m| m.as_str()))
-                        .or(Err(Error::WrapperError(WrapperErrorKind::InvalidParam)))
-                })?;
+        let port = port_pattern.captures(config_str).map_or(
+            Ok(TPMSimulatorConfig::DEFAULT_PORT_CONFIG),
+            |captures| {
+                u16::from_str(captures.get(2).map_or("", |m| m.as_str()))
+                    .or(Err(Error::WrapperError(WrapperErrorKind::InvalidParam)))
+            },
+        )?;
 
-        Ok(NetworkTPMConfig::Tcp { host, port })
+        Ok(TPMSimulatorConfig::Tcp { host, port })
     }
 }
 
 #[test]
 fn validate_from_str_networktpm_config() {
-    let config = NetworkTPMConfig::from_str("").unwrap();
+    let config = TPMSimulatorConfig::from_str("").unwrap();
     assert_eq!(config, Default::default());
 
-    let config = NetworkTPMConfig::from_str("fjshd89943r=joishdf894u9r,sio0983=9u98jj").unwrap();
+    let config = TPMSimulatorConfig::from_str("fjshd89943r=joishdf894u9r,sio0983=9u98jj").unwrap();
     assert_eq!(config, Default::default());
 
-    let config = NetworkTPMConfig::from_str("host=127.0.0.1,random=value").unwrap();
+    let config = TPMSimulatorConfig::from_str("host=127.0.0.1,random=value").unwrap();
     assert_eq!(
         config,
-        NetworkTPMConfig::Tcp {
+        TPMSimulatorConfig::Tcp {
             host: ServerAddress::Ip(IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1))),
-            port: DEFAULT_SERVER_PORT
+            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG
         }
     );
 
-    let config = NetworkTPMConfig::from_str("port=1234,random=value").unwrap();
+    let config = TPMSimulatorConfig::from_str("port=1234,random=value").unwrap();
     assert_eq!(
         config,
-        NetworkTPMConfig::Tcp {
+        TPMSimulatorConfig::Tcp {
             host: Default::default(),
             port: 1234
         }
     );
 
-    let config = NetworkTPMConfig::from_str("host=localhost,port=1234").unwrap();
+    let config = TPMSimulatorConfig::from_str("host=localhost,port=1234").unwrap();
     assert_eq!(
         config,
-        NetworkTPMConfig::Tcp {
+        TPMSimulatorConfig::Tcp {
             host: ServerAddress::Hostname(String::from("localhost")),
             port: 1234
         }
     );
 
-    let config = NetworkTPMConfig::from_str("port=1234,host=localhost").unwrap();
+    let config = TPMSimulatorConfig::from_str("port=1234,host=localhost").unwrap();
     assert_eq!(
         config,
-        NetworkTPMConfig::Tcp {
+        TPMSimulatorConfig::Tcp {
             host: ServerAddress::Hostname(String::from("localhost")),
             port: 1234
         }
     );
 
-    let config = NetworkTPMConfig::from_str("port=1234,host=localhost,random=value").unwrap();
+    let config = TPMSimulatorConfig::from_str("port=1234,host=localhost,random=value").unwrap();
     assert_eq!(
         config,
-        NetworkTPMConfig::Tcp {
+        TPMSimulatorConfig::Tcp {
             host: "localhost".parse::<ServerAddress>().unwrap(),
             port: 1234
         }
     );
 
-    let config = NetworkTPMConfig::from_str("host=1234.1234.1234.1234.12445.111").unwrap();
+    let config = TPMSimulatorConfig::from_str("host=1234.1234.1234.1234.12445.111").unwrap();
     assert_eq!(
         config,
-        NetworkTPMConfig::Tcp {
+        TPMSimulatorConfig::Tcp {
             host: ServerAddress::Hostname(String::from("1234.1234.1234.1234.12445.111")),
-            port: DEFAULT_SERVER_PORT
+            port: TPMSimulatorConfig::DEFAULT_PORT_CONFIG
         }
     );
 
-    let _ = NetworkTPMConfig::from_str("port=abdef").unwrap_err();
-    let _ = NetworkTPMConfig::from_str("host=-timey-wimey").unwrap_err();
-    let _ = NetworkTPMConfig::from_str("host=abc@def").unwrap_err();
-    let _ = NetworkTPMConfig::from_str("host=").unwrap_err();
-    let _ = NetworkTPMConfig::from_str("port=").unwrap_err();
-    let _ = NetworkTPMConfig::from_str("port=,host=,yas").unwrap_err();
+    let _ = TPMSimulatorConfig::from_str("port=abdef").unwrap_err();
+    let _ = TPMSimulatorConfig::from_str("host=-timey-wimey").unwrap_err();
+    let _ = TPMSimulatorConfig::from_str("host=abc@def").unwrap_err();
+    let _ = TPMSimulatorConfig::from_str("host=").unwrap_err();
+    let _ = TPMSimulatorConfig::from_str("port=").unwrap_err();
+    let _ = TPMSimulatorConfig::from_str("port=,host=,yas").unwrap_err();
 }
 
 /// Address of a TPM server


### PR DESCRIPTION
TSS added support for unix sockets in 3.2.0, this commit bring support for configuration of unix sockets to talk to either swtpm or mssim.

Upstream PR: https://github.com/tpm2-software/tpm2-tss/pull/2212