### PR TITLE
Bump enumflags2 to 0.7.7

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -16,7 +16,7 @@ bitfield = "0.13.2"
 serde = { version = "1.0.115", features = ["derive"] }
 mbox = "0.6.0"
 log = "0.4.11"
-enumflags2 = "0.7.1"
+enumflags2 = "0.7.7"
 num-derive = "0.3.2"
 num-traits = "0.2.12"
 hostname-validator = "1.1.0"


### PR DESCRIPTION
There's a RUSTSEC-2023-0035 CVE which is addressed in 0.7.7 so we should bump that to the minimum revision.