### PR TITLE
Fix start_auth_session resource leak

### DIFF
--- a/tss-esapi/src/abstraction/ak.rs
+++ b/tss-esapi/src/abstraction/ak.rs
@@ -129,7 +129,7 @@ pub fn load_ak(
             session_attributes_mask,
         )
         .or_else(|e| {
-            ctx.flush_context(SessionHandle::from(policy_auth_session).into())?;
+            context.flush_context(SessionHandle::from(policy_auth_session).into())?;
             Err(e)
         })?;
 
@@ -194,7 +194,7 @@ pub fn create_ak<IKC: IntoKeyCustomization>(
             session_attributes_mask,
         )
         .or_else(|e| {
-            ctx.flush_context(SessionHandle::from(policy_auth_session).into())?;
+            context.flush_context(SessionHandle::from(policy_auth_session).into())?;
             Err(e)
         })?;
 

--- a/tss-esapi/src/abstraction/ak.rs
+++ b/tss-esapi/src/abstraction/ak.rs
@@ -122,11 +122,16 @@ pub fn load_ak(
         .with_decrypt(true)
         .with_encrypt(true)
         .build();
-    context.tr_sess_set_attributes(
-        policy_auth_session,
-        session_attributes,
-        session_attributes_mask,
-    )?;
+    context
+        .tr_sess_set_attributes(
+            policy_auth_session,
+            session_attributes,
+            session_attributes_mask,
+        )
+        .or_else(|e| {
+            ctx.flush_context(SessionHandle::from(policy_auth_session).into())?;
+            Err(e)
+        })?;
 
     let key_handle = context.execute_with_temporary_object(
         SessionHandle::from(policy_auth_session).into(),
@@ -182,11 +187,16 @@ pub fn create_ak<IKC: IntoKeyCustomization>(
         .with_decrypt(true)
         .with_encrypt(true)
         .build();
-    context.tr_sess_set_attributes(
-        policy_auth_session,
-        session_attributes,
-        session_attributes_mask,
-    )?;
+    context
+        .tr_sess_set_attributes(
+            policy_auth_session,
+            session_attributes,
+            session_attributes_mask,
+        )
+        .or_else(|e| {
+            ctx.flush_context(SessionHandle::from(policy_auth_session).into())?;
+            Err(e)
+        })?;
 
     context.execute_with_temporary_object(
         SessionHandle::from(policy_auth_session).into(),

--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -305,7 +305,11 @@ impl Context {
             .with_decrypt(true)
             .with_encrypt(true)
             .build();
-        self.tr_sess_set_attributes(auth_session, session_attributes, session_attributes_mask)?;
+        self.tr_sess_set_attributes(auth_session, session_attributes, session_attributes_mask)
+            .or_else(|e| {
+                ctx.flush_context(SessionHandle::from(auth_session).into())?;
+                Err(e)
+            })?;
 
         let res = self.execute_with_session(Some(auth_session), f);
 

--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -307,7 +307,7 @@ impl Context {
             .build();
         self.tr_sess_set_attributes(auth_session, session_attributes, session_attributes_mask)
             .or_else(|e| {
-                ctx.flush_context(SessionHandle::from(auth_session).into())?;
+                self.flush_context(SessionHandle::from(auth_session).into())?;
                 Err(e)
             })?;
 


### PR DESCRIPTION
The session handle returned by _start_auth_session_. If there is an error in subsequent function calls, it is best to release it immediately.