### PR TITLE
Expanding UnMarshall + a few additions

### DIFF
--- a/tss-esapi/src/constants/command_code.rs
+++ b/tss-esapi/src/constants/command_code.rs
@@ -163,22 +163,7 @@ impl Marshall for CommandCode {
         let mut buffer = vec![0; Self::BUFFER_SIZE];
         let mut offset = 0;
 
-        ReturnCode::ensure_success(
-            unsafe {
-                crate::tss2_esys::Tss2_MU_TPM2_CC_Marshal(
-                    (*self).into(),
-                    buffer.as_mut_ptr(),
-                    Self::BUFFER_SIZE.try_into().map_err(|e| {
-                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
-                        Error::local_error(WrapperErrorKind::InvalidParam)
-                    })?,
-                    &mut offset,
-                )
-            },
-            |ret| {
-                error!("Failed to marshal CommandCode: {}", ret);
-            },
-        )?;
+        self.marshall_offset(&mut buffer, &mut offset)?;
 
         let checked_offset = usize::try_from(offset).map_err(|e| {
             error!("Failed to parse offset as usize: {}", e);
@@ -188,6 +173,30 @@ impl Marshall for CommandCode {
         buffer.truncate(checked_offset);
 
         Ok(buffer)
+    }
+
+    fn marshall_offset(
+        &self,
+        marshalled_data: &mut [u8],
+        offset: &mut std::os::raw::c_ulong,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2_CC_Marshal(
+                    (*self).into(),
+                    marshalled_data.as_mut_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshal CommandCode: {}", ret);
+            },
+        )?;
+        Ok(())
     }
 }
 

--- a/tss-esapi/src/constants/command_code.rs
+++ b/tss-esapi/src/constants/command_code.rs
@@ -158,23 +158,6 @@ impl From<CommandCode> for TPM2_CC {
 impl Marshall for CommandCode {
     const BUFFER_SIZE: usize = std::mem::size_of::<TPM2_CC>();
 
-    /// Produce a marshalled [TPM2_CC]
-    fn marshall(&self) -> Result<Vec<u8>> {
-        let mut buffer = vec![0; Self::BUFFER_SIZE];
-        let mut offset = 0;
-
-        self.marshall_offset(&mut buffer, &mut offset)?;
-
-        let checked_offset = usize::try_from(offset).map_err(|e| {
-            error!("Failed to parse offset as usize: {}", e);
-            Error::local_error(WrapperErrorKind::InvalidParam)
-        })?;
-
-        buffer.truncate(checked_offset);
-
-        Ok(buffer)
-    }
-
     fn marshall_offset(
         &self,
         marshalled_data: &mut [u8],
@@ -201,11 +184,6 @@ impl Marshall for CommandCode {
 }
 
 impl UnMarshall for CommandCode {
-    /// Unmarshall the structure from [`TPM2_CC`]
-    fn unmarshall(marshalled_data: &[u8]) -> Result<Self> {
-        CommandCode::unmarshall_offset(marshalled_data, &mut 0)
-    }
-
     fn unmarshall_offset(
         marshalled_data: &[u8],
         offset: &mut std::os::raw::c_ulong,

--- a/tss-esapi/src/constants/command_code.rs
+++ b/tss-esapi/src/constants/command_code.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 mod structure;
 
-use crate::{tss2_esys::TPM2_CC, Error, Result, WrapperErrorKind};
+use crate::{
+    traits::{Marshall, UnMarshall},
+    tss2_esys::TPM2_CC,
+    Error, Result, ReturnCode, WrapperErrorKind,
+};
 use log::error;
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use structure::CommandCodeStructure;
 
 /// Enum representing the command code constants.
@@ -148,5 +152,72 @@ impl From<CommandCode> for TPM2_CC {
     fn from(command_code: CommandCode) -> Self {
         // The values are well defined so this cannot fail.
         command_code.to_u32().unwrap()
+    }
+}
+
+impl Marshall for CommandCode {
+    const BUFFER_SIZE: usize = std::mem::size_of::<TPM2_CC>();
+
+    /// Produce a marshalled [TPM2_CC]
+    fn marshall(&self) -> Result<Vec<u8>> {
+        let mut buffer = vec![0; Self::BUFFER_SIZE];
+        let mut offset = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2_CC_Marshal(
+                    (*self).into(),
+                    buffer.as_mut_ptr(),
+                    Self::BUFFER_SIZE.try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    &mut offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshal CommandCode: {}", ret);
+            },
+        )?;
+
+        let checked_offset = usize::try_from(offset).map_err(|e| {
+            error!("Failed to parse offset as usize: {}", e);
+            Error::local_error(WrapperErrorKind::InvalidParam)
+        })?;
+
+        buffer.truncate(checked_offset);
+
+        Ok(buffer)
+    }
+}
+
+impl UnMarshall for CommandCode {
+    /// Unmarshall the structure from [`TPM2_CC`]
+    fn unmarshall(marshalled_data: &[u8]) -> Result<Self> {
+        CommandCode::unmarshall_offset(marshalled_data, &mut 0)
+    }
+
+    fn unmarshall_offset(
+        marshalled_data: &[u8],
+        offset: &mut std::os::raw::c_ulong,
+    ) -> Result<Self> {
+        let mut dest = TPM2_CC::default();
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2_CC_Unmarshal(
+                    marshalled_data.as_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert length of marshalled data: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    offset,
+                    &mut dest,
+                )
+            },
+            |ret| error!("Failed to unmarshal SensitiveCreate: {}", ret),
+        )?;
+
+        CommandCode::try_from(dest)
     }
 }

--- a/tss-esapi/src/interface_types/structure_tags.rs
+++ b/tss-esapi/src/interface_types/structure_tags.rs
@@ -1,8 +1,16 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{constants::StructureTag, tss2_esys::TPMI_ST_ATTEST, Error, Result, WrapperErrorKind};
-use std::convert::TryFrom;
+use log::error;
+use tss_esapi_sys::TPMI_ST_COMMAND_TAG;
+
+use crate::{
+    constants::StructureTag,
+    traits::{Marshall, UnMarshall},
+    tss2_esys::TPMI_ST_ATTEST,
+    Error, Result, ReturnCode, WrapperErrorKind,
+};
+use std::convert::{TryFrom, TryInto};
 
 /// Type of attestation.
 ///
@@ -64,5 +72,184 @@ impl TryFrom<TPMI_ST_ATTEST> for AttestationType {
 
     fn try_from(tpmi_st_attest: TPMI_ST_ATTEST) -> Result<Self> {
         AttestationType::try_from(StructureTag::try_from(tpmi_st_attest)?)
+    }
+}
+
+impl Marshall for AttestationType {
+    const BUFFER_SIZE: usize = std::mem::size_of::<TPMI_ST_ATTEST>();
+
+    /// Produce a marshalled [`TPMI_ST_ATTEST`]
+    fn marshall(&self) -> Result<Vec<u8>> {
+        let mut buffer = vec![0; Self::BUFFER_SIZE];
+        let mut offset = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2_ST_Marshal(
+                    (*self).into(),
+                    buffer.as_mut_ptr(),
+                    Self::BUFFER_SIZE.try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    &mut offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshal AttestationType: {}", ret);
+            },
+        )?;
+
+        let checked_offset = usize::try_from(offset).map_err(|e| {
+            error!("Failed to parse offset as usize: {}", e);
+            Error::local_error(WrapperErrorKind::InvalidParam)
+        })?;
+
+        buffer.truncate(checked_offset);
+
+        Ok(buffer)
+    }
+}
+
+impl UnMarshall for AttestationType {
+    /// Unmarshall the structure from [`TPMI_ST_ATTEST`]
+    fn unmarshall(marshalled_data: &[u8]) -> Result<Self> {
+        AttestationType::unmarshall_offset(marshalled_data, &mut 0)
+    }
+
+    fn unmarshall_offset(
+        marshalled_data: &[u8],
+        offset: &mut std::os::raw::c_ulong,
+    ) -> Result<Self> {
+        let mut dest = TPMI_ST_ATTEST::default();
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2_ST_Unmarshal(
+                    marshalled_data.as_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert length of marshalled data: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    offset,
+                    &mut dest,
+                )
+            },
+            |ret| error!("Failed to unmarshal AttestationType: {}", ret),
+        )?;
+
+        AttestationType::try_from(dest)
+    }
+}
+
+/// Type of command tag.
+///
+/// # Details
+/// Corresponds to `TPMI_ST_COMMAND_TAG`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandTag {
+    Sessions,
+    NoSessions,
+}
+
+impl From<CommandTag> for StructureTag {
+    fn from(value: CommandTag) -> Self {
+        match value {
+            CommandTag::Sessions => StructureTag::Sessions,
+            CommandTag::NoSessions => StructureTag::NoSessions,
+        }
+    }
+}
+
+impl TryFrom<StructureTag> for CommandTag {
+    type Error = Error;
+
+    fn try_from(value: StructureTag) -> std::result::Result<Self, Self::Error> {
+        match value {
+            StructureTag::Sessions => Ok(CommandTag::Sessions),
+            StructureTag::NoSessions => Ok(CommandTag::NoSessions),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+impl From<CommandTag> for TPMI_ST_COMMAND_TAG {
+    fn from(command_tag: CommandTag) -> Self {
+        StructureTag::from(command_tag).into()
+    }
+}
+
+impl TryFrom<TPMI_ST_COMMAND_TAG> for CommandTag {
+    type Error = Error;
+
+    fn try_from(tpmi_st_command_tag: TPMI_ST_COMMAND_TAG) -> Result<Self> {
+        CommandTag::try_from(StructureTag::try_from(tpmi_st_command_tag)?)
+    }
+}
+
+impl Marshall for CommandTag {
+    const BUFFER_SIZE: usize = std::mem::size_of::<TPMI_ST_COMMAND_TAG>();
+
+    /// Produce a marshalled [`TPMI_ST_COMMAND_TAG`]
+    fn marshall(&self) -> Result<Vec<u8>> {
+        let mut buffer = vec![0; Self::BUFFER_SIZE];
+        let mut offset = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2_ST_Marshal(
+                    (*self).into(),
+                    buffer.as_mut_ptr(),
+                    Self::BUFFER_SIZE.try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    &mut offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshal CommandTag: {}", ret);
+            },
+        )?;
+
+        let checked_offset = usize::try_from(offset).map_err(|e| {
+            error!("Failed to parse offset as usize: {}", e);
+            Error::local_error(WrapperErrorKind::InvalidParam)
+        })?;
+
+        buffer.truncate(checked_offset);
+
+        Ok(buffer)
+    }
+}
+
+impl UnMarshall for CommandTag {
+    /// Unmarshall the structure from [`TPMI_ST_COMMAND_TAG`]
+    fn unmarshall(marshalled_data: &[u8]) -> Result<Self> {
+        CommandTag::unmarshall_offset(marshalled_data, &mut 0)
+    }
+
+    fn unmarshall_offset(
+        marshalled_data: &[u8],
+        offset: &mut std::os::raw::c_ulong,
+    ) -> Result<Self> {
+        let mut dest = TPMI_ST_COMMAND_TAG::default();
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2_ST_Unmarshal(
+                    marshalled_data.as_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert length of marshalled data: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    offset,
+                    &mut dest,
+                )
+            },
+            |ret| error!("Failed to unmarshal CommandTag: {}", ret),
+        )?;
+
+        CommandTag::try_from(dest)
     }
 }

--- a/tss-esapi/src/interface_types/structure_tags.rs
+++ b/tss-esapi/src/interface_types/structure_tags.rs
@@ -83,22 +83,7 @@ impl Marshall for AttestationType {
         let mut buffer = vec![0; Self::BUFFER_SIZE];
         let mut offset = 0;
 
-        ReturnCode::ensure_success(
-            unsafe {
-                crate::tss2_esys::Tss2_MU_TPM2_ST_Marshal(
-                    (*self).into(),
-                    buffer.as_mut_ptr(),
-                    Self::BUFFER_SIZE.try_into().map_err(|e| {
-                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
-                        Error::local_error(WrapperErrorKind::InvalidParam)
-                    })?,
-                    &mut offset,
-                )
-            },
-            |ret| {
-                error!("Failed to marshal AttestationType: {}", ret);
-            },
-        )?;
+        self.marshall_offset(&mut buffer, &mut offset)?;
 
         let checked_offset = usize::try_from(offset).map_err(|e| {
             error!("Failed to parse offset as usize: {}", e);
@@ -108,6 +93,31 @@ impl Marshall for AttestationType {
         buffer.truncate(checked_offset);
 
         Ok(buffer)
+    }
+
+    fn marshall_offset(
+        &self,
+        marshalled_data: &mut [u8],
+        offset: &mut std::os::raw::c_ulong,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2_ST_Marshal(
+                    (*self).into(),
+                    marshalled_data.as_mut_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshal AttestationType: {}", ret);
+            },
+        )?;
+
+        Ok(())
     }
 }
 
@@ -195,22 +205,7 @@ impl Marshall for CommandTag {
         let mut buffer = vec![0; Self::BUFFER_SIZE];
         let mut offset = 0;
 
-        ReturnCode::ensure_success(
-            unsafe {
-                crate::tss2_esys::Tss2_MU_TPM2_ST_Marshal(
-                    (*self).into(),
-                    buffer.as_mut_ptr(),
-                    Self::BUFFER_SIZE.try_into().map_err(|e| {
-                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
-                        Error::local_error(WrapperErrorKind::InvalidParam)
-                    })?,
-                    &mut offset,
-                )
-            },
-            |ret| {
-                error!("Failed to marshal CommandTag: {}", ret);
-            },
-        )?;
+        self.marshall_offset(&mut buffer, &mut offset)?;
 
         let checked_offset = usize::try_from(offset).map_err(|e| {
             error!("Failed to parse offset as usize: {}", e);
@@ -220,6 +215,31 @@ impl Marshall for CommandTag {
         buffer.truncate(checked_offset);
 
         Ok(buffer)
+    }
+
+    fn marshall_offset(
+        &self,
+        marshalled_data: &mut [u8],
+        offset: &mut std::os::raw::c_ulong,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_TPM2_ST_Marshal(
+                    (*self).into(),
+                    marshalled_data.as_mut_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshal CommandTag: {}", ret);
+            },
+        )?;
+
+        Ok(())
     }
 }
 

--- a/tss-esapi/src/interface_types/structure_tags.rs
+++ b/tss-esapi/src/interface_types/structure_tags.rs
@@ -78,23 +78,6 @@ impl TryFrom<TPMI_ST_ATTEST> for AttestationType {
 impl Marshall for AttestationType {
     const BUFFER_SIZE: usize = std::mem::size_of::<TPMI_ST_ATTEST>();
 
-    /// Produce a marshalled [`TPMI_ST_ATTEST`]
-    fn marshall(&self) -> Result<Vec<u8>> {
-        let mut buffer = vec![0; Self::BUFFER_SIZE];
-        let mut offset = 0;
-
-        self.marshall_offset(&mut buffer, &mut offset)?;
-
-        let checked_offset = usize::try_from(offset).map_err(|e| {
-            error!("Failed to parse offset as usize: {}", e);
-            Error::local_error(WrapperErrorKind::InvalidParam)
-        })?;
-
-        buffer.truncate(checked_offset);
-
-        Ok(buffer)
-    }
-
     fn marshall_offset(
         &self,
         marshalled_data: &mut [u8],
@@ -122,11 +105,6 @@ impl Marshall for AttestationType {
 }
 
 impl UnMarshall for AttestationType {
-    /// Unmarshall the structure from [`TPMI_ST_ATTEST`]
-    fn unmarshall(marshalled_data: &[u8]) -> Result<Self> {
-        AttestationType::unmarshall_offset(marshalled_data, &mut 0)
-    }
-
     fn unmarshall_offset(
         marshalled_data: &[u8],
         offset: &mut std::os::raw::c_ulong,
@@ -200,23 +178,6 @@ impl TryFrom<TPMI_ST_COMMAND_TAG> for CommandTag {
 impl Marshall for CommandTag {
     const BUFFER_SIZE: usize = std::mem::size_of::<TPMI_ST_COMMAND_TAG>();
 
-    /// Produce a marshalled [`TPMI_ST_COMMAND_TAG`]
-    fn marshall(&self) -> Result<Vec<u8>> {
-        let mut buffer = vec![0; Self::BUFFER_SIZE];
-        let mut offset = 0;
-
-        self.marshall_offset(&mut buffer, &mut offset)?;
-
-        let checked_offset = usize::try_from(offset).map_err(|e| {
-            error!("Failed to parse offset as usize: {}", e);
-            Error::local_error(WrapperErrorKind::InvalidParam)
-        })?;
-
-        buffer.truncate(checked_offset);
-
-        Ok(buffer)
-    }
-
     fn marshall_offset(
         &self,
         marshalled_data: &mut [u8],
@@ -244,11 +205,6 @@ impl Marshall for CommandTag {
 }
 
 impl UnMarshall for CommandTag {
-    /// Unmarshall the structure from [`TPMI_ST_COMMAND_TAG`]
-    fn unmarshall(marshalled_data: &[u8]) -> Result<Self> {
-        CommandTag::unmarshall_offset(marshalled_data, &mut 0)
-    }
-
     fn unmarshall_offset(
         marshalled_data: &[u8],
         offset: &mut std::os::raw::c_ulong,

--- a/tss-esapi/src/traits.rs
+++ b/tss-esapi/src/traits.rs
@@ -1,6 +1,11 @@
+use std::convert::{TryFrom, TryInto};
+
+use log::error;
+use tss_esapi_sys::UINT32;
+
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Result;
+use crate::{Error, Result, ReturnCode, WrapperErrorKind};
 
 /// Trait for types that can be converted into
 /// TPM marshalled data.
@@ -15,4 +20,80 @@ pub trait Marshall: Sized {
 pub trait UnMarshall: Sized {
     /// Creates the type from marshalled data.
     fn unmarshall(marshalled_data: &[u8]) -> Result<Self>;
+
+    /// Creates the type from the marshalled data, and modifies
+    /// the `offset` to point to the first byte in the `marshalled_data`
+    /// buffer which was not used in the conversion.
+    fn unmarshall_offset(
+        _marshalled_data: &[u8],
+        _offset: &mut std::os::raw::c_ulong,
+    ) -> Result<Self> {
+        unimplemented!();
+    }
+}
+
+impl Marshall for u32 {
+    const BUFFER_SIZE: usize = std::mem::size_of::<UINT32>();
+
+    /// Produce a marshalled [UINT32]
+    fn marshall(&self) -> Result<Vec<u8>> {
+        let mut buffer = vec![0; Self::BUFFER_SIZE];
+        let mut offset = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_UINT32_Marshal(
+                    *self,
+                    buffer.as_mut_ptr(),
+                    Self::BUFFER_SIZE.try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    &mut offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshall u32: {}", ret);
+            },
+        )?;
+
+        let checked_offset = usize::try_from(offset).map_err(|e| {
+            error!("Failed to parse offset as usize: {}", e);
+            Error::local_error(WrapperErrorKind::InvalidParam)
+        })?;
+
+        buffer.truncate(checked_offset);
+
+        Ok(buffer)
+    }
+}
+
+impl UnMarshall for u32 {
+    fn unmarshall(marshalled_data: &[u8]) -> Result<Self> {
+        u32::unmarshall_offset(marshalled_data, &mut 0)
+    }
+
+    fn unmarshall_offset(
+        marshalled_data: &[u8],
+        offset: &mut std::os::raw::c_ulong,
+    ) -> Result<Self> {
+        let mut dest = 0_u32;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_UINT32_Unmarshal(
+                    marshalled_data.as_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert length of marshalled data: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    offset,
+                    &mut dest,
+                )
+            },
+            |ret| error!("Failed to unmarshal SensitiveCreate: {}", ret),
+        )?;
+
+        Ok(dest)
+    }
 }

--- a/tss-esapi/src/traits.rs
+++ b/tss-esapi/src/traits.rs
@@ -13,6 +13,17 @@ pub trait Marshall: Sized {
     const BUFFER_SIZE: usize;
     /// Returns the type in the form of marshalled data
     fn marshall(&self) -> Result<Vec<u8>>;
+
+    /// Writes the type in the form of marshalled data to `marshalled_data`,
+    /// and modifies the `offset` to point to the first byte in the buffer
+    /// which was not written in the conversion.
+    fn marshall_offset(
+        &self,
+        _marshalled_data: &mut [u8],
+        _offset: &mut std::os::raw::c_ulong,
+    ) -> Result<()> {
+        unimplemented!();
+    }
 }
 
 /// Trait for types that can be created from
@@ -40,22 +51,7 @@ impl Marshall for u32 {
         let mut buffer = vec![0; Self::BUFFER_SIZE];
         let mut offset = 0;
 
-        ReturnCode::ensure_success(
-            unsafe {
-                crate::tss2_esys::Tss2_MU_UINT32_Marshal(
-                    *self,
-                    buffer.as_mut_ptr(),
-                    Self::BUFFER_SIZE.try_into().map_err(|e| {
-                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
-                        Error::local_error(WrapperErrorKind::InvalidParam)
-                    })?,
-                    &mut offset,
-                )
-            },
-            |ret| {
-                error!("Failed to marshall u32: {}", ret);
-            },
-        )?;
+        self.marshall_offset(&mut buffer, &mut offset)?;
 
         let checked_offset = usize::try_from(offset).map_err(|e| {
             error!("Failed to parse offset as usize: {}", e);
@@ -65,6 +61,31 @@ impl Marshall for u32 {
         buffer.truncate(checked_offset);
 
         Ok(buffer)
+    }
+
+    fn marshall_offset(
+        &self,
+        marshalled_data: &mut [u8],
+        offset: &mut std::os::raw::c_ulong,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                crate::tss2_esys::Tss2_MU_UINT32_Marshal(
+                    *self,
+                    marshalled_data.as_mut_ptr(),
+                    marshalled_data.len().try_into().map_err(|e| {
+                        error!("Failed to convert size of buffer to TSS size_t type: {}", e);
+                        Error::local_error(WrapperErrorKind::InvalidParam)
+                    })?,
+                    offset,
+                )
+            },
+            |ret| {
+                error!("Failed to marshall u32: {}", ret);
+            },
+        )?;
+
+        Ok(())
     }
 }
 

--- a/tss-esapi/tests/integration_tests/common/marshall.rs
+++ b/tss-esapi/tests/integration_tests/common/marshall.rs
@@ -9,3 +9,22 @@ pub fn check_marshall_unmarshall<T: Marshall + UnMarshall + Eq + std::fmt::Debug
 
     assert_eq!(val, &unmarshalled);
 }
+
+pub fn check_marshall_unmarshall_offset<T: Marshall + UnMarshall + Eq + std::fmt::Debug>(val: &T) {
+    let mut buf = val.marshall().expect("Failed to marshall value");
+    let len = buf.len();
+    let mut offset = 0;
+
+    buf.append(&mut buf.clone());
+    buf.append(&mut vec![0xff; 256]);
+
+    let unmarshalled_one =
+        T::unmarshall_offset(&buf, &mut offset).expect("Failed to unmarshall first copy");
+    assert_eq!(offset, len as u64);
+    assert_eq!(val, &unmarshalled_one);
+
+    let unmarshalled_two =
+        T::unmarshall_offset(&buf, &mut offset).expect("Failed to unmarshall second copy");
+    assert_eq!(offset, (len * 2) as u64);
+    assert_eq!(val, &unmarshalled_two);
+}

--- a/tss-esapi/tests/integration_tests/common/marshall.rs
+++ b/tss-esapi/tests/integration_tests/common/marshall.rs
@@ -11,20 +11,28 @@ pub fn check_marshall_unmarshall<T: Marshall + UnMarshall + Eq + std::fmt::Debug
 }
 
 pub fn check_marshall_unmarshall_offset<T: Marshall + UnMarshall + Eq + std::fmt::Debug>(val: &T) {
-    let mut buf = val.marshall().expect("Failed to marshall value");
+    let buf = val.marshall().expect("Failed to marshall value");
     let len = buf.len();
+
+    let mut buf = vec![0xff; 1024];
     let mut offset = 0;
 
-    buf.append(&mut buf.clone());
-    buf.append(&mut vec![0xff; 256]);
+    val.marshall_offset(&mut buf, &mut offset)
+        .expect("Failed first marshall_offset");
+    assert_eq!(offset, len as u64);
 
+    val.marshall_offset(&mut buf, &mut offset)
+        .expect("Failed second marshall_offset");
+    assert_eq!(offset, (len * 2) as u64);
+
+    offset = 0;
     let unmarshalled_one =
-        T::unmarshall_offset(&buf, &mut offset).expect("Failed to unmarshall first copy");
+        T::unmarshall_offset(&buf, &mut offset).expect("Failed to unmarshall_offset first copy");
     assert_eq!(offset, len as u64);
     assert_eq!(val, &unmarshalled_one);
 
     let unmarshalled_two =
-        T::unmarshall_offset(&buf, &mut offset).expect("Failed to unmarshall second copy");
+        T::unmarshall_offset(&buf, &mut offset).expect("Failed to unmarshall_offset second copy");
     assert_eq!(offset, (len * 2) as u64);
     assert_eq!(val, &unmarshalled_two);
 }

--- a/tss-esapi/tests/integration_tests/constants_tests/command_code_tests.rs
+++ b/tss-esapi/tests/integration_tests/constants_tests/command_code_tests.rs
@@ -218,3 +218,10 @@ fn test_invalid_conversions() {
         "A value representing a non existing command code did not produce the expected error"
     );
 }
+
+#[test]
+fn test_marshall_unmarshall() {
+    let cc = CommandCode::EvictControl;
+    crate::common::check_marshall_unmarshall(&cc);
+    crate::common::check_marshall_unmarshall_offset(&cc);
+}

--- a/tss-esapi/tests/integration_tests/interface_types_tests/structure_tags_tests.rs
+++ b/tss-esapi/tests/integration_tests/interface_types_tests/structure_tags_tests.rs
@@ -22,6 +22,27 @@ macro_rules! test_valid_conversions {
             stringify!($strucutre_tag_item),
         );
     };
+
+    (CommandTag::$attestation_type_item:ident, StructureTag::$strucutre_tag_item:ident) => {
+        assert_eq!(
+            CommandTag::$attestation_type_item,
+            CommandTag::try_from(StructureTag::$strucutre_tag_item).expect(&format!(
+                "Could not convert StructureTag {}",
+                stringify!($attestation_type_item)
+            )),
+            "StructureTag {} did not convert to the correct CommandTag {}",
+            stringify!($strucutre_tag_item),
+            stringify!($attestation_type_item),
+        );
+
+        assert_eq!(
+            StructureTag::$strucutre_tag_item,
+            StructureTag::from(CommandTag::$attestation_type_item),
+            "CommandTag {} did not convert to the correct StructureTag {}",
+            stringify!($attestation_type_item),
+            stringify!($strucutre_tag_item),
+        );
+    };
 }
 
 mod attestation_type_tests {
@@ -56,5 +77,42 @@ mod attestation_type_tests {
             AttestationType::try_from(StructureTag::FuManifest),
             "Expected an error when converting StructureTag FuManifest into AttestationType",
         )
+    }
+
+    #[test]
+    fn test_marshall_unmarshall() {
+        let val = AttestationType::SessionAudit;
+        crate::common::check_marshall_unmarshall(&val);
+        crate::common::check_marshall_unmarshall_offset(&val);
+    }
+}
+
+mod command_tag_tests {
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        constants::StructureTag, interface_types::structure_tags::CommandTag, Error,
+        WrapperErrorKind,
+    };
+
+    #[test]
+    fn test_conversions() {
+        test_valid_conversions!(CommandTag::Sessions, StructureTag::Sessions);
+        test_valid_conversions!(CommandTag::NoSessions, StructureTag::NoSessions);
+    }
+
+    #[test]
+    fn test_invalid_conversions() {
+        assert_eq!(
+            Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+            CommandTag::try_from(StructureTag::FuManifest),
+            "Expected an error when converting StructureTag FuManifest into CommandTag",
+        )
+    }
+
+    #[test]
+    fn test_marshall_unmarshall() {
+        let val = CommandTag::Sessions;
+        crate::common::check_marshall_unmarshall(&val);
+        crate::common::check_marshall_unmarshall_offset(&val);
     }
 }

--- a/tss-esapi/tests/integration_tests/main.rs
+++ b/tss-esapi/tests/integration_tests/main.rs
@@ -15,4 +15,5 @@ mod handles_tests;
 mod interface_types_tests;
 mod structures_tests;
 mod tcti_ldr_tests;
+mod traits;
 mod utils_tests;

--- a/tss-esapi/tests/integration_tests/traits.rs
+++ b/tss-esapi/tests/integration_tests/traits.rs
@@ -1,0 +1,9 @@
+// Copyright 2023 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test]
+fn test_u32_marshall_unmarshall() {
+    let val = 0xdeadbeef_u32;
+    crate::common::check_marshall_unmarshall(&val);
+    crate::common::check_marshall_unmarshall_offset(&val);
+}


### PR DESCRIPTION
Hi all,

This PR contains two commits:

* first one adds another method to the UnMarshall trait to allow it to unmarshall from the buffer at a given offset, and return the post-unmarshalling offset back; it also adds Marshall/UnMarshall for CommandCode and u32
* second one adds CommandTag as another StructureTag, as well as Marshall/UnMarshall for this new enum, and for the AttestationType enum

Obviously, also adding tests for the new stuff. The plan is to modify the remaining UnMarshall implementations to use unmarshall_offset as the "base" implementation, and unmarshall to just use that underneath.

Let me know if you'd like me to split out the 2nd commit - I've put them together in one PR since the 2nd depends on the 1st.