### PR TITLE
Fixes version in tss-esapi crate on main.

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "7.1.0"
+version = "8.0.0-alpha"
 authors = ["Parsec Project Contributors"]
 edition = "2018"
 description = "Rust-native wrapper around TSS 2.0 Enhanced System API"


### PR DESCRIPTION
- Sets the version of the the tss-esapi crate to 8.0.0-alpha on the main branch in order to avoid confusion.