### PR TITLE
Moves Clippy lint checks from tests scripts to a separate job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build the container
         run: docker build -t fedoracontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-fedora
       - name: Run the tests
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi fedoracontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-fedora.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env USE_FROZEN_LOCKFILE=1 fedoracontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-fedora.sh
 
   tests-fedora-rawhide:
     name: Fedora rawhide tests
@@ -96,3 +96,16 @@ jobs:
         run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu
       - name: Check documentation
         run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi -e RUSTDOCFLAGS="-Dwarnings" ubuntucontainer cargo doc --document-private-items --no-deps
+
+  # Check that there are no Clippy lint errors.
+  clippy:
+    name: Check Clippy lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the container
+        run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu  --target tpm2-tss
+      - name: Check Clippy lints MSRV
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env RUST_TOOLCHAIN_VERSION=1.66.0 ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/lint-checks.sh
+      - name: Check Clippy lints latest
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/lint-checks.sh

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ At the moment we test (via CI) and support the following Rust compiler versions:
 * On Ubuntu we test with:
     - The latest stable compiler version, as accessible through `rustup`.
     - The 1.66 compiler version.
-* On Fedora we test with the compiler version included with the Fedora 35 release.
+* On Fedora we test with the compiler version included with the Fedora 36 release.
+* On Fedora rawhide we test with the compiler version included.
 
 If you need support for other versions of the compiler, get in touch with us to see what we can do!
 

--- a/tss-esapi/tests/Dockerfile-fedora
+++ b/tss-esapi/tests/Dockerfile-fedora
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:36
 
 RUN dnf install -y \
 	tpm2-tss-devel tpm2-abrmd tpm2-tools \

--- a/tss-esapi/tests/Dockerfile-ubuntu
+++ b/tss-esapi/tests/Dockerfile-ubuntu
@@ -1,10 +1,15 @@
-FROM ghcr.io/tpm2-software/ubuntu-18.04:latest
+FROM ghcr.io/tpm2-software/ubuntu-18.04:latest AS base
 
+FROM base AS rust-toolchain
+# Install Rust toolchain
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+FROM rust-toolchain AS tpm2-tss
+# Download and install the TSS library
 ARG TPM2_TSS_VERSION=2.4.6
 ENV TPM2_TSS_VERSION=$TPM2_TSS_VERSION
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
-
-# Download and install the TSS library
 RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch $TPM2_TSS_VERSION
 RUN cd tpm2-tss \
 	&& ./bootstrap \
@@ -13,13 +18,10 @@ RUN cd tpm2-tss \
 	&& make install \
 	&& ldconfig
 
+FROM tpm2-tss AS tpm2-tools
 # Download and install TPM2 tools
 RUN git clone https://github.com/tpm2-software/tpm2-tools.git --branch 4.1
 RUN cd tpm2-tools \
 	&& ./bootstrap \
 	&& ./configure --enable-unit \
 	&& make install
-
-# Install Rust toolchain
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"

--- a/tss-esapi/tests/all-fedora.sh
+++ b/tss-esapi/tests/all-fedora.sh
@@ -3,12 +3,19 @@
 # Copyright 2019 Contributors to the Parsec project.
 # SPDX-License-Identifier: Apache-2.0
 
-# This script executes static checks and tests for the tss-esapi crate.
+# This script executes tests for the tss-esapi crate.
 # It can be run inside the container which Dockerfile is in the same folder.
 #
 # Usage: ./tests/all.sh
 
 set -euf -o pipefail
+
+if [[ ! -z ${USE_FROZEN_LOCKFILE:+x} ]]; then
+	# Some versions of Fedora that are used during testing are old
+    # so in order to prevent any drift from the versions available
+    # in the old versions the frozen Cargo lock is used.
+	cp tests/Cargo.lock.frozen ../Cargo.lock
+fi
 
 ############################
 # Run the TPM SWTPM server #
@@ -32,11 +39,6 @@ tpm2-abrmd \
     --allow-root \
     --session \
     --flush-all &
-
-##################
-# Execute clippy #
-##################
-cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::cargo
 
 ###################
 # Build the crate #

--- a/tss-esapi/tests/all-ubuntu.sh
+++ b/tss-esapi/tests/all-ubuntu.sh
@@ -3,7 +3,7 @@
 # Copyright 2019 Contributors to the Parsec project.
 # SPDX-License-Identifier: Apache-2.0
 
-# This script executes static checks and tests for the tss-esapi crate.
+# This script executes tests for the tss-esapi crate.
 # It can be run inside the container which Dockerfile is in the same folder.
 #
 # Usage: ./tests/all.sh
@@ -35,11 +35,6 @@ fi
 tpm_server &
 sleep 5
 tpm2_startup -c -T mssim
-
-##################
-# Execute clippy #
-##################
-cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::cargo
 
 ###################
 # Build the crate #

--- a/tss-esapi/tests/lint-checks.sh
+++ b/tss-esapi/tests/lint-checks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script executes static checks for the tss-esapi crate.
+
+set -euf -o pipefail
+
+#################################################
+# Change rust toolchain version
+#################################################
+if [[ ! -z ${RUST_TOOLCHAIN_VERSION:+x} ]]; then
+	rustup override set ${RUST_TOOLCHAIN_VERSION}
+	# Use the frozen Cargo lock to prevent any drift from MSRV being upgraded
+	# underneath our feet.
+	cp tests/Cargo.lock.frozen ../Cargo.lock
+fi
+
+##################
+# Execute clippy #
+##################
+cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::cargo


### PR DESCRIPTION
This fixes https://github.com/parallaxsecond/rust-tss-esapi/issues/468.