### PR TITLE
Disables the clippy multiple_crate_versions lint error.

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tss-esapi"
 version = "8.0.0-alpha"
 authors = ["Parsec Project Contributors"]
-edition = "2018"
+edition = "2018"                                                       # TODO Update edition to 2021 - Remove the disabled lints that are due to using old edition.
 description = "Rust-native wrapper around TSS 2.0 Enhanced System API"
 readme = "README.md"
 keywords = ["tpm", "tss", "esys", "esapi"]

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -29,7 +29,10 @@
     missing_copy_implementations,
     rustdoc::broken_intra_doc_links,
 )]
-
+// This comes from Zeroize they changed version of Syn used
+// when zeroize_derive was updated to Rust Edition 2021.
+// TODO: Remove this when updating Rust Edition.
+#![allow(clippy::multiple_crate_versions)]
 //! # TSS 2.0 Rust Wrapper over Enhanced System API
 //! This crate exposes the functionality of the TCG Software Stack Enhanced System API to
 //! Rust developers, both directly through FFI bindings and through more Rust-tailored interfaces


### PR DESCRIPTION
In Rust version 1.77 clippy has begun reporting
errors for when two versions of the same crate
exists among the dependencies. In this case
it is the `syn` crate for which there exists two
versions. The reason for this is that the
`zeroize_derive` crate updated the `syn` version
after making a Rust Edition bump. So the ones
using Rust Edition 2018 gets an older version
of `zeroize_derive` which uses `syn` with major
release version 1.