### PR TITLE
Fix a typo in variable name in `TpmFormatZeroWarning`

### DIFF
--- a/tss-esapi/src/constants/return_code/tpm/format_zero/warning.rs
+++ b/tss-esapi/src/constants/return_code/tpm/format_zero/warning.rs
@@ -70,8 +70,8 @@ impl TryFrom<u8> for TpmFormatZeroWarning {
 }
 
 impl From<TpmFormatZeroWarning> for u8 {
-    fn from(tpm_format_zeror_wraning: TpmFormatZeroWarning) -> u8 {
+    fn from(value: TpmFormatZeroWarning) -> u8 {
         // This is safe because the values are well defined.
-        tpm_format_zeror_wraning.to_u8().unwrap()
+        value.to_u8().unwrap()
     }
 }


### PR DESCRIPTION
The typo standed out so I fixed it and changed to use `value`: the name of the parameter from [`std::convert::From`][FR] documentation.

[FR]: https://doc.rust-lang.org/std/convert/trait.From.html