### PR TITLE
Add `abstraction` feature

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -23,9 +23,9 @@ hostname-validator = "1.1.0"
 regex = "1.3.9"
 zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.4.0" }
-oid = "0.2.1"
-picky-asn1 = "0.3.0"
-picky-asn1-x509 = "0.6.1"
+oid = { version = "0.2.1", optional = true }
+picky-asn1 = { version = "0.3.0", optional = true }
+picky-asn1-x509 = { version = "0.6.1", optional = true }
 cfg-if = "1.0.0"
 
 [dev-dependencies]
@@ -36,4 +36,6 @@ sha2 = "0.10.1"
 semver = "1.0.7"
 
 [features]
+default = ["abstraction"]
 generate-bindings = ["tss-esapi-sys/generate-bindings"]
+abstraction = ["oid", "picky-asn1", "picky-asn1-x509"]

--- a/tss-esapi/README.md
+++ b/tss-esapi/README.md
@@ -17,6 +17,17 @@ time using the headers identified on the system.
 
 Our end-goal is to achieve a fully Rust-native interface that offers strong safety and security guarantees. Check out our [documentation](https://docs.rs/tss-esapi/*/tss_esapi/#notes-on-code-safety) for an overview of our code safety approach.
 
+## Cargo Features
+
+The crate currently offers the following features:
+
+* `generate_bindings` - forces the underlying `tss-esapi-sys`
+  crate to regenerate the FFI bindings on each build, using the TSS
+  libraries available on the build machine.
+* `abstraction` (enabled by default) - provides a set of abstracted primitives
+  on top of the basic Rust-native ESAPI API provided by the crate. This feature
+  can be turned off to reduce the number of dependencies built.
+
 ## Cross compiling
 
 For more information on cross-compiling the `tss-esapi` crate, please see the README of the `tss-esapi-sys` crate.

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -94,6 +94,7 @@ mod context;
 
 pub mod error;
 pub use tss_esapi_sys as tss2_esys;
+#[cfg(feature = "abstraction")]
 pub mod abstraction;
 pub mod attributes;
 pub mod constants;

--- a/tss-esapi/tests/integration_tests/main.rs
+++ b/tss-esapi/tests/integration_tests/main.rs
@@ -5,6 +5,7 @@
 #[path = "common/mod.rs"]
 mod common;
 
+#[cfg(feature = "abstraction")]
 mod abstraction_tests;
 mod attributes_tests;
 mod constants_tests;


### PR DESCRIPTION
Adding a feature that separates the abstraction from the basic interface of the Rust-native crate. This feature is enabled by default so as not to break existing uses.