### PR TITLE
Native tpms context

### DIFF
--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -20,10 +20,11 @@ use crate::{
     structures::{
         Auth, CreateKeyResult, Data, Digest, EccPoint, EccScheme, Name, Public, PublicBuilder,
         PublicEccParametersBuilder, PublicKeyRsa, PublicRsaParametersBuilder, RsaExponent,
-        RsaScheme, Signature, SignatureScheme, SymmetricDefinitionObject, VerifiedTicket,
+        RsaScheme, SavedTpmContext, Signature, SignatureScheme, SymmetricDefinitionObject,
+        VerifiedTicket,
     },
     tcti_ldr::TctiNameConf,
-    utils::{create_restricted_decryption_rsa_public, PublicKey, TpmsContext},
+    utils::{create_restricted_decryption_rsa_public, PublicKey},
     Context, Error, Result, ReturnCode, WrapperErrorKind as ErrorKind,
 };
 
@@ -341,7 +342,7 @@ impl TransientKeyContext {
     /// just a public key.
     pub fn migrate_key_from_ctx(
         &mut self,
-        context: TpmsContext,
+        context: SavedTpmContext,
         auth: Option<Auth>,
     ) -> Result<KeyMaterial> {
         self.set_session_attrs()?;

--- a/tss-esapi/src/constants/tss.rs
+++ b/tss-esapi/src/constants/tss.rs
@@ -644,6 +644,10 @@ pub const TSS2_RESMGR_TPM_RC_LAYER: TSS2_RC = 0x000C0000; /* base is a TPM2_RC_*
 
 pub const TSS2_RC_SUCCESS: TSS2_RC = 0x00000000;
 
+pub const TPMI_DH_SAVED_TRANSIENT: TPMI_DH_SAVED = 0x80000000; /* an ordinary transient object */
+pub const TPMI_DH_SAVED_SEQUENCE: TPMI_DH_SAVED = 0x80000001; /* a sequence object */
+pub const TPMI_DH_SAVED_TRANSIENT_CLEAR: TPMI_DH_SAVED = 0x80000002; /* a transient object with the stClear attribute SET */
+
 pub use crate::tss2_esys::TSS2_BASE_RC_ABI_MISMATCH; /* Passed in ABI version doesn't match called module's ABI version */
 pub use crate::tss2_esys::TSS2_BASE_RC_BAD_CONTEXT; /* A context structure is bad */
 pub use crate::tss2_esys::TSS2_BASE_RC_BAD_REFERENCE; /* A pointer is NULL that isn't allowed to be NULL. */

--- a/tss-esapi/src/handles/tpm.rs
+++ b/tss-esapi/src/handles/tpm.rs
@@ -326,7 +326,10 @@ pub mod saved_session {
 pub mod transient {
     //! Module for transient TPM handles
     use super::*;
-    use crate::constants::tss::{TPM2_HT_TRANSIENT, TPM2_TRANSIENT_FIRST, TPM2_TRANSIENT_LAST};
+    use crate::constants::tss::{
+        TPM2_HT_TRANSIENT, TPM2_TRANSIENT_FIRST, TPM2_TRANSIENT_LAST, TPMI_DH_SAVED_SEQUENCE,
+        TPMI_DH_SAVED_TRANSIENT, TPMI_DH_SAVED_TRANSIENT_CLEAR,
+    };
 
     create_tpm_handle_type!(
         TransientTpmHandle,
@@ -334,6 +337,13 @@ pub mod transient {
         TPM2_HT_TRANSIENT,
         TPM2_TRANSIENT_FIRST,
         TPM2_TRANSIENT_LAST
+    );
+    add_constant_handle!(TransientTpmHandle, SavedTransient, TPMI_DH_SAVED_TRANSIENT);
+    add_constant_handle!(TransientTpmHandle, SavedSequence, TPMI_DH_SAVED_SEQUENCE);
+    add_constant_handle!(
+        TransientTpmHandle,
+        SavedTransientClear,
+        TPMI_DH_SAVED_TRANSIENT_CLEAR
     );
 }
 

--- a/tss-esapi/src/interface_types/data_handles.rs
+++ b/tss-esapi/src/interface_types/data_handles.rs
@@ -1,3 +1,5 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
 /// This module contains native representations of the TPMI_DH types.
 use crate::{
     handles::{
@@ -8,6 +10,7 @@ use crate::{
     Error, Result, WrapperErrorKind,
 };
 use std::convert::TryFrom;
+
 /// Enum representing the 'Object' data handles interface type.
 ///
 /// # Details
@@ -70,8 +73,7 @@ pub enum Pcr {
 /// Enum representing the 'Context' data handles interface type.
 ///
 /// # Details
-/// This corresponds to the TPMI_DH_CONTEXT interface type.
-/// This corresponds to the TPMI_DH_CONTEXT interface type. This only
+/// This corresponds to the `TPMI_DH_CONTEXT` interface type. This only
 /// exist for compatibility purposes the specification is not entirely
 /// clear on whether this should still be used or be completely replaced by
 /// [Saved].
@@ -116,13 +118,18 @@ impl TryFrom<TPMI_DH_CONTEXT> for ContextDataHandle {
 /// Enum representing the 'Saved' data handles interface type.
 ///
 /// # Details
-/// This corresponds to the TPMI_DH_SAVED interface type.
+/// This corresponds to the `TPMI_DH_SAVED` interface type.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Saved {
+    /// A HMAC session context.
     Hmac(HmacSessionTpmHandle),
+    /// A policy session context.
     Policy(PolicySessionTpmHandle),
+    /// An ordinary transient object.
     Transient,
+    /// A sequence object.
     Sequence,
+    /// A transient object with stClear attribute SET.
     TransientClear,
 }
 
@@ -160,5 +167,17 @@ impl TryFrom<TPMI_DH_SAVED> for Saved {
             TpmHandle::Transient(handle) => Saved::try_from(handle),
             _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
         })
+    }
+}
+
+impl From<Saved> for TPMI_DH_SAVED {
+    fn from(native: Saved) -> TPMI_DH_SAVED {
+        match native {
+            Saved::Hmac(handle) => handle.into(),
+            Saved::Policy(handle) => handle.into(),
+            Saved::Transient => TransientTpmHandle::SavedTransient.into(),
+            Saved::Sequence => TransientTpmHandle::SavedSequence.into(),
+            Saved::TransientClear => TransientTpmHandle::SavedTransientClear.into(),
+        }
     }
 }

--- a/tss-esapi/src/interface_types/data_handles.rs
+++ b/tss-esapi/src/interface_types/data_handles.rs
@@ -1,10 +1,17 @@
-// Copyright 2020 Contributors to the Parsec project.
-// SPDX-License-Identifier: Apache-2.0
-
-use crate::handles::{NvIndexTpmHandle, PcrTpmHandle, PersistentTpmHandle, TransientTpmHandle};
-
-/// Can be created with either a persistent
-/// or transient TPM handle.
+/// This module contains native representations of the TPMI_DH types.
+use crate::{
+    handles::{
+        HmacSessionTpmHandle, NvIndexTpmHandle, PcrTpmHandle, PersistentTpmHandle,
+        PolicySessionTpmHandle, TpmHandle, TransientTpmHandle,
+    },
+    tss2_esys::TPMI_DH_CONTEXT,
+    Error, Result, WrapperErrorKind,
+};
+use std::convert::TryFrom;
+/// Enum representing the 'Object' data handles interface type.
+///
+/// # Details
+/// This corresponds to the TPMI_DH_OBJECT interface type.
 #[derive(Debug, Copy, Clone)]
 pub enum Object {
     Transient(TransientTpmHandle),
@@ -53,10 +60,52 @@ pub enum Entity {
     Platform,
     Endorsement,
     Lockout,
-    // TODO: Handle Auth
+    // TODO: Handle Auth, that is vendor specific.
 }
 
 #[derive(Debug, Copy, Clone)]
 pub enum Pcr {
     Pcr(PcrTpmHandle),
+}
+
+/// Enum representing the 'Context' data handles interface type.
+///
+/// # Details
+/// This corresponds to the TPMI_DH_CONTEXT interface type.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ContextDataHandle {
+    Hmac(HmacSessionTpmHandle),
+    Policy(PolicySessionTpmHandle),
+    Transient(TransientTpmHandle),
+}
+
+impl From<HmacSessionTpmHandle> for ContextDataHandle {
+    fn from(hmac_session_tpm_handle: HmacSessionTpmHandle) -> Self {
+        ContextDataHandle::Hmac(hmac_session_tpm_handle)
+    }
+}
+
+impl From<PolicySessionTpmHandle> for ContextDataHandle {
+    fn from(policy_session_tpm_handle: PolicySessionTpmHandle) -> Self {
+        ContextDataHandle::Policy(policy_session_tpm_handle)
+    }
+}
+
+impl From<TransientTpmHandle> for ContextDataHandle {
+    fn from(transient_tpm_handle: TransientTpmHandle) -> Self {
+        ContextDataHandle::Transient(transient_tpm_handle)
+    }
+}
+
+impl TryFrom<TPMI_DH_CONTEXT> for ContextDataHandle {
+    type Error = Error;
+
+    fn try_from(ffi: TPMI_DH_CONTEXT) -> Result<Self> {
+        TpmHandle::try_from(ffi).and_then(|tpm_handle| match tpm_handle {
+            TpmHandle::HmacSession(handle) => Ok(Self::Hmac(handle)),
+            TpmHandle::PolicySession(handle) => Ok(Self::Policy(handle)),
+            TpmHandle::Transient(handle) => Ok(Self::Transient(handle)),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        })
+    }
 }

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -390,3 +390,12 @@ pub mod symmetric_key {
 pub mod timeout {
     buffer_type!(Timeout, 8, TPM2B_TIMEOUT);
 }
+
+pub mod tpm_context_data {
+    use crate::tss2_esys::TPMS_CONTEXT_DATA;
+    buffer_type!(
+        TpmContextData,
+        std::mem::size_of::<TPMS_CONTEXT_DATA>(),
+        TPM2B_CONTEXT_DATA
+    );
+}

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -41,7 +41,7 @@ pub use self::buffers::{
     private_key_rsa::PrivateKeyRsa, private_vendor_specific::PrivateVendorSpecific,
     public::PublicBuffer, public_key_rsa::PublicKeyRsa, sensitive::SensitiveBuffer,
     sensitive_create::SensitiveCreateBuffer, sensitive_data::SensitiveData,
-    symmetric_key::SymmetricKey, timeout::Timeout,
+    symmetric_key::SymmetricKey, timeout::Timeout, tpm_context_data::TpmContextData,
 };
 /////////////////////////////////////////////////////////
 /// The creation section
@@ -212,3 +212,8 @@ pub use nv::storage::{NvPublic, NvPublicBuilder};
 /////////////////////////////////////////////////////////
 mod algorithm;
 pub use algorithm::symmetric::sensitive_create::SensitiveCreate;
+/////////////////////////////////////////////////////////
+/// TPM context structures
+/////////////////////////////////////////////////////////
+mod tpm_context;
+pub use tpm_context::SavedTpmContext;

--- a/tss-esapi/src/structures/tagged/public.rs
+++ b/tss-esapi/src/structures/tagged/public.rs
@@ -495,7 +495,7 @@ impl TryFrom<TPMT_PUBLIC> for Public {
 impl_mu_standard!(Public, TPMT_PUBLIC);
 
 impl Serialize for Public {
-    /// Serialise the [Public] data into it's bytes representation of the TCG
+    /// Serialize the [Public] data into it's bytes representation of the TCG
     /// TPMT_PUBLIC structure.
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where

--- a/tss-esapi/src/structures/tpm_context.rs
+++ b/tss-esapi/src/structures/tpm_context.rs
@@ -1,0 +1,104 @@
+// Copyright 2024 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    handles::TpmHandle,
+    interface_types::{data_handles::Saved, reserved_handles::Hierarchy},
+    structures::TpmContextData,
+    traits::impl_mu_standard,
+    traits::{Marshall, UnMarshall},
+    tss2_esys::TPMS_CONTEXT,
+    Error, Result,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::convert::TryFrom;
+
+/// Structure holding the content of a TPM context.
+#[derive(Debug, Clone)]
+pub struct SavedTpmContext {
+    sequence: u64,
+    saved_handle: Saved,
+    hierarchy: Hierarchy,
+    context_blob: TpmContextData,
+}
+
+impl SavedTpmContext {
+    /// The sequence parameter
+    ///
+    /// # Details
+    /// "The sequence parameter is used to differentiate the contexts and to allow the TPM to create a different
+    ///  encryption key for each context."
+    pub const fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    /// The saved handle.
+    pub const fn saved_handle(&self) -> Saved {
+        self.saved_handle
+    }
+
+    /// The hierarchy for the saved context.
+    pub const fn hierarchy(&self) -> Hierarchy {
+        self.hierarchy
+    }
+
+    /// The context blob.
+    ///
+    /// # Details
+    /// "This is the hierarchy ([Hierarchy]) for the saved context and determines the proof value used
+    ///  in the construction of the encryption and integrity values for the context. For session and sequence
+    ///  contexts, the hierarchy is [Hierarchy::Null]. The hierarchy for a transient object may be [Hierarchy::Null]
+    ///  but it is not required."
+    pub fn context_blob(&self) -> &TpmContextData {
+        &self.context_blob
+    }
+}
+
+impl TryFrom<TPMS_CONTEXT> for SavedTpmContext {
+    type Error = Error;
+
+    fn try_from(tss: TPMS_CONTEXT) -> Result<SavedTpmContext> {
+        Ok(SavedTpmContext {
+            sequence: tss.sequence,
+            saved_handle: Saved::try_from(tss.savedHandle)?,
+            hierarchy: TpmHandle::try_from(tss.hierarchy).and_then(Hierarchy::try_from)?,
+            context_blob: TpmContextData::try_from(tss.contextBlob)?,
+        })
+    }
+}
+
+impl From<SavedTpmContext> for TPMS_CONTEXT {
+    fn from(native: SavedTpmContext) -> TPMS_CONTEXT {
+        TPMS_CONTEXT {
+            sequence: native.sequence,
+            savedHandle: native.saved_handle.into(),
+            hierarchy: TpmHandle::from(native.hierarchy).into(),
+            contextBlob: native.context_blob.into(),
+        }
+    }
+}
+
+impl_mu_standard!(SavedTpmContext, TPMS_CONTEXT);
+
+impl Serialize for SavedTpmContext {
+    /// Serialize the [SavedTpmContext] data into it's bytes representation of the TCG
+    /// TPMS_CONTEXT structure.
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = self.marshall().map_err(serde::ser::Error::custom)?;
+        serializer.serialize_bytes(&bytes)
+    }
+}
+
+impl<'de> Deserialize<'de> for SavedTpmContext {
+    /// Deserialize the [SavedTpmContext] data from it's bytes representation of the TCG
+    /// TPMS_CONTEXT structure.
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = <Vec<u8>>::deserialize(deserializer)?;
+        Self::unmarshall(&bytes).map_err(serde::de::Error::custom)
+    }
+}

--- a/tss-esapi/tests/integration_tests/common/tpm2b_types_equality_checks.rs
+++ b/tss-esapi/tests/integration_tests/common/tpm2b_types_equality_checks.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use tss_esapi::tss2_esys::{
-    TPM2B_AUTH, TPM2B_DATA, TPM2B_DIGEST, TPM2B_MAX_NV_BUFFER, TPM2B_NAME, TPM2B_SENSITIVE_CREATE,
-    TPM2B_SENSITIVE_DATA,
+    TPM2B_AUTH, TPM2B_CONTEXT_DATA, TPM2B_DATA, TPM2B_DIGEST, TPM2B_MAX_NV_BUFFER, TPM2B_NAME,
+    TPM2B_SENSITIVE_CREATE, TPM2B_SENSITIVE_DATA,
 };
 
 macro_rules! ensure_sized_buffer_equality {
@@ -59,4 +59,11 @@ pub fn ensure_tpm2b_sensitive_create_equality(
         "'size' value in TPM2B_SENSITIVE_CREATE, mismatch between actual and expected",
     );
     crate::common::ensure_tpms_sensitive_create_equality(&expected.sensitive, &actual.sensitive);
+}
+
+pub fn ensure_tpm2b_context_data_equality(
+    expected: &TPM2B_CONTEXT_DATA,
+    actual: &TPM2B_CONTEXT_DATA,
+) {
+    ensure_sized_buffer_equality!(expected, actual, buffer, TPM2B_CONTEXT_DATA);
 }

--- a/tss-esapi/tests/integration_tests/common/tpms_types_equality_checks.rs
+++ b/tss-esapi/tests/integration_tests/common/tpms_types_equality_checks.rs
@@ -7,7 +7,7 @@ use tss_esapi::{
     },
     tss2_esys::{
         TPMS_ALG_PROPERTY, TPMS_ATTEST, TPMS_CERTIFY_INFO, TPMS_CLOCK_INFO,
-        TPMS_COMMAND_AUDIT_INFO, TPMS_CREATION_INFO, TPMS_ECC_PARMS, TPMS_EMPTY,
+        TPMS_COMMAND_AUDIT_INFO, TPMS_CONTEXT, TPMS_CREATION_INFO, TPMS_ECC_PARMS, TPMS_EMPTY,
         TPMS_KEYEDHASH_PARMS, TPMS_NV_CERTIFY_INFO, TPMS_PCR_SELECTION, TPMS_QUOTE_INFO,
         TPMS_RSA_PARMS, TPMS_SCHEME_ECDAA, TPMS_SCHEME_HASH, TPMS_SCHEME_HMAC, TPMS_SCHEME_XOR,
         TPMS_SENSITIVE_CREATE, TPMS_SESSION_AUDIT_INFO, TPMS_SYMCIPHER_PARMS,
@@ -315,4 +315,20 @@ pub fn ensure_tpms_empty_equality(expected: &TPMS_EMPTY, actual: &TPMS_EMPTY) {
         expected.empty, actual.empty,
         "'empty' value TPMS_EMPTY, mismatch between actual and expected."
     );
+}
+
+pub fn ensure_tpms_context_equality(expected: &TPMS_CONTEXT, actual: &TPMS_CONTEXT) {
+    assert_eq!(
+        expected.sequence, actual.sequence,
+        "'sequence' value TPMS_CONTEXT, mismatch between actual and expected"
+    );
+    assert_eq!(
+        expected.savedHandle, actual.savedHandle,
+        "'savedHandle' value TPMS_CONTEXT, mismatch between actual and expected"
+    );
+    assert_eq!(
+        expected.hierarchy, actual.hierarchy,
+        "'hierarchy' value TPMS_CONTEXT, mismatch between actual and expected"
+    );
+    crate::common::ensure_tpm2b_context_data_equality(&expected.contextBlob, &actual.contextBlob);
 }

--- a/tss-esapi/tests/integration_tests/interface_types_tests/data_handles_tests.rs
+++ b/tss-esapi/tests/integration_tests/interface_types_tests/data_handles_tests.rs
@@ -1,0 +1,76 @@
+// Copyright 2023 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use std::convert::TryFrom;
+use tss_esapi::{
+    constants::tss::{
+        TPM2_HMAC_SESSION_LAST, TPM2_PERMANENT_LAST, TPM2_POLICY_SESSION_LAST, TPM2_TRANSIENT_LAST,
+    },
+    handles::{HmacSessionTpmHandle, PolicySessionTpmHandle, TransientTpmHandle},
+    interface_types::data_handles::ContextDataHandle,
+    Error, WrapperErrorKind,
+};
+
+macro_rules! context_data_handle_valid_conversions {
+    (ContextDataHandle::$enum_item:ident, $handle_type:ident, $tss:ident) => {
+        let context_data_handle = ContextDataHandle::try_from($tss).unwrap_or_else(|_| {
+            panic!(
+                "Converting {} into ContextDataHandle should not cause an error.",
+                std::stringify!($tss)
+            );
+        });
+        let expected_handle = $handle_type::try_from($tss).unwrap_or_else(|_| {
+            panic!(
+                "Converting {} into {} should not cause an error.",
+                std::stringify!($tss),
+                std::stringify!($handle_type)
+            );
+        });
+        if let ContextDataHandle::$enum_item(actual_handle) = context_data_handle {
+            assert_eq!(
+                expected_handle,
+                actual_handle,
+                "{} was converted into the expected handle.",
+                std::stringify!($tss)
+            );
+        } else {
+            panic!(
+                "{} should convert into a {}",
+                std::stringify!($tss),
+                std::stringify!(ContextDataHandle::$enum_item)
+            );
+        }
+        assert_eq!(
+            context_data_handle,
+            ContextDataHandle::from(expected_handle)
+        );
+    };
+}
+
+#[test]
+fn test_context_data_handle_valid_conversions() {
+    context_data_handle_valid_conversions!(
+        ContextDataHandle::Hmac,
+        HmacSessionTpmHandle,
+        TPM2_HMAC_SESSION_LAST
+    );
+    context_data_handle_valid_conversions!(
+        ContextDataHandle::Policy,
+        PolicySessionTpmHandle,
+        TPM2_POLICY_SESSION_LAST
+    );
+    context_data_handle_valid_conversions!(
+        ContextDataHandle::Transient,
+        TransientTpmHandle,
+        TPM2_TRANSIENT_LAST
+    );
+}
+
+#[test]
+fn test_context_data_handle_invalid_conversion() {
+    let result = ContextDataHandle::try_from(TPM2_PERMANENT_LAST);
+    if let Err(error) = result {
+        assert_eq!(Error::WrapperError(WrapperErrorKind::InvalidParam), error);
+    } else {
+        panic!("Converting an invalid value `TPM2_PERMANENT_LAST` into a ContextDataHandle should produce an error.");
+    }
+}

--- a/tss-esapi/tests/integration_tests/interface_types_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/interface_types_tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod algorithms_tests;
+mod data_handles_tests;
 mod key_bits_tests;
 mod reserved_handles_tests;
 mod structure_tags_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/mod.rs
@@ -20,3 +20,4 @@ mod tagged_property_tests;
 mod tagged_tests;
 mod time_attest_info_tests;
 mod time_info_tests;
+mod tpm_context_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/tpm_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/tpm_context_tests.rs
@@ -1,0 +1,40 @@
+use std::convert::TryFrom;
+use tss_esapi::{
+    handles::TpmHandle,
+    interface_types::{data_handles::Saved, reserved_handles::Hierarchy},
+    structures::{SavedTpmContext, TpmContextData},
+    tss2_esys::TPMS_CONTEXT,
+};
+
+#[test]
+fn test_valid_conversions() {
+    let expected_sequence = 13243546576879u64;
+    let expected_saved_handle = Saved::Transient;
+    let expected_hierarchy = Hierarchy::Owner;
+    let expected_context_blob =
+        TpmContextData::try_from(vec![1u8, 2u8, 12u8, 23u8, 45u8, 56u8, 98u8])
+            .expect("It should be possible to create TpmContextData buffer type from bytes.");
+    let expected_tpms_context = TPMS_CONTEXT {
+        sequence: expected_sequence,
+        savedHandle: expected_saved_handle.into(),
+        hierarchy: TpmHandle::from(expected_hierarchy).into(),
+        contextBlob: expected_context_blob.clone().into(),
+    };
+    // Conversion TPMS_CONTEXT -> SavedTpmContext
+    let actual_saved_tpm_context = SavedTpmContext::try_from(expected_tpms_context).expect(
+        "It should be possible to convert a valid TPMS_CONTEXT structure into a SavedTpmContext",
+    );
+    assert_eq!(expected_sequence, actual_saved_tpm_context.sequence());
+    assert_eq!(
+        expected_saved_handle,
+        actual_saved_tpm_context.saved_handle()
+    );
+    assert_eq!(expected_hierarchy, actual_saved_tpm_context.hierarchy());
+    assert_eq!(
+        expected_context_blob,
+        *actual_saved_tpm_context.context_blob()
+    );
+    // SavedTpmContext -> TPMS_CONTEXT
+    let actual_tpms_context = TPMS_CONTEXT::from(actual_saved_tpm_context);
+    crate::common::ensure_tpms_context_equality(&expected_tpms_context, &actual_tpms_context);
+}


### PR DESCRIPTION
In this pull request the `TpmsContext` struct that was residing inside `utils` module have been moved to the `structures` module and been renamed to `SavedTpmContext`.