### PR TITLE
Implement tr_serialize and tr_deserialize

### DIFF
--- a/tss-esapi/src/ffi.rs
+++ b/tss-esapi/src/ffi.rs
@@ -25,3 +25,8 @@ where
     ffi_data.ffi_data_zeroize();
     owned_ffi_data
 }
+
+pub(crate) fn to_owned_bytes(ffi_bytes_ptr: *mut u8, size: usize) -> Vec<u8> {
+    let ffi_bytes = unsafe { MBox::<[u8]>::from_raw_parts(ffi_bytes_ptr, size) };
+    return Vec::<u8>::from(ffi_bytes.as_ref());
+}


### PR DESCRIPTION
I don't know if the implementation with `buffer.len().try_into().map_err` and `std::slice::from_raw_parts` is the cleanest solution. Please let me know if you have ideas for cleaner solutions.
Regarding the tests, the `new_handle = old_handle + 1`, but I think checking the public part (which includes the public key) is the most relevant test for it.

Edit:
The test with the new context is needed. Currently it works with the old context, but not with a new one.