### PR TITLE
Cargo.toml: Specify rust-version=1.66.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ At the moment we test (via CI) and support the following Rust compiler versions:
 * On Ubuntu we test with:
     - The latest stable compiler version, as accessible through `rustup`.
     - The 1.66 compiler version.
-* On Fedora we test with the compiler version included with the Fedora 35 release.
+* On Fedora we test with the compiler version included with the Fedora 36 release.
 
 If you need support for other versions of the compiler, get in touch with us to see what we can do!
 

--- a/tss-esapi-sys/Cargo.toml
+++ b/tss-esapi-sys/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 repository = "https://github.com/parallaxsecond/rust-tss-esapi"
 documentation = "https://docs.rs/crate/tss-esapi-sys"
 links = "tss2-esys"
+rust-version = "1.66.0"
 
 [build-dependencies]
 bindgen = { version = "0.66.1", optional = true }

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["api-bindings", "external-ffi-bindings", "cryptography"]
 license = "Apache-2.0"
 repository = "https://github.com/parallaxsecond/rust-tss-esapi"
 documentation = "https://docs.rs/crate/tss-esapi"
+rust-version = "1.66.0"
 
 [dependencies]
 bitfield = "0.14.0"

--- a/tss-esapi/tests/Dockerfile-fedora
+++ b/tss-esapi/tests/Dockerfile-fedora
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:36
 
 RUN dnf install -y \
 	tpm2-tss-devel tpm2-abrmd tpm2-tools \


### PR DESCRIPTION
Mark MSRV (Minimum Supported Rust Version) as 1.66.0