### PR TITLE
Handles Clippy lint error that occurs in Rust 1.68

### DIFF
--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -57,8 +57,8 @@ fn main() {
     }
 }
 
-#[allow(clippy::uninlined_format_args)]
 #[cfg(feature = "generate-bindings")]
+#[allow(clippy::uninlined_format_args)]
 pub fn generate_from_system(esapi_out: PathBuf) {
     pkg_config::Config::new()
         .atleast_version(MINIMUM_VERSION)

--- a/tss-esapi/src/tcti_ldr.rs
+++ b/tss-esapi/src/tcti_ldr.rs
@@ -633,6 +633,7 @@ pub enum BusType {
     Session,
 }
 
+#[allow(clippy::derivable_impls)] // Remove this when MSRV is higher then 1.57
 impl Default for BusType {
     fn default() -> Self {
         BusType::System


### PR DESCRIPTION
- This handles a lint error that was is reported by Clippy in version 1.68 of Rust.