### PR TITLE
Adds tests for WrapperErrorKind.

### DIFF
--- a/tss-esapi/src/error/wrapper.rs
+++ b/tss-esapi/src/error/wrapper.rs
@@ -31,27 +31,27 @@ impl std::fmt::Display for WrapperErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             WrapperErrorKind::WrongParamSize => {
-                write!(f, "parameter provided is of the wrong size")
+                write!(f, "Parameter provided is of the wrong size.")
             }
             WrapperErrorKind::ParamsMissing => {
-                write!(f, "some of the required parameters were not provided")
+                write!(f, "Some of the required parameters were not provided.")
             }
             WrapperErrorKind::InconsistentParams => write!(
                 f,
-                "the provided parameters have inconsistent values or variants"
+                "The provided parameters have inconsistent values or variants."
             ),
             WrapperErrorKind::UnsupportedParam => write!(
                 f,
-                "the provided parameter is not yet supported by the library"
+                "The provided parameter is not yet supported by the library."
             ),
             WrapperErrorKind::InvalidParam => {
-                write!(f, "the provided parameter is invalid for that type.")
+                write!(f, "The provided parameter is invalid for that type.")
             }
-            WrapperErrorKind::WrongValueFromTpm => write!(f, "the TPM returned an invalid value."),
-            WrapperErrorKind::MissingAuthSession => write!(f, "Missing authorization session"),
-            WrapperErrorKind::InvalidHandleState => write!(f, "Invalid handle state"),
+            WrapperErrorKind::WrongValueFromTpm => write!(f, "The TPM returned an invalid value."),
+            WrapperErrorKind::MissingAuthSession => write!(f, "Missing authorization session."),
+            WrapperErrorKind::InvalidHandleState => write!(f, "Invalid handle state."),
             WrapperErrorKind::InternalError => {
-                write!(f, "an unexpected error occurred within the crate")
+                write!(f, "An unexpected error occurred within the crate.")
             }
         }
     }

--- a/tss-esapi/tests/integration_tests/error_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2022 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod return_code_tests;
+mod wrapper_error_kind_tests;

--- a/tss-esapi/tests/integration_tests/error_tests/wrapper_error_kind_tests.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/wrapper_error_kind_tests.rs
@@ -1,0 +1,51 @@
+// Copyright 2023 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use tss_esapi::error::WrapperErrorKind;
+
+#[test]
+fn test_display() {
+    assert_eq!(
+        "Parameter provided is of the wrong size.",
+        format!("{}", WrapperErrorKind::WrongParamSize)
+    );
+
+    assert_eq!(
+        "Some of the required parameters were not provided.",
+        format!("{}", WrapperErrorKind::ParamsMissing)
+    );
+
+    assert_eq!(
+        "The provided parameters have inconsistent values or variants.",
+        format!("{}", WrapperErrorKind::InconsistentParams)
+    );
+
+    assert_eq!(
+        "The provided parameter is not yet supported by the library.",
+        format!("{}", WrapperErrorKind::UnsupportedParam)
+    );
+
+    assert_eq!(
+        "The provided parameter is invalid for that type.",
+        format!("{}", WrapperErrorKind::InvalidParam)
+    );
+
+    assert_eq!(
+        "The TPM returned an invalid value.",
+        format!("{}", WrapperErrorKind::WrongValueFromTpm)
+    );
+
+    assert_eq!(
+        "Missing authorization session.",
+        format!("{}", WrapperErrorKind::MissingAuthSession)
+    );
+
+    assert_eq!(
+        "Invalid handle state.",
+        format!("{}", WrapperErrorKind::InvalidHandleState)
+    );
+
+    assert_eq!(
+        "An unexpected error occurred within the crate.",
+        format!("{}", WrapperErrorKind::InternalError)
+    );
+}


### PR DESCRIPTION
- Adds tests that checks that the implementation of the Display trait for WrapperErrorKind is producing the expected messages.