### PR TITLE
tss-esapi/transient: get_root_key_name

### DIFF
--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     attributes::{ObjectAttributesBuilder, SessionAttributesBuilder},
     constants::{SessionType, TpmFormatZeroError},
     error::{TpmFormatZeroResponseCode, TpmResponseCode},
-    handles::{KeyHandle, SessionHandle},
+    handles::{KeyHandle, ObjectHandle, SessionHandle},
     interface_types::{
         algorithm::{HashingAlgorithm, PublicAlgorithm},
         ecc::EccCurve,
@@ -18,7 +18,7 @@ use crate::{
         reserved_handles::Hierarchy,
     },
     structures::{
-        Auth, CreateKeyResult, Data, Digest, EccPoint, EccScheme, Public, PublicBuilder,
+        Auth, CreateKeyResult, Data, Digest, EccPoint, EccScheme, Name, Public, PublicBuilder,
         PublicEccParametersBuilder, PublicKeyRsa, PublicRsaParametersBuilder, RsaExponent,
         RsaScheme, Signature, SignatureScheme, SymmetricDefinitionObject, VerifiedTicket,
     },
@@ -384,6 +384,12 @@ impl TransientKeyContext {
 
         self.context.flush_context(key_handle.into())?;
         Ok(key_material)
+    }
+
+    /// Gets the name of the root key of the TransientKeyContext
+    pub fn get_root_key_name(&mut self) -> Result<Name> {
+        let obj_handle: ObjectHandle = self.root_key_handle.into();
+        self.context.tr_get_name(obj_handle)
     }
 
     /// Sets the encrypt and decrypt flags on the main session used by the context.


### PR DESCRIPTION
Expose the root key name of a TransientKeyContext. This may be used for verifying previously generated keys.