### PR TITLE
Adds tests for vendor specific errors.

### DIFF
--- a/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/mod.rs
@@ -4,5 +4,6 @@
 mod tpm_format_one_argument_number_tests;
 mod tpm_format_one_error_tests;
 mod tpm_format_zero_error_tests;
+mod tpm_format_zero_vendor_specific_tests;
 mod tpm_format_zero_warning_tests;
 mod tpm_response_code_tests;

--- a/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/tpm_format_zero_vendor_specific_tests.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/tpm_format_zero_vendor_specific_tests.rs
@@ -1,0 +1,45 @@
+// Copyright 2023 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.
+use bitfield::bitfield;
+use std::convert::TryFrom;
+use tss_esapi::{
+    constants::tss::{TPM2_RC_INITIALIZE, TSS2_TPM_RC_LAYER},
+    error::{ReturnCode, TpmFormatZeroResponseCode, TpmResponseCode},
+};
+
+bitfield! {
+    pub struct VendorSpecificBitHelper(u32);
+    _, set_is_vendor_specific: 10;
+}
+
+#[test]
+fn test_valid_conversions() {
+    // Bit 10 In the TPM format zero return code is the bit indicating vendor specific.
+    // |11|10| 9|   8   | 7| 6| 5| 4| 3| 2| 1| 0|
+    // | W| V| R|TPM 2.0|  |    error number    |
+    let mut helper = VendorSpecificBitHelper(TSS2_TPM_RC_LAYER | TPM2_RC_INITIALIZE);
+    helper.set_is_vendor_specific(true);
+    let expected_tss_rc = helper.0;
+
+    let actual_rc = ReturnCode::try_from(expected_tss_rc)
+        .expect("Failed to convert TPM zero error return code value with vendor specific bit set into a Result.");
+
+    if let ReturnCode::Tpm(TpmResponseCode::FormatZero(
+        TpmFormatZeroResponseCode::VendorSpecific(actual),
+    )) = actual_rc
+    {
+        assert_eq!(
+            expected_tss_rc,
+            actual.into(),
+            "Converting vendor specific return code did not return the original value."
+        );
+    } else {
+        panic!("TPM TSS2_RC layer did no convert into ReturnCode::Tpm");
+    }
+
+    assert_eq!(
+        expected_tss_rc,
+        actual_rc.into(),
+        "The vendor specific return code did not convert into the expected TSS2_RC in the TPM layer."
+    )
+}


### PR DESCRIPTION
- Adds tests that check that a TPM format zero vendor specific response code gets parsed and converted properly.

- Adds a test that is checking if the correct wrapper error is returned when the reserved bit is SET in the TPM format zero response code.

- Adds a test that is checking if the correct wrapper error is returned when the TPM 2.0 bit is CLEAR in the TPM format zero response code.