### PR TITLE
Fix for handles not being unique.

### DIFF
--- a/tss-esapi/src/abstraction/nv.rs
+++ b/tss-esapi/src/abstraction/nv.rs
@@ -42,6 +42,8 @@ pub fn read_full(
 }
 
 /// Returns the NvPublic and Name associated with an NV index TPM handle
+///
+/// NOTE: This call _may_ close existing ESYS handles to the NV Index.
 fn get_nv_index_info(
     context: &mut Context,
     nv_index_tpm_handle: NvIndexTpmHandle,
@@ -63,6 +65,8 @@ fn get_nv_index_info(
 }
 
 /// Lists all the currently defined NV Indexes' names and public components
+///
+/// NOTE: This call _may_ close existing ESYS handles to the NV Index.
 pub fn list(context: &mut Context) -> Result<Vec<(NvPublic, Name)>> {
     context.execute_without_session(|ctx| {
         ctx.get_capability(
@@ -166,6 +170,8 @@ pub fn max_nv_buffer_size(ctx: &mut Context) -> Result<usize> {
 /// Provides methods and trait implementations to interact with a non-volatile storage index that has been opened.
 ///
 /// Use [`NvOpenOptions::open`] to obtain an [`NvReaderWriter`] object.
+///
+/// NOTE: When the `NvReaderWriter` is dropped, any existing ESYS handles to NV Indexes _may_ be closed.
 #[derive(Debug)]
 pub struct NvReaderWriter<'a> {
     context: &'a mut Context,

--- a/tss-esapi/tests/integration_tests/abstraction_tests/ek_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/ek_tests.rs
@@ -8,7 +8,6 @@ use tss_esapi::{
 
 use crate::common::create_ctx_without_session;
 
-#[ignore = "issues with tpm2-tss"]
 #[test]
 fn test_retrieve_ek_pubcert() {
     let mut context = create_ctx_without_session();


### PR DESCRIPTION
Handles returned from tpm2-tss APIs does not need to be unique. This an attempt to fix problem #383.

This problem was also discussed in https://github.com/tpm2-software/tpm2-tss/issues/2537.

Signed-off-by: Jesper Brynolf <jesper.brynolf@gmail.com>