### PR TITLE
Bump picky- crates

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -27,8 +27,8 @@ regex = "1.3.9"
 zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.4.0" }
 oid = { version = "0.2.1", optional = true }
-picky-asn1 = { version = "0.3.0", optional = true }
-picky-asn1-x509 = { version = "0.6.1", optional = true }
+picky-asn1 = { version = "0.7.2", optional = true }
+picky-asn1-x509 = { version = "0.11.0", optional = true }
 cfg-if = "1.0.0"
 strum = { version = "0.25.0", optional = true }
 strum_macros = { version = "0.25.0", optional = true }

--- a/tss-esapi/src/abstraction/public.rs
+++ b/tss-esapi/src/abstraction/public.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Holds either [`picky_asn1_x509::RsaPublicKey`] for [`crate::structures::Public::Rsa`] or
 /// [`picky_asn1_x509::EcPoint`] for [`crate::structures::Public::Ecc`].
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum DecodedKey {
     RsaPublicKey(RsaPublicKey),
     EcPoint(EcPoint),


### PR DESCRIPTION
A recent fix [1] in the picky-asn1-der crate highlights an issue that could lead to faulty results handed off by the abstractions in the tss-esapi crate. Specifically, mishandling of ASN.1 Integers could result in invalid encodings of various pieces of data such as elliptic curve points.

[1] https://github.com/Devolutions/picky-rs/pull/209/files