### PR TITLE
Add serde to Public and Private

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = .git,target,Cargo.lock
-ignore-words-list = acsend,crate,keypair,daa
+ignore-words-list = acsend,crate,keypair,daa,de,ser

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -37,6 +37,7 @@ paste = "1.0.14"
 [dev-dependencies]
 env_logger = "0.9.0"
 sha2 = "0.10.1"
+serde_json = "^1.0.108"
 
 [build-dependencies]
 semver = "1.0.7"

--- a/tss-esapi/src/structures/buffers/private.rs
+++ b/tss-esapi/src/structures/buffers/private.rs
@@ -2,8 +2,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::traits::impl_mu_standard;
+use crate::traits::{Marshall, UnMarshall};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tss_esapi_sys::_PRIVATE;
 
 buffer_type!(Private, ::std::mem::size_of::<_PRIVATE>(), TPM2B_PRIVATE);
 
 impl_mu_standard!(Private, TPM2B_PRIVATE);
+
+impl Serialize for Private {
+    /// Serialise the [Private] data into it's bytes representation of the TCG
+    /// TPM2B_PRIVATE structure.
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = self.marshall().map_err(serde::ser::Error::custom)?;
+        serializer.serialize_bytes(&bytes)
+    }
+}
+
+impl<'de> Deserialize<'de> for Private {
+    /// Deserialise the [Private] data from it's bytes representation of the TCG
+    /// TPM2B_PRIVATE structure.
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = <Vec<u8>>::deserialize(deserializer)?;
+        Self::unmarshall(&bytes).map_err(serde::de::Error::custom)
+    }
+}

--- a/tss-esapi/tests/integration_tests/common/mod.rs
+++ b/tss-esapi/tests/integration_tests/common/mod.rs
@@ -32,11 +32,13 @@ use tss_esapi::{
 };
 
 mod marshall;
+mod serde;
 mod tpm2b_types_equality_checks;
 mod tpma_types_equality_checks;
 mod tpml_types_equality_checks;
 mod tpms_types_equality_checks;
 mod tpmt_types_equality_checks;
+pub use self::serde::*;
 pub use marshall::*;
 pub use tpm2b_types_equality_checks::*;
 pub use tpma_types_equality_checks::*;

--- a/tss-esapi/tests/integration_tests/common/serde.rs
+++ b/tss-esapi/tests/integration_tests/common/serde.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use serde::{de::DeserializeOwned, Serialize};
+use tss_esapi::traits::{Marshall, UnMarshall};
+
+pub fn check_serialise_deserialise<
+    T: Serialize + DeserializeOwned + Marshall + UnMarshall + Eq + std::fmt::Debug,
+>(
+    val: &T,
+) {
+    let json = serde_json::to_vec(val).expect("Failed to serialise value");
+
+    let unmarshalled: T = serde_json::from_slice(&json).expect("Failed to deserialise");
+
+    assert_eq!(val, &unmarshalled);
+}

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/private.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/private.rs
@@ -12,6 +12,13 @@ fn marshall_unmarshall() {
 }
 
 #[test]
+fn serialise_deserialise() {
+    crate::common::check_serialise_deserialise(&Private::default());
+    let private = Private::try_from([0xff; 100].to_vec()).unwrap();
+    crate::common::check_serialise_deserialise(&private);
+}
+
+#[test]
 fn marshall_unmarshall_offset() {
     crate::common::check_marshall_unmarshall_offset(&Private::default());
     let private = Private::try_from([0xff; 100].to_vec()).unwrap();

--- a/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/public.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/public.rs
@@ -15,6 +15,13 @@ fn marshall_unmarshall() {
 }
 
 #[test]
+fn serialise_deserialise() {
+    crate::common::publics()
+        .iter()
+        .for_each(crate::common::check_serialise_deserialise);
+}
+
+#[test]
 fn tpm2b_conversion() {
     crate::common::publics().iter().for_each(|public| {
         let public = public.clone();


### PR DESCRIPTION
Add support for serde to Public and Private, going through the current Marshall and Unmarshall pathways. This pattern is quite "simple" so it could be possible to duplicate it to other structures, or macro them for types that implement Marshall and Unmarshall. 