### PR TITLE
Fixes problem with sign requiring a HashcheckTicket.

### DIFF
--- a/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
+++ b/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
@@ -45,9 +45,10 @@ impl Context {
         key_handle: KeyHandle,
         digest: Digest,
         scheme: SignatureScheme,
-        validation: HashcheckTicket,
+        validation: Option<HashcheckTicket>,
     ) -> Result<Signature> {
         let mut signature_ptr = null_mut();
+        let validation_ticket = validation.unwrap_or_default().try_into()?;
         ReturnCode::ensure_success(
             unsafe {
                 Esys_Sign(
@@ -58,7 +59,7 @@ impl Context {
                     self.optional_session_3(),
                     &digest.into(),
                     &scheme.into(),
-                    &validation.try_into()?,
+                    &validation_ticket,
                     &mut signature_ptr,
                 )
             },

--- a/tss-esapi/src/structures/tickets.rs
+++ b/tss-esapi/src/structures/tickets.rs
@@ -130,11 +130,11 @@ pub struct HashcheckTicket {
 impl Default for HashcheckTicket {
     /// The default for the Hashcheck ticket is the Null ticket.
     fn default() -> Self {
-        return Self {
+        Self {
             tag: StructureTag::Hashcheck,
             hierarchy: Hierarchy::Null,
             digest: Vec::<u8>::new(),
-        };
+        }
     }
 }
 

--- a/tss-esapi/src/structures/tickets.rs
+++ b/tss-esapi/src/structures/tickets.rs
@@ -11,7 +11,10 @@ use crate::{
 };
 
 use log::error;
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    default::Default,
+};
 
 /// Macro used for implementing try_from
 /// TssTicketType -> TicketType
@@ -122,6 +125,17 @@ pub struct HashcheckTicket {
     tag: StructureTag,
     hierarchy: Hierarchy,
     digest: Vec<u8>,
+}
+
+impl Default for HashcheckTicket {
+    /// The default for the Hashcheck ticket is the Null ticket.
+    fn default() -> Self {
+        return Self {
+            tag: StructureTag::Hashcheck,
+            hierarchy: Hierarchy::Null,
+            digest: Vec::<u8>::new(),
+        };
+    }
 }
 
 impl Ticket for HashcheckTicket {

--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -57,13 +57,9 @@ impl TryFrom<TPMS_CONTEXT> for TpmsContext {
             hierarchy: tss2_context.hierarchy,
             context_blob: tss2_context.contextBlob.buffer.to_vec(),
         };
-        context.context_blob.truncate(
-            tss2_context
-                .contextBlob
-                .size
-                .try_into()
-                .map_err(|_| Error::local_error(WrapperErrorKind::WrongParamSize))?,
-        );
+        context
+            .context_blob
+            .truncate(tss2_context.contextBlob.size.into());
         Ok(context)
     }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -530,12 +530,11 @@ mod test_policy_name_hash {
 
 mod test_policy_authorize {
     use crate::common::{create_ctx_with_session, get_pcr_policy_digest, signing_key_pub};
-    use std::convert::{TryFrom, TryInto};
+    use std::convert::TryFrom;
     use tss_esapi::{
-        constants::tss::{TPM2_RH_NULL, TPM2_ST_HASHCHECK},
         interface_types::{algorithm::HashingAlgorithm, resource_handles::Hierarchy},
         structures::{Auth, MaxBuffer, Nonce, SignatureScheme},
-        tss2_esys::{TPM2B_NONCE, TPMT_TK_HASHCHECK},
+        tss2_esys::TPM2B_NONCE,
     };
     #[test]
     fn test_policy_authorize() {
@@ -569,19 +568,9 @@ mod test_policy_authorize {
             .unwrap()
             .0;
 
-        let validation = TPMT_TK_HASHCHECK {
-            tag: TPM2_ST_HASHCHECK,
-            hierarchy: TPM2_RH_NULL,
-            digest: Default::default(),
-        };
         // A signature over just the policy_digest, since the policy_ref is empty
         let signature = context
-            .sign(
-                key_handle,
-                ahash.clone(),
-                SignatureScheme::Null,
-                validation.try_into().unwrap(),
-            )
+            .sign(key_handle, ahash.clone(), SignatureScheme::Null, None)
             .unwrap();
         let tkt = context
             .verify_signature(key_handle, ahash, signature)

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 mod test_verify_signature {
     use crate::common::{create_ctx_with_session, signing_key_pub, HASH};
-    use std::convert::{TryFrom, TryInto};
+    use std::convert::TryFrom;
     use tss_esapi::{
-        constants::tss::{TPM2_RH_NULL, TPM2_ST_HASHCHECK},
         interface_types::{algorithm::HashingAlgorithm, resource_handles::Hierarchy},
         structures::{Auth, Digest, PublicKeyRsa, RsaSignature, Signature, SignatureScheme},
-        tss2_esys::TPMT_TK_HASHCHECK,
     };
 
     #[test]
@@ -28,17 +26,12 @@ mod test_verify_signature {
             .unwrap()
             .key_handle;
 
-        let validation = TPMT_TK_HASHCHECK {
-            tag: TPM2_ST_HASHCHECK,
-            hierarchy: TPM2_RH_NULL,
-            digest: Default::default(),
-        };
         let signature = context
             .sign(
                 key_handle,
                 Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 SignatureScheme::Null,
-                validation.try_into().unwrap(),
+                None,
             )
             .unwrap();
 
@@ -69,17 +62,12 @@ mod test_verify_signature {
             .unwrap()
             .key_handle;
 
-        let validation = TPMT_TK_HASHCHECK {
-            tag: TPM2_ST_HASHCHECK,
-            hierarchy: TPM2_RH_NULL,
-            digest: Default::default(),
-        };
         let mut signature = context
             .sign(
                 key_handle,
                 Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 SignatureScheme::Null,
-                validation.try_into().unwrap(),
+                None,
             )
             .unwrap();
 
@@ -176,12 +164,10 @@ mod test_verify_signature {
 
 mod test_sign {
     use crate::common::{create_ctx_with_session, signing_key_pub, HASH};
-    use std::convert::{TryFrom, TryInto};
+    use std::convert::TryFrom;
     use tss_esapi::{
-        constants::tss::{TPM2_RH_NULL, TPM2_ST_HASHCHECK},
         interface_types::resource_handles::Hierarchy,
         structures::{Auth, Digest, SignatureScheme},
-        tss2_esys::TPMT_TK_HASHCHECK,
     };
 
     #[test]
@@ -202,17 +188,12 @@ mod test_sign {
             .unwrap()
             .key_handle;
 
-        let validation = TPMT_TK_HASHCHECK {
-            tag: TPM2_ST_HASHCHECK,
-            hierarchy: TPM2_RH_NULL,
-            digest: Default::default(),
-        };
         context
             .sign(
                 key_handle,
                 Digest::try_from(HASH[..32].to_vec()).unwrap(),
                 SignatureScheme::Null,
-                validation.try_into().unwrap(),
+                None,
             )
             .unwrap();
     }
@@ -235,17 +216,12 @@ mod test_sign {
             .unwrap()
             .key_handle;
 
-        let validation = TPMT_TK_HASHCHECK {
-            tag: TPM2_ST_HASHCHECK,
-            hierarchy: TPM2_RH_NULL,
-            digest: Default::default(),
-        };
         context
             .sign(
                 key_handle,
                 Digest::try_from(Vec::<u8>::new()).unwrap(),
                 SignatureScheme::Null,
-                validation.try_into().unwrap(),
+                None,
             )
             .unwrap_err();
     }
@@ -268,17 +244,12 @@ mod test_sign {
             .unwrap()
             .key_handle;
 
-        let validation = TPMT_TK_HASHCHECK {
-            tag: TPM2_ST_HASHCHECK,
-            hierarchy: TPM2_RH_NULL,
-            digest: Default::default(),
-        };
         context
             .sign(
                 key_handle,
                 Digest::try_from([0xbb; 40].to_vec()).unwrap(),
                 SignatureScheme::Null,
-                validation.try_into().unwrap(),
+                None,
             )
             .unwrap_err();
     }


### PR DESCRIPTION
- This fixes #475 by making the HashcheckTicket that was previously required in the ```sign``` context method optional instead. If it is ```None``` it is then internally converted into the HashcheckTicket version of the `Null ticket` before being converted to the corresponding TSS type. This has the benefit of removing the need to use the TSS type in order to create a `Null ticket`.