### PR TITLE
Move MSRV to 1.60.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu
       - name: Run the container
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env RUST_TOOLCHAIN_VERSION=1.57.0 ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env RUST_TOOLCHAIN_VERSION=1.60.0 ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
   # All in one job as I think it is a big overhead to build and run the Docker
   # container?
   tests-ubuntu:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ At the moment we test (via CI) and support the following Rust compiler versions:
 
 * On Ubuntu we test with:
     - The latest stable compiler version, as accessible through `rustup`.
-    - The 1.57 compiler version.
+    - The 1.60 compiler version.
 * On Fedora we test with the compiler version included with the Fedora 35 release.
 
 If you need support for other versions of the compiler, get in touch with us to see what we can do!


### PR DESCRIPTION
Our dependency on the `log` crate means that currently the crate does not compile with our MSRV. It makes more sense for us to bump the MSRV and stay aligned with updates of `log`.