### PR TITLE
Cleans up TPM format zero error messages.

### DIFF
--- a/tss-esapi/src/context/tpm_commands/testing.rs
+++ b/tss-esapi/src/context/tpm_commands/testing.rs
@@ -33,7 +33,28 @@ impl Context {
 
     /// Get the TPM self test result
     ///
-    /// The returned buffer data is manufacturer-specific information.
+    /// # Details
+    /// The first parameter returned is a buffer with manufacturer-specific information.
+    ///
+    /// The second parameter returned by the method is an indicator of how the
+    /// test went in the form a [Result].
+    ///
+    /// If testing of all functions is complete without functional failures then Ok(())
+    /// or else a `TssError` (see [Error](crate::error::Error)) is returned.
+    ///
+    /// - A [TpmFormatZeroWarningResponseCode](crate::error::TpmFormatZeroWarningResponseCode) with a `Testing`
+    ///   [TpmFormatZeroWarning](crate::constants::return_code::TpmFormatZeroWarning) indicates that the test
+    ///   are not complete.
+    ///
+    /// - A [TpmFormatZeroErrorResponseCode](crate::error::TpmFormatZeroErrorResponseCode) with a `NeedsTest`
+    ///   [TpmFormatZeroError](crate::constants::return_code::TpmFormatZeroError) indicates that no self test
+    ///   has been performed and testable function has not been tested.
+    ///
+    /// - A [TpmFormatZeroErrorResponseCode](crate::error::TpmFormatZeroErrorResponseCode) with a `Failure`
+    ///   [TpmFormatZeroError](crate::constants::return_code::TpmFormatZeroError) indicates that there was
+    ///   a failure.
+    ///
+    /// See [Part 3, Commands](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf).
     pub fn get_test_result(&mut self) -> Result<(MaxBuffer, Result<()>)> {
         let mut out_data_ptr = null_mut();
         let mut test_result: u32 = 0;

--- a/tss-esapi/src/error/return_code/tpm/format_zero/error.rs
+++ b/tss-esapi/src/error/return_code/tpm/format_zero/error.rs
@@ -5,6 +5,14 @@ use std::convert::TryFrom;
 
 /// Type representing the TPM format zero error
 /// response code.
+///
+/// # Details
+/// The error messages are short forms of the descriptions given in the specification
+/// that describes return codes (see the
+/// [Part 2, Structures](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part2_Structures_pub.pdf)).
+/// Sometimes these descriptions refers to fields within the structures described in the specification. When
+/// a message contains such a description then the name of the of the field is surrounded with backticks
+/// (e.g. `authValue`).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TpmFormatZeroErrorResponseCode {
     error_number: TpmFormatZeroError,
@@ -50,40 +58,40 @@ impl std::error::Error for TpmFormatZeroErrorResponseCode {}
 impl std::fmt::Display for TpmFormatZeroErrorResponseCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.error_number {
-            TpmFormatZeroError::Initialize => write!(f, "TPM not initialized by TPM2_Startup or already initialized"),
-            TpmFormatZeroError::Failure => write!(f, "commands not being accepted because of a TPM failure. NOTE: This may be returned by TPM2_GetTestResult() as the testResultparameter"),
-            TpmFormatZeroError::Sequence => write!(f, "improper use of a sequence handle"),
-            TpmFormatZeroError::Private => write!(f, "not currently used"),
-            TpmFormatZeroError::Hmac => write!(f, "not currently used"),
-            TpmFormatZeroError::Disabled => write!(f, "the command is disabled"),
-            TpmFormatZeroError::Exclusive => write!(f, "command failed because audit sequence required exclusivity"),
-            TpmFormatZeroError::AuthType => write!(f, "authorization handle is not correct for command"),
-            TpmFormatZeroError::AuthMissing => write!(f, "command requires an authorization session for handle and it is not present"),
-            TpmFormatZeroError::Policy => write!(f, "policy failure in math operation or an invalid authPolicy value"),
-            TpmFormatZeroError::Pcr => write!(f, "PCR check fail"),
-            TpmFormatZeroError::PcrChanged => write!(f, "PCR have changed since checked"),
-            TpmFormatZeroError::Upgrade => write!(f, "for all commands other than TPM2_FieldUpgradeData(), this code indicates that the TPM is in field upgrade mode; for TPM2_FieldUpgradeData(), this code indicates that the TPM is not in field upgrade mode"),
-            TpmFormatZeroError::TooManyContexts => write!(f, "context ID counter is at maximum"),
-            TpmFormatZeroError::AuthUnavailable => write!(f, "authValue or authPolicy is not available for selected entity"),
-            TpmFormatZeroError::Reboot => write!(f, "a _TPM_Init and Startup(CLEAR) is required before the TPM can resume operation"),
-            TpmFormatZeroError::Unbalanced => write!(f, "the protection algorithms (hash and symmetric) are not reasonably balanced. The digest size of the hash must be larger than the key size of the symmetric algorithm"),
-            TpmFormatZeroError::CommandSize => write!(f, "command commandSizevalue is inconsistent with contents of the command buffer; either the size is not the same as the octets loaded by the hardware interface layer or the value is not large enough to hold a command header"),
-            TpmFormatZeroError::CommandCode => write!(f, "command code not supported"),
-            TpmFormatZeroError::AuthSize => write!(f, "the value of authorizationSizeis out of range or the number of octets in the Authorization Area is greater than required"),
-            TpmFormatZeroError::AuthContext => write!(f, "use of an authorization session with a context command or another command that cannot have an authorization session"),
-            TpmFormatZeroError::NvRange => write!(f, "NV offset+size is out of range"),
-            TpmFormatZeroError::NvSize => write!(f, "Requested allocation size is larger than allowed"),
-            TpmFormatZeroError::NvLocked => write!(f, "NV access locked"),
-            TpmFormatZeroError::NvAuthorization => write!(f, "NV access authorization fails in command actions (this failure does not affect lockout.action)"),
-            TpmFormatZeroError::NvUninitialized => write!(f, "an NV Index is used before being initialized or the state saved by TPM2_Shutdown(STATE) could not be restored"),
-            TpmFormatZeroError::NvSpace => write!(f, "insufficient space for NV allocation"),
-            TpmFormatZeroError::NvDefined => write!(f, "NV Index or persistent object already defined"),
-            TpmFormatZeroError::BadContext => write!(f, "context in TPM2_ContextLoad() is not valid"),
-            TpmFormatZeroError::CpHash => write!(f, "cpHash value already set or not correct for use"),
-            TpmFormatZeroError::Parent => write!(f, "handle for parent is not a valid parent"),
-            TpmFormatZeroError::NeedsTest => write!(f, "some function needs testing."),
-            TpmFormatZeroError::NoResult => write!(f, "returned when an internal function cannot process a request due to an unspecified problem. This code is usually related to invalid parameters that are not properly filtered by the input unmarshaling code."),
-            TpmFormatZeroError::Sensitive => write!(f, "the sensitive area did not unmarshal correctly after decryption - this code is used in lieu of the other unmarshaling errors so that an attacker cannot determine where the unmarshaling error occurred"),
+            TpmFormatZeroError::Initialize => write!(f, "TPM not initialized by TPM2_Startup or already initialized."),
+            TpmFormatZeroError::Failure => write!(f, "Commands not accepted because of a TPM failure."),
+            TpmFormatZeroError::Sequence => write!(f, "Improper use of a sequence handle."),
+            TpmFormatZeroError::Private => write!(f, "Not currently used."),
+            TpmFormatZeroError::Hmac => write!(f, "Not currently used."),
+            TpmFormatZeroError::Disabled => write!(f, "The command is disabled."),
+            TpmFormatZeroError::Exclusive => write!(f, "Command failed because audit sequence required exclusivity."),
+            TpmFormatZeroError::AuthType => write!(f, "Authorization handle is not correct for command."),
+            TpmFormatZeroError::AuthMissing => write!(f, "Command requires an authorization session for handle and it is not present."),
+            TpmFormatZeroError::Policy => write!(f, "Policy failure in math operation or an invalid `authPolicy` value."),
+            TpmFormatZeroError::Pcr => write!(f, "PCR check fail."),
+            TpmFormatZeroError::PcrChanged => write!(f, "PCR have changed since checked."),
+            TpmFormatZeroError::Upgrade => write!(f, "For all commands other than TPM2_FieldUpgradeData(), this code indicates that the TPM is in field upgrade mode; for TPM2_FieldUpgradeData(), this code indicates that the TPM is not in field upgrade mode."),
+            TpmFormatZeroError::TooManyContexts => write!(f, "Context ID counter is at maximum."),
+            TpmFormatZeroError::AuthUnavailable => write!(f, "`authValue` or `authPolicy` is not available for selected entity."),
+            TpmFormatZeroError::Reboot => write!(f, "A _TPM_Init and Startup(CLEAR) is required before the TPM can resume operation."),
+            TpmFormatZeroError::Unbalanced => write!(f, "The protection algorithms (hash and symmetric) are not reasonably balanced. The digest size of the hash must be larger than the key size of the symmetric algorithm."),
+            TpmFormatZeroError::CommandSize => write!(f, "Command `commandSize` value is inconsistent with contents of the command buffer; either the size is not the same as the octets loaded by the hardware interface layer or the value is not large enough to hold a command header."),
+            TpmFormatZeroError::CommandCode => write!(f, "Command code not supported."),
+            TpmFormatZeroError::AuthSize => write!(f, "The value of `authorizationSize` is out of range or the number of octets in the authorization area is greater than required."),
+            TpmFormatZeroError::AuthContext => write!(f, "Use of an authorization session with a context command or another command that cannot have an authorization session."),
+            TpmFormatZeroError::NvRange => write!(f, "NV offset+size is out of range."),
+            TpmFormatZeroError::NvSize => write!(f, "Requested allocation size is larger than allowed."),
+            TpmFormatZeroError::NvLocked => write!(f, "NV access locked."),
+            TpmFormatZeroError::NvAuthorization => write!(f, "NV access authorization fails in command actions."),
+            TpmFormatZeroError::NvUninitialized => write!(f, "An NV Index is used before being initialized or the state saved by TPM2_Shutdown(STATE) could not be restored."),
+            TpmFormatZeroError::NvSpace => write!(f, "Insufficient space for NV allocation."),
+            TpmFormatZeroError::NvDefined => write!(f, "NV Index or persistent object already defined."),
+            TpmFormatZeroError::BadContext => write!(f, "Context in TPM2_ContextLoad() is not valid."),
+            TpmFormatZeroError::CpHash => write!(f, "`cpHash` value already set or not correct for use."),
+            TpmFormatZeroError::Parent => write!(f, "Handle for parent is not a valid parent."),
+            TpmFormatZeroError::NeedsTest => write!(f, "Function needs testing."),
+            TpmFormatZeroError::NoResult => write!(f, "Function cannot process a request due to an unspecified problem. This code is usually related to invalid parameters that are not properly filtered by the input unmarshaling code."),
+            TpmFormatZeroError::Sensitive => write!(f, "The sensitive area did not unmarshal correctly after decryption."),
         }
     }
 }

--- a/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/tpm_format_zero_error_tests.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/tpm_format_zero_error_tests.rs
@@ -32,12 +32,14 @@ macro_rules! test_valid_conversion {
             expected_tpm_format_zero_error_rc,
             TpmFormatZeroErrorResponseCode::try_from(($tpm_rc - TPM2_RC_VER1) as u8).expect(
                 &format!(
-                    "{} did not convert into a TpmFormatZeroErrorResponseCode",
-                    std::stringify!($tpm_rc - TPM2_RC_VER1)
+                    "{} did not convert into a {}",
+                    std::stringify!($tpm_rc - TPM2_RC_VER1),
+                    std::any::type_name::<TpmFormatZeroErrorResponseCode>(),
                 )
             ),
-            "{} did not convert into the expected TpmFormatZeroErrorResponseCode",
+            "{} did not convert into the expected {}",
             std::stringify!($tpm_rc - TPM2_RC_VER1),
+            std::any::type_name::<TpmFormatZeroErrorResponseCode>()
         );
 
         let actual_rc = ReturnCode::try_from(expected_tss_rc)
@@ -50,8 +52,9 @@ macro_rules! test_valid_conversion {
             assert_eq!(
                 expected_tpm_format_zero_error_rc,
                 actual_tpm_format_zero_error_rc,
-                "{} in the TPM layer did not convert into the expected TpmFormatZeroResponseCode",
-                std::stringify!($tpm_rc)
+                "{} in the TPM layer did not convert into the expected {}",
+                std::stringify!($tpm_rc),
+                std::any::type_name::<TpmFormatZeroResponseCode>(),
             );
         } else {
             panic!("TPM TSS2_RC layer did no convert into ReturnCode::Tpm");
@@ -60,9 +63,25 @@ macro_rules! test_valid_conversion {
         assert_eq!(
             expected_tss_rc,
             actual_rc.into(),
-            "TpmFormatZeroResponseCode with {} did not convert into expected {} TSS2_RC in the TPM layer.",
+            "{} with {} did not convert into expected {} TSS2_RC in the TPM layer.",
+            std::any::type_name::<TpmFormatZeroResponseCode>(),
             std::stringify!(TpmFormatZeroError::$item),
             std::stringify!($tpm_rc),
+        );
+    };
+}
+
+macro_rules! test_display_trait_impl {
+    ($expected_error_message:tt, TpmFormatZeroError::$zero_error:ident) => {
+        assert_eq!(
+            format!(
+                "{}",
+                TpmFormatZeroErrorResponseCode::from(TpmFormatZeroError::$zero_error)
+            ),
+            $expected_error_message,
+            "{} with {} did not produce the expected error message",
+            std::any::type_name::<TpmFormatZeroErrorResponseCode>(),
+            std::stringify!(TpmFormatZeroError::$zero_error),
         );
     };
 }
@@ -123,5 +142,106 @@ fn test_invalid_conversions() {
         ReturnCode::try_from(tss_invalid_tpm_format_zero_error_rc),
         Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
         "Converting invalid TPM layer response code did not produce the expected error"
+    );
+}
+
+#[test]
+fn test_display_implementation() {
+    test_display_trait_impl!(
+        "TPM not initialized by TPM2_Startup or already initialized.",
+        TpmFormatZeroError::Initialize
+    );
+    test_display_trait_impl!(
+        "Commands not accepted because of a TPM failure.",
+        TpmFormatZeroError::Failure
+    );
+    test_display_trait_impl!(
+        "Improper use of a sequence handle.",
+        TpmFormatZeroError::Sequence
+    );
+    test_display_trait_impl!("Not currently used.", TpmFormatZeroError::Private);
+    test_display_trait_impl!("Not currently used.", TpmFormatZeroError::Hmac);
+    test_display_trait_impl!("The command is disabled.", TpmFormatZeroError::Disabled);
+    test_display_trait_impl!(
+        "Command failed because audit sequence required exclusivity.",
+        TpmFormatZeroError::Exclusive
+    );
+    test_display_trait_impl!(
+        "Authorization handle is not correct for command.",
+        TpmFormatZeroError::AuthType
+    );
+    test_display_trait_impl!(
+        "Command requires an authorization session for handle and it is not present.",
+        TpmFormatZeroError::AuthMissing
+    );
+    test_display_trait_impl!(
+        "Policy failure in math operation or an invalid `authPolicy` value.",
+        TpmFormatZeroError::Policy
+    );
+    test_display_trait_impl!("PCR check fail.", TpmFormatZeroError::Pcr);
+    test_display_trait_impl!(
+        "PCR have changed since checked.",
+        TpmFormatZeroError::PcrChanged
+    );
+    test_display_trait_impl!("For all commands other than TPM2_FieldUpgradeData(), this code indicates that the TPM is in field upgrade mode; for TPM2_FieldUpgradeData(), this code indicates that the TPM is not in field upgrade mode.", TpmFormatZeroError::Upgrade);
+    test_display_trait_impl!(
+        "Context ID counter is at maximum.",
+        TpmFormatZeroError::TooManyContexts
+    );
+    test_display_trait_impl!(
+        "`authValue` or `authPolicy` is not available for selected entity.",
+        TpmFormatZeroError::AuthUnavailable
+    );
+    test_display_trait_impl!(
+        "A _TPM_Init and Startup(CLEAR) is required before the TPM can resume operation.",
+        TpmFormatZeroError::Reboot
+    );
+    test_display_trait_impl!("The protection algorithms (hash and symmetric) are not reasonably balanced. The digest size of the hash must be larger than the key size of the symmetric algorithm.", TpmFormatZeroError::Unbalanced);
+    test_display_trait_impl!("Command `commandSize` value is inconsistent with contents of the command buffer; either the size is not the same as the octets loaded by the hardware interface layer or the value is not large enough to hold a command header.", TpmFormatZeroError::CommandSize);
+    test_display_trait_impl!(
+        "Command code not supported.",
+        TpmFormatZeroError::CommandCode
+    );
+    test_display_trait_impl!("The value of `authorizationSize` is out of range or the number of octets in the authorization area is greater than required.", TpmFormatZeroError::AuthSize);
+    test_display_trait_impl!("Use of an authorization session with a context command or another command that cannot have an authorization session.", TpmFormatZeroError::AuthContext);
+    test_display_trait_impl!(
+        "NV offset+size is out of range.",
+        TpmFormatZeroError::NvRange
+    );
+    test_display_trait_impl!(
+        "Requested allocation size is larger than allowed.",
+        TpmFormatZeroError::NvSize
+    );
+    test_display_trait_impl!("NV access locked.", TpmFormatZeroError::NvLocked);
+    test_display_trait_impl!(
+        "NV access authorization fails in command actions.",
+        TpmFormatZeroError::NvAuthorization
+    );
+    test_display_trait_impl!("An NV Index is used before being initialized or the state saved by TPM2_Shutdown(STATE) could not be restored.", TpmFormatZeroError::NvUninitialized);
+    test_display_trait_impl!(
+        "Insufficient space for NV allocation.",
+        TpmFormatZeroError::NvSpace
+    );
+    test_display_trait_impl!(
+        "NV Index or persistent object already defined.",
+        TpmFormatZeroError::NvDefined
+    );
+    test_display_trait_impl!(
+        "Context in TPM2_ContextLoad() is not valid.",
+        TpmFormatZeroError::BadContext
+    );
+    test_display_trait_impl!(
+        "`cpHash` value already set or not correct for use.",
+        TpmFormatZeroError::CpHash
+    );
+    test_display_trait_impl!(
+        "Handle for parent is not a valid parent.",
+        TpmFormatZeroError::Parent
+    );
+    test_display_trait_impl!("Function needs testing.", TpmFormatZeroError::NeedsTest);
+    test_display_trait_impl!("Function cannot process a request due to an unspecified problem. This code is usually related to invalid parameters that are not properly filtered by the input unmarshaling code.", TpmFormatZeroError::NoResult);
+    test_display_trait_impl!(
+        "The sensitive area did not unmarshal correctly after decryption.",
+        TpmFormatZeroError::Sensitive
     );
 }

--- a/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/tpm_format_zero_warning_tests.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/tpm_format_zero_warning_tests.rs
@@ -74,7 +74,7 @@ macro_rules! test_display_trait_impl {
                 TpmFormatZeroWarningResponseCode::from(TpmFormatZeroWarning::$zero_warning)
             ),
             $expected_error_message,
-            "BaseReturnCode with {} did not produce the expected error message",
+            "TpmFormatZeroWarningResponseCode with {} did not produce the expected error message",
             std::stringify!(TpmFormatZeroWarning::$zero_warning),
         );
     };


### PR DESCRIPTION
- Changes the error messages so that they form proper sentences.

- Removes comments from the error messages (e.g. text that contains the work 'NOTE').

- Adds test for the display trait implementation.