### PR TITLE
Add support for testing with opensuse

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.gitignore
+.mypy_cache
+.vscode
+*.md
+**/__pycache__/**
+docs
+Makefile
+target
+test.db
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.patch
 *NVChip
 .vscode
+.cargo/
+vendor/

--- a/tss-esapi/tests/Dockerfile-opensuse-tw
+++ b/tss-esapi/tests/Dockerfile-opensuse-tw
@@ -1,0 +1,23 @@
+# USAGE:
+# docker build -t tssdev -f ./tss-esapi/tests/Dockerfile-opensuse-tw .
+# docker run -v ./:/usr/src/rust-tss-esapi --rm -i -t tssdev
+#
+# It is a good idea to vendor to prevent repeat crate downloads.
+# mkdir .cargo
+# cargo vendor > .cargo/config.toml
+
+FROM opensuse/tumbleweed:latest
+
+RUN zypper install -y \
+    tpm2-0-tss-devel tpm2.0-tools tpm2.0-abrmd \
+    swtpm \
+    cargo \
+    clang \
+    dbus-1-daemon
+
+# Instead of bind mounting, we could do this instead.
+# COPY . /usr/src/rust-tss-esapi
+
+WORKDIR /usr/src/rust-tss-esapi
+
+CMD ["/usr/bin/bash", "tss-esapi/tests/all-opensuse.sh"]

--- a/tss-esapi/tests/all-opensuse.sh
+++ b/tss-esapi/tests/all-opensuse.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script executes tests for the tss-esapi crate.
+# It can be run inside the container which Dockerfile is in the same folder.
+#
+# Usage: ./tests/all.sh
+
+set -euf -o pipefail
+
+############################
+# Run the TPM SWTPM server #
+############################
+mkdir /tmp/tpmdir
+swtpm_setup --tpm2 \
+    --tpmstate /tmp/tpmdir \
+    --createek --decryption --create-ek-cert \
+    --create-platform-cert \
+    --pcr-banks sha1,sha256 \
+    --display
+swtpm socket --tpm2 \
+    --tpmstate dir=/tmp/tpmdir \
+    --flags startup-clear \
+    --ctrl type=tcp,port=2322 \
+    --server type=tcp,port=2321 \
+    --daemon
+
+###################
+# Build the crate #
+###################
+RUST_BACKTRACE=1 cargo build --features "generate-bindings integration-tests"
+
+#################
+# Run the tests #
+#################
+TEST_TCTI="swtpm:host=localhost,port=2321" RUST_BACKTRACE=1 RUST_LOG=info cargo test --features "generate-bindings integration-tests" --  --test-threads=1 --nocapture
+


### PR DESCRIPTION
This adds opensuse as an option for the docker integration tests. Additionally, it adds a .dockerignore file to improve build times and reduce image size.