### PR TITLE
Add bundled feature to allow tpm2-tss to be built from source

### DIFF
--- a/tss-esapi-sys/Cargo.toml
+++ b/tss-esapi-sys/Cargo.toml
@@ -15,13 +15,14 @@ rust-version = "1.66.0"
 
 [build-dependencies]
 autotools = { version = "0.2.6", optional = true }
-bindgen = { version = "0.66.1", optional = true }
+bindgen = { version = "0.69.4", optional = true }
 pkg-config = "0.3.18"
 target-lexicon = "0.12.0"
 
 [target.'cfg(windows)'.build-dependencies]
 msbuild = { git = "https://github.com/uglyoldbob/msbuild.git", optional = true }
+winreg = {version = "0.52", optional = true }
 
 [features]
 generate-bindings = ["bindgen"]
-bundled = ["dep:autotools", "dep:msbuild"]
+bundled = ["dep:autotools", "dep:msbuild", "dep:winreg"]

--- a/tss-esapi-sys/Cargo.toml
+++ b/tss-esapi-sys/Cargo.toml
@@ -16,10 +16,11 @@ rust-version = "1.66.0"
 [build-dependencies]
 autotools = { version = "0.2.6", optional = true }
 bindgen = { version = "0.66.1", optional = true }
+msbuild = { git = "https://github.com/uglyoldbob/msbuild.git", optional = true }
 pkg-config = "0.3.18"
 target-lexicon = "0.12.0"
 
 
 [features]
 generate-bindings = ["bindgen"]
-bundled = ["dep:autotools"]
+bundled = ["dep:autotools", "dep:msbuild"]

--- a/tss-esapi-sys/Cargo.toml
+++ b/tss-esapi-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tss-esapi-sys"
 version = "0.5.0"
 authors = ["Parsec Project Contributors"]
-edition = "2018"
+edition = "2021"
 description = "FFI wrapper around TSS 2.0 Enhanced System API"
 readme = "README.md"
 keywords = ["tpm", "tss", "esys", "esapi"]
@@ -14,9 +14,12 @@ links = "tss2-esys"
 rust-version = "1.66.0"
 
 [build-dependencies]
+autotools = { version = "0.2.6", optional = true }
 bindgen = { version = "0.66.1", optional = true }
 pkg-config = "0.3.18"
 target-lexicon = "0.12.0"
 
+
 [features]
 generate-bindings = ["bindgen"]
+bundled = ["dep:autotools"]

--- a/tss-esapi-sys/Cargo.toml
+++ b/tss-esapi-sys/Cargo.toml
@@ -16,10 +16,11 @@ rust-version = "1.66.0"
 [build-dependencies]
 autotools = { version = "0.2.6", optional = true }
 bindgen = { version = "0.66.1", optional = true }
-msbuild = { git = "https://github.com/uglyoldbob/msbuild.git", optional = true }
 pkg-config = "0.3.18"
 target-lexicon = "0.12.0"
 
+[target.'cfg(windows)'.build-dependencies]
+msbuild = { git = "https://github.com/uglyoldbob/msbuild.git", optional = true }
 
 [features]
 generate-bindings = ["bindgen"]

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -99,7 +99,7 @@ fn main() {
         generate_from_system(esys_path);
     }
 
-    #[cfg(feature = "bundled")]
+    #[cfg(all(feature = "bundled", not(windows)))]
     {
         let out_path = env::var("OUT_DIR").expect("No output directory given");
         let source_path = fetch_source(
@@ -115,6 +115,22 @@ fn main() {
             format!("{}", install_path.join("lib").join("pkgconfig").display()),
         );
         use_pkgconfig(MINIMUM_VERSION, "4.0.0", "tss2-esys");
+    }
+
+    #[cfg(all(feature = "bundled", windows))]
+    {
+        let out_path = env::var("OUT_DIR").expect("No output directory given");
+        let source_path = fetch_source(
+            out_path,
+            "tpm2-tss",
+            "https://github.com/tpm2-software/tpm2-tss.git",
+            "3.2.2",
+        );
+
+        let mut msbuild = msbuild::MsBuild::find_msbuild().unwrap();
+        msbuild.run(source_path, &[
+            "-ds",
+            "tpm2-tss.sln"]);
     }
 
     #[cfg(all(not(feature = "generate-bindings"), not(features = "bundled")))]

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -246,7 +246,19 @@ pub fn generate_from_system(esapi_out: PathBuf) {
     }
     #[cfg(windows)]
     {
-        
+        builder = builder.blocklist_type("IMAGE_TLS_DIRECTORY")
+            .blocklist_type("PIMAGE_TLS_DIRECTORY")
+            .blocklist_type("IMAGE_TLS_DIRECTORY64")
+            .blocklist_type("PIMAGE_TLS_DIRECTORY64")
+            .blocklist_type("_IMAGE_TLS_DIRECTORY64")
+            .blocklist_type("MONITORINFOEX")
+            .blocklist_type("MONITORINFOEXA")
+            .blocklist_type("MONITORINFOEXW")
+            .blocklist_type("tagMONITORINFOEXA")
+            .blocklist_type("tagMONITORINFOEXW")
+            .blocklist_type("LPMONITORINFOEX")
+            .blocklist_type("LPMONITORINFOEXA")
+            .blocklist_type("LPMONITORINFOEXW");
     }
     builder.clang_arg(format!("-I{}/tss2/", tss2_esys_include_path))
         .clang_arg(format!("-I{}/tss2/", tss2_tctildr_include_path))

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -274,4 +274,16 @@ pub fn generate_from_system(esapi_out: PathBuf) {
         .expect("Unable to generate bindings to TSS2 ESYS APIs.")
         .write_to_file(esapi_out)
         .expect("Couldn't write ESYS bindings!");
+    #[cfg(windows)]
+    {
+        println!("cargo:rustc-link-lib=dylib=tss2-esys");
+        println!("cargo:rustc-link-lib=dylib=tss2-mu");
+        println!("cargo:rustc-link-lib=dylib=tss2-sys");
+        println!("cargo:rustc-link-lib=dylib=tss2-tctildr");
+        println!("cargo:rustc-link-lib=dylib=tss2-tcti-tbs");
+        println!(
+            "cargo:rustc-link-search=dylib={}",
+            p.join("x64").join("Debug").display()
+        );
+    }
 }

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -129,7 +129,6 @@ fn main() {
 
         let mut msbuild = msbuild::MsBuild::find_msbuild(Some("2017")).unwrap();
         msbuild.run(source_path, &[
-            "-ds",
             "tpm2-tss.sln"]);
     }
 

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -127,13 +127,13 @@ fn main() {
             "3.2.2",
         );
 
-        let mut msbuild = msbuild::MsBuild::find_msbuild().unwrap();
+        let mut msbuild = msbuild::MsBuild::find_msbuild(Some("2017")).unwrap();
         msbuild.run(source_path, &[
             "-ds",
             "tpm2-tss.sln"]);
     }
 
-    #[cfg(all(not(feature = "generate-bindings"), not(features = "bundled")))]
+    #[cfg(all(not(feature = "generate-bindings"), not(feature = "bundled")))]
     {
         use std::str::FromStr;
         use target_lexicon::{Architecture, OperatingSystem, Triple};

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -45,7 +45,7 @@ fn compile_with_autotools(p: PathBuf) -> PathBuf {
     let output1 = Command::new("./bootstrap")
         .current_dir(&p)
         .output()
-        .expect("bootstrapt script failed");
+        .expect("bootstrap script failed");
     let status = output1.status;
     assert!(
         status.success(),

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -114,7 +114,16 @@ fn main() {
         );
 
         let mut msbuild = msbuild::MsBuild::find_msbuild(Some("2017")).unwrap();
+
+        let profile = std::env::var("PROFILE").unwrap();
+        let build_string = match profile.as_str() {
+            "debug" => "",
+            "release" => "/p:Configuration=Release",
+            _ => panic!("Unknown cargo profile:"),
+        };
+
         msbuild.run(source_path, &[
+            build_string,
             "tpm2-tss.sln"]);
     }
 
@@ -266,6 +275,7 @@ pub fn generate_from_system(esapi_out: PathBuf) {
         .header(format!("{}/tss2/tss2_esys.h", tss2_esys_include_path))
         .header(format!("{}/tss2/tss2_tctildr.h", tss2_tctildr_include_path))
         .header(format!("{}/tss2/tss2_mu.h", tss2_mu_include_path))
+        .header(format!("{}/tss2/tss2_tcti_tbs.h", tss2_mu_include_path))
         // See this issue: https://github.com/parallaxsecond/rust-cryptoki/issues/12
         .blocklist_type("max_align_t")
         .generate_comments(false)
@@ -281,9 +291,17 @@ pub fn generate_from_system(esapi_out: PathBuf) {
         println!("cargo:rustc-link-lib=dylib=tss2-sys");
         println!("cargo:rustc-link-lib=dylib=tss2-tctildr");
         println!("cargo:rustc-link-lib=dylib=tss2-tcti-tbs");
+
+        let profile = std::env::var("PROFILE").unwrap();
+        let build_string = match profile.as_str() {
+            "debug" => "Debug",
+            "release" => "Release",
+            _ => panic!("Unknown cargo profile:"),
+        };
+
         println!(
             "cargo:rustc-link-search=dylib={}",
-            p.join("x64").join("Debug").display()
+            p.join("x64").join(build_string).display()
         );
     }
 }

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -17,25 +17,18 @@ const MINIMUM_VERSION: &str = "3.2.2";
 fn fetch_source(dest_path: impl AsRef<Path>, name: &str, repo: &str, branch: &str) -> PathBuf {
     let parent_path = dest_path.as_ref();
     let repo_path = parent_path.join(name);
-    let output = if !repo_path.join("Makefile.am").exists() {
-        Command::new("git")
+    if !repo_path.join("Makefile.am").exists() {
+        let output = Command::new("git")
             .args(["clone", repo, "--depth", "1", "--branch", branch])
             .current_dir(parent_path)
             .output()
-            .expect(&format!("git clone for {} failed", name))
-    } else {
-        Command::new("git")
-            .args(["pull", "--ff-only", "origin", branch])
-            .current_dir(&repo_path)
-            .output()
-            .expect(&format!("git pull for {} failed", name))
-    };
-
-    let status = output.status;
-    assert!(
-        status.success(),
-        "git clone/pull for {name} returned failure status {status}:\n{output:?}"
-    );
+            .expect(&format!("git clone for {} failed", name));
+        let status = output.status;
+            assert!(
+                status.success(),
+                "git clone for {name} returned failure status {status}:\n{output:?}"
+            );
+    }
 
     repo_path
 }

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -46,6 +46,7 @@ semver = "1.0.7"
 
 [features]
 default = ["abstraction"]
+bundled = [ "tss-esapi-sys/bundled" ]
 generate-bindings = ["tss-esapi-sys/generate-bindings"]
 abstraction = ["oid", "picky-asn1", "picky-asn1-x509"]
 integration-tests = ["strum", "strum_macros"]

--- a/tss-esapi/build.rs
+++ b/tss-esapi/build.rs
@@ -3,9 +3,10 @@
 use semver::{Version, VersionReq};
 
 fn main() {
+    #[cfg(feature = "bundled")]
+    std::env::set_var("DEP_TSS2_ESYS_VERSION", "3.2.2");
     let tss_version_string = std::env::var("DEP_TSS2_ESYS_VERSION")
         .expect("Failed to parse ENV variable DEP_TSS2_ESYS_VERSION as string");
-
     let tss_version = Version::parse(&tss_version_string)
         .expect("Failed to parse the DEP_TSS2_ESYS_VERSION variable as a semver version");
 

--- a/tss-esapi/src/tcti_ldr.rs
+++ b/tss-esapi/src/tcti_ldr.rs
@@ -17,6 +17,8 @@ use std::path::PathBuf;
 use std::ptr::null_mut;
 use std::str::FromStr;
 
+#[cfg(target_os = "windows")]
+const TBS: &str = "tbs";
 const DEVICE: &str = "device";
 const MSSIM: &str = "mssim";
 const SWTPM: &str = "swtpm";
@@ -143,6 +145,9 @@ pub enum TctiNameConf {
     ///
     /// For more information about configuration, see [this page](https://www.mankier.com/3/Tss2_Tcti_Tabrmd_Init)
     Tabrmd(TabrmdConfig),
+    /// Connect to a TPM through the windows TBS
+    #[cfg(target_os = "windows")]
+    Tbs,
 }
 
 impl TctiNameConf {
@@ -174,6 +179,8 @@ impl TryFrom<TctiNameConf> for CString {
             TctiNameConf::Mssim(..) => MSSIM,
             TctiNameConf::Swtpm(..) => SWTPM,
             TctiNameConf::Tabrmd(..) => TABRMD,
+            #[cfg(target_os = "windows")]
+            TctiNameConf::Tbs => TBS,
         };
 
         let tcti_conf = match tcti {
@@ -204,6 +211,8 @@ impl TryFrom<TctiNameConf> for CString {
             TctiNameConf::Tabrmd(config) => {
                 format!("bus_name={},bus_type={}", config.bus_name, config.bus_type)
             }
+            #[cfg(target_os = "windows")]
+            TctiNameConf::Tbs => String::new(),
         };
 
         if tcti_conf.is_empty() {


### PR DESCRIPTION
This pull request adds a feature called bundled, which pulls the tpm2-tss code from git and compiles it.
Tested on ubuntu linux and windows 11.

The linux build needs all of the normal requirements for building tpm2-tss as described in their repository.

Windows builds require visual studio 2017, with the c2 clang option, visual studio build tools 10.0.17134.0. Openssl should be installed to C:\OpenSSL-v11-Win64