### PR TITLE
ea_commands: add policy_authorize_nv

### DIFF
--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -698,7 +698,7 @@ impl Context {
     ///     NvAuth::Owner,
     ///     nv_index_handle,
     /// ).expect("failed to extend policy with policy_authorize_nv");;
-    ///
+    /// #
     /// # context
     /// #     .nv_undefine_space(Provision::Owner, nv_index_handle)
     /// #     .expect("Call to nv_undefine_space failed");

--- a/tss-esapi/tests/integration_tests/common/mod.rs
+++ b/tss-esapi/tests/integration_tests/common/mod.rs
@@ -435,7 +435,6 @@ pub fn create_public_sealed_object() -> Public {
         .expect("Failed to create public structure.")
 }
 
-#[allow(dead_code)]
 pub fn write_nv_index(context: &mut Context, nv_index: NvIndexTpmHandle) -> NvIndexHandle {
     // Create owner nv public.
     let owner_nv_index_attributes = NvIndexAttributesBuilder::new()

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -930,7 +930,7 @@ mod test_policy_authorize_nv {
                 .with_encrypt(true)
                 .build();
 
-        let nv_index = NvIndexTpmHandle::new(0x01500015).unwrap();
+        let nv_index = NvIndexTpmHandle::new(0x01500500).unwrap();
         let initial_owner_nv_index_handle = write_nv_index(&mut context, nv_index);
 
         context


### PR DESCRIPTION
Although binding is already present, policy_authorize_nv was missing from the supported enhanced authorization commands.
Add a simple implementation to fill the gap.