### PR TITLE
Fix codespell action

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,target,Cargo.lock
+ignore-words-list = crate,keypair,daa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,14 @@ on: [push, pull_request]
 
 jobs:
   # Use the following command to fix words locally:
-  # codespell --ignore-words-list "crate,daa,keypair" --skip "*/target,*-sys" --write-changes
+  # codespell --write-changes
   check-spelling:
     name: Check spelling
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Check spelling
-        uses: codespell-project/actions-codespell@master
-        with:
-          ignore_words_list: "crate,daa,keypair"
-          path: tss-esapi
-          skip: "*/target,*-sys"
+        uses: codespell-project/actions-codespell@v1
 
   formatting:
     name: Check formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@
 
 **Fixed bugs:**
 
-- PcrSlot wont compile if TPM2\_PCR\_SELECT\_MAX != 4 [\#310](https://github.com/parallaxsecond/rust-tss-esapi/issues/310)
+- PcrSlot won't compile if TPM2\_PCR\_SELECT\_MAX != 4 [\#310](https://github.com/parallaxsecond/rust-tss-esapi/issues/310)
 - Build failure for tss-esapi 6.1.0 with zeroize\_derive 1.2.0 [\#260](https://github.com/parallaxsecond/rust-tss-esapi/issues/260)
 - Investigate if context methods are using incorrect types. [\#186](https://github.com/parallaxsecond/rust-tss-esapi/issues/186)
 - Change default RSA exponent to 0 [\#292](https://github.com/parallaxsecond/rust-tss-esapi/pull/292) ([ionut-arm](https://github.com/ionut-arm))
@@ -128,7 +128,7 @@
 **Merged pull requests:**
 
 - Prepare 7.0.0-beta.1 release [\#320](https://github.com/parallaxsecond/rust-tss-esapi/pull/320) ([ionut-arm](https://github.com/ionut-arm))
-- Updates depedencies [\#318](https://github.com/parallaxsecond/rust-tss-esapi/pull/318) ([Superhepper](https://github.com/Superhepper))
+- Updates dependencies [\#318](https://github.com/parallaxsecond/rust-tss-esapi/pull/318) ([Superhepper](https://github.com/Superhepper))
 - Fixes some pcr issues. [\#317](https://github.com/parallaxsecond/rust-tss-esapi/pull/317) ([Superhepper](https://github.com/Superhepper))
 - Creates native type for TPML\_CCA [\#315](https://github.com/parallaxsecond/rust-tss-esapi/pull/315) ([Superhepper](https://github.com/Superhepper))
 - Make the crate compatible with 1.53 toolchain [\#314](https://github.com/parallaxsecond/rust-tss-esapi/pull/314) ([ionut-arm](https://github.com/ionut-arm))
@@ -145,7 +145,7 @@
 - Added SignatureScheme type. [\#286](https://github.com/parallaxsecond/rust-tss-esapi/pull/286) ([Superhepper](https://github.com/Superhepper))
 - Make Name wrap the raw type directly [\#280](https://github.com/parallaxsecond/rust-tss-esapi/pull/280) ([wiktor-k](https://github.com/wiktor-k))
 - Add `policy_duplication_select` to Context [\#278](https://github.com/parallaxsecond/rust-tss-esapi/pull/278) ([wiktor-k](https://github.com/wiktor-k))
-- Added auth\_policy method to ther Public structure. [\#274](https://github.com/parallaxsecond/rust-tss-esapi/pull/274) ([Superhepper](https://github.com/Superhepper))
+- Added auth\_policy method to the Public structure. [\#274](https://github.com/parallaxsecond/rust-tss-esapi/pull/274) ([Superhepper](https://github.com/Superhepper))
 - Improved tests and naming for CapabilityType [\#273](https://github.com/parallaxsecond/rust-tss-esapi/pull/273) ([Superhepper](https://github.com/Superhepper))
 - Fix a typo in "bitfield" [\#272](https://github.com/parallaxsecond/rust-tss-esapi/pull/272) ([wiktor-k](https://github.com/wiktor-k))
 - Fix builders when using Null symmetric \(and a couple of small fixes\) [\#271](https://github.com/parallaxsecond/rust-tss-esapi/pull/271) ([wiktor-k](https://github.com/wiktor-k))

--- a/tss-esapi-sys/README.md
+++ b/tss-esapi-sys/README.md
@@ -28,7 +28,7 @@ case:
 $ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ```
 
-The FFI bindings presented by this crate can be either those commited in the
+The FFI bindings presented by this crate can be either those committed in the
 crate under `src/bindings` or generated on the fly from the library headers
 found on the system, at build time. For generating the bindings at build time
 please enable the `generate-bindings` feature, as it is not enabled by default.

--- a/tss-esapi/src/attributes/command_code.rs
+++ b/tss-esapi/src/attributes/command_code.rs
@@ -50,7 +50,7 @@ impl TryFrom<TPMA_CC> for CommandCodeAttributes {
         let command_code_attributes = CommandCodeAttributes(tpma_cc);
         if command_code_attributes.reserved() != 0 || command_code_attributes.res() != 0 {
             error!(
-                "Command code attributes from the TPM contained a non zero value in a resrved area"
+                "Command code attributes from the TPM contained a non zero value in a reserved area"
             );
             return Err(Error::local_error(WrapperErrorKind::InvalidParam));
         }

--- a/tss-esapi/src/constants/tss.rs
+++ b/tss-esapi/src/constants/tss.rs
@@ -652,7 +652,7 @@ pub use crate::tss2_esys::TSS2_BASE_RC_BAD_SIZE; /* If size of a parameter is in
 pub use crate::tss2_esys::TSS2_BASE_RC_BAD_TCTI_STRUCTURE; /* TCTI context is bad. */
 pub use crate::tss2_esys::TSS2_BASE_RC_BAD_TR; /* Invalid ESYS_TR handle */
 pub use crate::tss2_esys::TSS2_BASE_RC_BAD_VALUE; /* A parameter has a bad value */
-pub use crate::tss2_esys::TSS2_BASE_RC_GENERAL_FAILURE; /* Catch all for all errors not otherwise specifed */
+pub use crate::tss2_esys::TSS2_BASE_RC_GENERAL_FAILURE; /* Catch all for all errors not otherwise specified */
 pub use crate::tss2_esys::TSS2_BASE_RC_INCOMPATIBLE_TCTI; /* Unknown or unusable TCTI version */
 pub use crate::tss2_esys::TSS2_BASE_RC_INSUFFICIENT_BUFFER; /* A buffer isn't large enough */
 pub use crate::tss2_esys::TSS2_BASE_RC_INSUFFICIENT_CONTEXT; /* Context not large enough */

--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -457,7 +457,7 @@ impl Drop for Context {
             }
         }
 
-        // Check if all handles have been cleaned up proeprly.
+        // Check if all handles have been cleaned up properly.
         if self.handle_manager.has_open_handles() {
             error!("Not all handles have had their resources successfully released");
         }

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -217,7 +217,7 @@ impl Context {
     /// #                               handle,
     /// #                               tss_esapi::interface_types::dynamic_handles::Persistent::Persistent(persistent_tpm_handle),
     /// #                           )
-    /// #                           .expect("Failed to evict persitent handle")
+    /// #                           .expect("Failed to evict persistent handle")
     /// #                 });
     /// #                 break;
     /// #             }
@@ -281,7 +281,7 @@ impl Context {
     /// #     ctx.tr_from_tpm_public(TpmHandle::Persistent(persistent_tpm_handle))
     /// #         .expect("Failed to load the persistent handle")
     /// # });
-    /// # // Evict the persitent handle from the tpm
+    /// # // Evict the persistent handle from the tpm
     /// # let _ = context.execute_with_session(Some(AuthSession::Password), |ctx| {
     /// #   ctx
     /// #       .evict_control(Provision::Owner, retireved_persistent_handle, persistent)
@@ -336,7 +336,7 @@ impl Context {
     /// #                               handle,
     /// #                               tss_esapi::interface_types::dynamic_handles::Persistent::Persistent(persistent_tpm_handle),
     /// #                           )
-    /// #                           .expect("Failed to evict persitent handle")
+    /// #                           .expect("Failed to evict persistent handle")
     /// #                 });
     /// #                 break;
     /// #             }
@@ -400,7 +400,7 @@ impl Context {
     /// #     ctx.tr_from_tpm_public(TpmHandle::Persistent(persistent_tpm_handle))
     /// #         .expect("Failed to load the persistent handle")
     /// # });
-    /// // Evict the persitent handle from the tpm
+    /// // Evict the persistent handle from the tpm
     /// // An authorization session is required!
     /// let _ = context.execute_with_session(Some(AuthSession::Password), |ctx| {
     ///     ctx

--- a/tss-esapi/src/error/return_code/tpm/format_one.rs
+++ b/tss-esapi/src/error/return_code/tpm/format_one.rs
@@ -98,7 +98,7 @@ impl std::fmt::Display for TpmFormatOneResponseCode {
 
 bitfield! {
     /// A struct representing the format one
-    /// TPM retrun code.
+    /// TPM return code.
     #[derive(PartialEq, Copy, Clone)]
     struct TpmFormatOneResponseCodeStructure(u16);
     impl Debug;

--- a/tss-esapi/src/error/return_code/tpm/format_one/argument_number.rs
+++ b/tss-esapi/src/error/return_code/tpm/format_one/argument_number.rs
@@ -26,24 +26,24 @@ impl From<u8> for ArgumentNumber {
 
 impl From<ArgumentNumber> for u8 {
     fn from(argument_number: ArgumentNumber) -> u8 {
-        let mut strucuture = ArgumentNumberStructure(0);
+        let mut structure = ArgumentNumberStructure(0);
         match argument_number {
             ArgumentNumber::Parameter(number) => {
-                strucuture.set_is_parameter(true);
-                strucuture.set_parameter_number(number);
+                structure.set_is_parameter(true);
+                structure.set_parameter_number(number);
             }
             ArgumentNumber::Session(number) => {
-                strucuture.set_is_parameter(false);
-                strucuture.set_is_session(true);
-                strucuture.set_session_number(number);
+                structure.set_is_parameter(false);
+                structure.set_is_session(true);
+                structure.set_session_number(number);
             }
             ArgumentNumber::Handle(number) => {
-                strucuture.set_is_parameter(false);
-                strucuture.set_is_session(false);
-                strucuture.set_handle_number(number);
+                structure.set_is_parameter(false);
+                structure.set_is_session(false);
+                structure.set_handle_number(number);
             }
         }
-        strucuture.0
+        structure.0
     }
 }
 
@@ -65,7 +65,7 @@ impl std::fmt::Display for ArgumentNumber {
 
 bitfield! {
     /// A struct representing the the argument in format one
-    /// TPM retrun code.
+    /// TPM return code.
     #[derive(PartialEq, Copy, Clone)]
     struct ArgumentNumberStructure(u8);
     impl Debug;

--- a/tss-esapi/src/structures/lists/command_code_attributes.rs
+++ b/tss-esapi/src/structures/lists/command_code_attributes.rs
@@ -11,7 +11,7 @@ use std::{convert::TryFrom, iter::IntoIterator, ops::Deref};
 /// A structure holding a list of command code attributes.
 ///
 /// # Details
-/// This corresponds to the TPML_CCA strucutre.
+/// This corresponds to the TPML_CCA structure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandCodeAttributesList {
     command_code_attributes: Vec<CommandCodeAttributes>,

--- a/tss-esapi/src/structures/lists/tagged_tpm_property.rs
+++ b/tss-esapi/src/structures/lists/tagged_tpm_property.rs
@@ -13,7 +13,7 @@ use std::{convert::TryFrom, iter::IntoIterator, ops::Deref};
 /// A structure holding a list of tagged tpm properties.
 ///
 /// # Details
-/// This corresponds to the TPML_TAGGED_TPM_PROPERTY strucutre.
+/// This corresponds to the TPML_TAGGED_TPM_PROPERTY structure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaggedTpmPropertyList {
     tagged_tpm_properties: Vec<TaggedProperty>,

--- a/tss-esapi/src/structures/property/algorithm_property.rs
+++ b/tss-esapi/src/structures/property/algorithm_property.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use std::convert::{TryFrom, TryInto};
 
-/// Strucutre for holding information describing an
+/// Structure for holding information describing an
 /// algorithm.
 ///
 /// # Details

--- a/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
@@ -301,7 +301,7 @@ fn two_signatures_different_digest() {
             panic!("Unexpected signature for signature 2");
         }
     } else {
-        panic!("Unexpected singature for signature 1");
+        panic!("Unexpected signature for signature 1");
     }
 }
 

--- a/tss-esapi/tests/integration_tests/attributes_tests/command_code_attributes_tests.rs
+++ b/tss-esapi/tests/integration_tests/attributes_tests/command_code_attributes_tests.rs
@@ -187,7 +187,7 @@ fn test_invalid_conversions_non_vendor_specific_invalid_command_index() {
     assert_eq!(
         Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
         CommandCodeAttributes::try_from(invalid_tpma_cc),
-        "Converting TPMA_CC witrh invalid command code index into CommandCodeAttributes did no produce the expected error"
+        "Converting TPMA_CC with invalid command code index into CommandCodeAttributes did no produce the expected error"
     );
 }
 
@@ -261,7 +261,7 @@ fn test_builder() {
         .with_c_handles(expected.c_handles())
         .with_r_handle(expected.r_handle())
         .build()
-        .expect("Failed to buiild command code attributes");
+        .expect("Failed to build command code attributes");
 
     assert_eq!(
         expected.command_index(),

--- a/tss-esapi/tests/integration_tests/attributes_tests/session_attributes_tests.rs
+++ b/tss-esapi/tests/integration_tests/attributes_tests/session_attributes_tests.rs
@@ -111,10 +111,10 @@ fn test_valid_session_attributes_conversions() {
 fn test_invalid_session_attributes_conversions() {
     test_conversion_with_reserved_bits_set!(1u8
         .checked_shl(3)
-        .expect("Failed to create value with resrved bit 3 set"));
+        .expect("Failed to create value with reserved bit 3 set"));
     test_conversion_with_reserved_bits_set!(1u8
         .checked_shl(4)
-        .expect("Failed to create value with resrved bit 4 set"));
+        .expect("Failed to create value with reserved bit 4 set"));
 }
 
 #[test]
@@ -155,10 +155,10 @@ fn test_valid_session_attributes_mask_conversions() {
 fn test_invalid_session_attributes_mask_conversions() {
     test_mask_conversion_with_reserved_bits_set!(1u8
         .checked_shl(3)
-        .expect("Failed to create value with resrved bit 3 set"));
+        .expect("Failed to create value with reserved bit 3 set"));
     test_mask_conversion_with_reserved_bits_set!(1u8
         .checked_shl(4)
-        .expect("Failed to create value with resrved bit 4 set"));
+        .expect("Failed to create value with reserved bit 4 set"));
 }
 
 #[test]

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
@@ -221,7 +221,7 @@ mod test_evict_control {
         // Create persistent TPM handle with
         let persistent_tpm_handle =
             PersistentTpmHandle::new(u32::from_be_bytes([0x81, 0x00, 0x00, 0x01]))
-                .expect("Failed to create persitent tpm handle");
+                .expect("Failed to create persistent tpm handle");
         // Create interface type Persistent by using the handle.
         let persistent = Persistent::Persistent(persistent_tpm_handle);
 
@@ -272,7 +272,7 @@ mod test_evict_control {
                 .expect("Failed to load the persistent handle")
         });
 
-        // Evict the persitent handle from the tpm
+        // Evict the persistent handle from the tpm
         context
             .evict_control(Provision::Owner, retrieved_persistent_handle, persistent)
             .expect("Failed to evict persistent handle");

--- a/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/tpm_format_one_error_tests.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/return_code_tests/tpm_tests/tpm_format_one_error_tests.rs
@@ -69,7 +69,7 @@ macro_rules! test_valid_conversion {
             assert_eq!(
                 expected_tpm_format_one_error_rc,
                 actual_tpm_format_one_error_rc,
-                "{} associted with {} nr {} did not convert into the expected TpmFormatOneResponseCode",
+                "{} associated with {} nr {} did not convert into the expected TpmFormatOneResponseCode",
                 std::stringify!($tpm_error_rc),
                 std::stringify!($argument_number_item),
                 std::stringify!($argument_number_value),

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/algorithm_property_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/algorithm_property_list_tests.rs
@@ -43,7 +43,7 @@ fn test_conversions() {
         .for_each(|((expected_aid, expected_aa), ap)| {
             assert_eq!(
                 expected_aid, &ap.algorithm_identifier(),
-                "An AlgorithmProperty in the AlgorithmPropertyList converted from TPML_ALG_PROPERTY did not contain the expected algorithm identifer"
+                "An AlgorithmProperty in the AlgorithmPropertyList converted from TPML_ALG_PROPERTY did not contain the expected algorithm identifier"
             );
             assert_eq!(
                 expected_aa, &ap.algorithm_properties(),
@@ -94,7 +94,7 @@ fn test_valid_conversion_vector() {
         .for_each(|((expected_aid, expected_aa), ap)| {
             assert_eq!(
                 expected_aid, &ap.algorithm_identifier(),
-                "An AlgorithmProperty in the Vec<AlgorithmProperty> converted from AlgorithmPropertyList did not contain the expected algorithm identifer"
+                "An AlgorithmProperty in the Vec<AlgorithmProperty> converted from AlgorithmPropertyList did not contain the expected algorithm identifier"
             );
             assert_eq!(
                 expected_aa, &ap.algorithm_properties(),

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/command_code_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/command_code_list_tests.rs
@@ -57,7 +57,7 @@ fn test_conversions() {
             assert_eq!(
                 TPM2_CC::from(*expected),
                 *actual,
-                "Command code missmatch between command codes in CommandCodeList and converted CommandCodeList"
+                "Command code mismatch between command codes in CommandCodeList and converted CommandCodeList"
             )
         });
 


### PR DESCRIPTION
Previously the action did not checkout the repository and as such actually didn't do what it was supposed to.

This patch fixes all typos that accumulated over the time. Adds the checkout action and fixes the codespell version action to `v1`.

Additionally codespell settings have been moved to a file so that the `codespell` command line can be executed locally using the same settings as in the CI.