### PR TITLE
Update to remove const_err

### DIFF
--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #![deny(
     nonstandard_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,


### PR DESCRIPTION
This PR only removed `const_err` since it will be a hard error in future: https://github.com/rust-lang/rust/issues/71800
Signed-off-by: Marcus de Lima <marcus.lima@azion.com>