### PR TITLE
Fixes lint errors reported by clippy in rust 1.72.

### DIFF
--- a/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
@@ -119,7 +119,7 @@ fn test_pcr_read_all() {
         )
         .expect("Call 3 to pcr_read failed");
 
-    vec![read_pcrs_1, read_pcrs_2, read_pcrs_3]
+    [read_pcrs_1, read_pcrs_2, read_pcrs_3]
         .iter()
         .enumerate()
         .for_each(|(idx, dl)| {

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/algorithm_property_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/algorithm_property_list_tests.rs
@@ -13,7 +13,7 @@ use std::convert::{TryFrom, TryInto};
 
 #[test]
 fn test_conversions() {
-    let expected_algorithm_properties = vec![
+    let expected_algorithm_properties = [
         (AlgorithmIdentifier::Rsa, AlgorithmAttributes(1)),
         (AlgorithmIdentifier::Aes, AlgorithmAttributes(2)),
     ];
@@ -61,7 +61,7 @@ fn test_conversions() {
 
 #[test]
 fn test_valid_conversion_vector() {
-    let expected_algorithm_properties = vec![
+    let expected_algorithm_properties = [
         (AlgorithmIdentifier::Rsa, AlgorithmAttributes(1)),
         (AlgorithmIdentifier::Aes, AlgorithmAttributes(2)),
     ];

--- a/tss-esapi/tests/integration_tests/structures_tests/lists_tests/command_code_list_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/lists_tests/command_code_list_tests.rs
@@ -12,7 +12,7 @@ use std::convert::{TryFrom, TryInto};
 
 #[test]
 fn test_conversions() {
-    let expected_command_codes = vec![
+    let expected_command_codes = [
         CommandCode::ChangeEps,
         CommandCode::ChangePps,
         CommandCode::Clear,
@@ -83,7 +83,7 @@ fn test_conversions() {
 
 #[test]
 fn test_valid_conversion_vector() {
-    let expected_command_codes = vec![
+    let expected_command_codes = [
         CommandCode::ChangeEps,
         CommandCode::ChangePps,
         CommandCode::Clear,


### PR DESCRIPTION
- This fixes a lint error regarding vectors being used instead of arrays that was being reported by clippy in version 1.72 of rust.