### PR TITLE
Implement `AsRef<[u8]>` for all buffer types

### DIFF
--- a/tss-esapi/src/interface_types/algorithm.rs
+++ b/tss-esapi/src/interface_types/algorithm.rs
@@ -292,8 +292,8 @@ impl TryFrom<TPMI_ALG_SYM_MODE> for SymmetricMode {
 /// Enum representing the asymmetric algorithm interface type.
 ///
 /// # Details
-/// Use [AsymmetricAlgorithmSelection] instead where possible.
-/// This corresponds to TPMI_ALG_ASYM.
+/// Use [crate::abstraction::AsymmetricAlgorithmSelection] instead where possible.
+/// This corresponds to `TPMI_ALG_ASYM`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum AsymmetricAlgorithm {
     Rsa,

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -44,6 +44,12 @@ macro_rules! named_field_buffer_type {
             }
         }
 
+        impl AsRef<[u8]> for $native_type {
+            fn as_ref(&self) -> &[u8] {
+                self.as_bytes()
+            }
+        }
+
         impl Deref for $native_type {
             type Target = Vec<u8>;
             fn deref(&self) -> &Self::Target {

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/max_buffer_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/max_buffer_tests.rs
@@ -47,4 +47,17 @@ mod test_auth {
             assert_eq!(expected, actual);
         }
     }
+
+    #[test]
+    fn test_as_ref() {
+        // The following function accepts the broadest selection of types as its argument
+        // including MaxBuffer. It also returns the MaxBuffer but in such a way that the
+        // client is not aware of the true underlying type.
+        fn accepts_returns_as_ref(data: impl AsRef<[u8]>) -> tss_esapi::Result<impl AsRef<[u8]>> {
+            let data = data.as_ref();
+            let max_buffer = MaxBuffer::from_bytes(data)?;
+            Ok(max_buffer)
+        }
+        accepts_returns_as_ref(MaxBuffer::from_bytes(&[1, 2, 3]).unwrap()).unwrap();
+    }
 }


### PR DESCRIPTION
This allows using type generated by `named_field_buffer_type` macro in all places where `AsRef<[u8]>` arguments are accepted and also returning them via `impl` return types which hide the underlying implementation type.