### PR TITLE
Fix create_ak for ECC keys

### DIFF
--- a/tss-esapi/src/abstraction/ak.rs
+++ b/tss-esapi/src/abstraction/ak.rs
@@ -16,7 +16,7 @@ use crate::{
         session_handles::PolicySession,
     },
     structures::{
-        Auth, CreateKeyResult, EccScheme, KeyDerivationFunctionScheme, Private, Public,
+        Auth, CreateKeyResult, EccPoint, EccScheme, KeyDerivationFunctionScheme, Private, Public,
         PublicBuilder, PublicEccParametersBuilder, PublicKeyRsa, PublicRsaParametersBuilder,
         RsaExponent, RsaScheme, SymmetricDefinitionObject,
     },
@@ -77,12 +77,17 @@ fn create_ak_public<IKC: IntoKeyCustomization>(
                     .with_ecc_scheme(EccScheme::create(
                         EccSchemeAlgorithm::try_from(AlgorithmIdentifier::from(sign_alg))?,
                         Some(hash_alg),
-                        Some(0),
+                        if sign_alg == SignatureSchemeAlgorithm::EcDaa {
+                            Some(0)
+                        } else {
+                            None
+                        },
                     )?)
                     .with_curve(ecc_curve)
                     .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
                     .build()?,
-            ),
+            )
+            .with_ecc_unique_identifier(EccPoint::default()),
     };
 
     let key_builder = if let Some(ref k) = key_customization {

--- a/tss-esapi/tests/integration_tests/abstraction_tests/ak_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/ak_tests.rs
@@ -68,6 +68,28 @@ fn test_create_ak_rsa_ecc() {
 }
 
 #[test]
+fn test_create_ak_ecc_ecc() {
+    let mut context = create_ctx_without_session();
+
+    let ek_ecc = ek::create_ek_object(
+        &mut context,
+        AsymmetricAlgorithmSelection::Ecc(EccCurve::NistP384),
+        None,
+    )
+    .unwrap();
+    ak::create_ak(
+        &mut context,
+        ek_ecc,
+        HashingAlgorithm::Sha256,
+        AsymmetricAlgorithmSelection::Ecc(EccCurve::NistP256),
+        SignatureSchemeAlgorithm::EcDsa,
+        None,
+        None,
+    )
+    .unwrap();
+}
+
+#[test]
 fn test_create_and_use_ak() {
     let mut context = create_ctx_without_session();
 

--- a/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/public_ecc_parameters_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/public_ecc_parameters_tests.rs
@@ -92,3 +92,72 @@ fn test_signing_with_wrong_symmetric() {
         Err(Error::WrapperError(WrapperErrorKind::InconsistentParams))
     ));
 }
+
+#[test]
+fn test_signing_with_mismatched_scheme_nist() {
+    assert_eq!(
+        PublicEccParametersBuilder::new()
+            .with_restricted(false)
+            .with_is_decryption_key(false)
+            .with_is_signing_key(true)
+            .with_curve(EccCurve::NistP256)
+            .with_ecc_scheme(
+                EccScheme::create(
+                    EccSchemeAlgorithm::Sm2,
+                    Some(HashingAlgorithm::Sha256),
+                    None
+                )
+                .unwrap()
+            )
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .with_symmetric(SymmetricDefinitionObject::Null)
+            .build(),
+        Err(Error::WrapperError(WrapperErrorKind::InconsistentParams))
+    );
+}
+
+#[test]
+fn test_signing_with_mismatched_scheme_sm2() {
+    assert_eq!(
+        PublicEccParametersBuilder::new()
+            .with_restricted(false)
+            .with_is_decryption_key(false)
+            .with_is_signing_key(true)
+            .with_curve(EccCurve::Sm2P256)
+            .with_ecc_scheme(
+                EccScheme::create(
+                    EccSchemeAlgorithm::EcDsa,
+                    Some(HashingAlgorithm::Sha256),
+                    None
+                )
+                .unwrap()
+            )
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .with_symmetric(SymmetricDefinitionObject::Null)
+            .build(),
+        Err(Error::WrapperError(WrapperErrorKind::InconsistentParams))
+    );
+}
+
+#[test]
+fn test_signing_with_mismatched_scheme_bn() {
+    assert_eq!(
+        PublicEccParametersBuilder::new()
+            .with_restricted(false)
+            .with_is_decryption_key(false)
+            .with_is_signing_key(true)
+            .with_curve(EccCurve::BnP256)
+            .with_ecc_scheme(
+                EccScheme::create(
+                    EccSchemeAlgorithm::EcDsa,
+                    Some(HashingAlgorithm::Sha256),
+                    None
+                )
+                .unwrap()
+            )
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .with_symmetric(SymmetricDefinitionObject::Null)
+            .build(),
+        Err(Error::WrapperError(WrapperErrorKind::InconsistentParams))
+    );
+}


### PR DESCRIPTION
Fixing the parameters for creating AKs in the Endorsement Hierarchy. The `count` value part of the `EccScheme` has been adjusted, and an empty `EccPoint` was added as unique identifier for the key.