### PR TITLE
Fixes lint problems reported by Clippy in Rust 1.80.0

### DIFF
--- a/tss-esapi/build.rs
+++ b/tss-esapi/build.rs
@@ -3,6 +3,12 @@
 use semver::{Version, VersionReq};
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(hierarchy_is_esys_tr)");
+    println!("cargo:rustc-check-cfg=cfg(has_tss_base_rc_values_28_to_51)");
+    println!("cargo:rustc-check-cfg=cfg(has_tss_base_rc_values_52_to_53)");
+    println!("cargo:rustc-check-cfg=cfg(has_tpmu_sensitive_create)");
+    println!("cargo:rustc-check-cfg=cfg(has_esys_tr_get_tpm_handle)");
+
     let tss_version_string = std::env::var("DEP_TSS2_ESYS_VERSION")
         .expect("Failed to parse ENV variable DEP_TSS2_ESYS_VERSION as string");
 
@@ -11,11 +17,6 @@ fn main() {
 
     let supported_tss_version =
         VersionReq::parse("<5.0.0, >=2.3.3").expect("Failed to parse supported TSS version");
-
-    let hierarchy_is_esys_tr_req = VersionReq::parse(">=3.0.0").unwrap();
-    if hierarchy_is_esys_tr_req.matches(&tss_version) {
-        println!("cargo:rustc-cfg=hierarchy_is_esys_tr")
-    }
 
     assert!(
         supported_tss_version.matches(&tss_version),

--- a/tss-esapi/src/abstraction/transient/key_attestation.rs
+++ b/tss-esapi/src/abstraction/transient/key_attestation.rs
@@ -32,7 +32,7 @@ use std::convert::TryFrom;
 ///
 /// * it includes all the public parameters of the attested key
 /// * can be hashed (in its marshaled form) with the name hash
-/// (found by unmarshaling it) to obtain `name`
+///   (found by unmarshaling it) to obtain `name`
 pub struct MakeCredParams {
     /// TPM name of the object being attested
     pub name: Vec<u8>,
@@ -48,10 +48,8 @@ impl TransientKeyContext {
     ///
     /// # Parameters
     ///
-    /// * `object` - the object whose TPM name will be included in
-    /// the credential
-    /// * `key` - the key to be used to encrypt the secret that wraps
-    /// the credential
+    /// * `object` - the object whose TPM name will be included in the credential
+    /// * `key` - the key to be used to encrypt the secret that wraps the credential
     ///
     /// **Note**: If no `key` is given, the default Endorsement Key
     /// will be used.
@@ -88,8 +86,7 @@ impl TransientKeyContext {
     ///
     /// * `object` - the object whose TPM name is included in the credential
     /// * `key` - the key used to encrypt the secret that wraps the credential
-    /// * `credential_blob` - encrypted credential that will be returned by the
-    /// TPM
+    /// * `credential_blob` - encrypted credential that will be returned by the TPM
     /// * `secret` - encrypted secret that was used to encrypt the credential
     ///
     /// **Note**: if no `key` is given, the default Endorsement Key

--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -101,9 +101,9 @@ impl KeyMaterial {
 ///
 /// - `material` identifies the numeric value of the key object
 /// - `params` identifies the algorithm to use on the key and other relevant
-/// parameters
+///   parameters
 /// - `auth` identifies the optional authentication value to be used with the
-/// key
+///   key
 #[derive(Debug, Clone)]
 pub struct ObjectWrapper {
     pub material: KeyMaterial,
@@ -660,10 +660,10 @@ impl TransientKeyContextBuilder {
     ///
     /// # Errors
     /// * errors are returned if any method calls return an error: `Context::start_auth_session`
-    /// `Context::create_primary`, `Context::flush_context`, `Context::set_handle_auth`
-    /// or if an internal error occurs when getting random numbers from the local machine
+    ///   `Context::create_primary`, `Context::flush_context`, `Context::set_handle_auth`
+    ///   or if an internal error occurs when getting random numbers from the local machine
     /// * if the root key authentication size is given greater than 32 or if the root key size is
-    /// not 1024, 2048, 3072 or 4096, a `InvalidParam` wrapper error is returned
+    ///   not 1024, 2048, 3072 or 4096, a `InvalidParam` wrapper error is returned
     pub fn build(mut self) -> Result<TransientKeyContext> {
         if self.root_key_auth_size > 32 {
             return Err(Error::local_error(ErrorKind::WrongParamSize));

--- a/tss-esapi/src/constants/tss.rs
+++ b/tss-esapi/src/constants/tss.rs
@@ -677,7 +677,7 @@ pub use crate::tss2_esys::TSS2_BASE_RC_RSP_AUTH_FAILED; /* Authorizing the TPM r
 pub use crate::tss2_esys::TSS2_BASE_RC_TRY_AGAIN; /* Operation timed out; function must be called again to be completed */
 
 cfg_if::cfg_if! {
-    if #[cfg(has_tss_base_rc_values_28_to_51_req)] {
+    if #[cfg(has_tss_base_rc_values_28_to_51)] {
         pub use crate::tss2_esys::TSS2_BASE_RC_NO_CONFIG; /* No config is available */
         pub use crate::tss2_esys::TSS2_BASE_RC_BAD_PATH; /* The provided path is bad */
         pub use crate::tss2_esys::TSS2_BASE_RC_NOT_DELETABLE; /* The object is not deletable */
@@ -731,7 +731,7 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(has_tss_base_rc_values_52_to_53_req)] {
+    if #[cfg(has_tss_base_rc_values_52_to_53)] {
         pub use crate::tss2_esys::TSS2_BASE_RC_NOT_PROVISIONED; /* Provisioning was not executed */
         pub use crate::tss2_esys::TSS2_BASE_RC_ALREADY_PROVISIONED; /* Already provisioned */
     } else {

--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -33,10 +33,11 @@ use std::ptr::null_mut;
 ///
 /// Code safety-wise, the methods should cover the two kinds of problems that might arise:
 /// * in terms of memory safety, all parameters passed down to the TSS are verified and the library
-/// stack is then trusted to provide back valid outputs
+///   stack is then trusted to provide back valid outputs
 /// * in terms of thread safety, all methods require a mutable reference to the context object,
-/// ensuring that no two threads can use the context at the same time for an operation (barring use
-/// of `unsafe` constructs on the client side)
+///   ensuring that no two threads can use the context at the same time for an operation (barring use
+///   of `unsafe` constructs on the client side)
+///
 /// More testing and verification will be added to ensure this.
 ///
 /// For most methods, if the wrapped TSS call fails and returns a non-zero `TPM2_RC`, a
@@ -86,7 +87,7 @@ impl Context {
     ///
     /// # Errors
     /// * if either `Tss2_TctiLdr_Initiialize` or `Esys_Initialize` fail, a corresponding
-    /// Tss2ResponseCode will be returned
+    ///   Tss2ResponseCode will be returned
     pub fn new(tcti_name_conf: TctiNameConf) -> Result<Self> {
         let mut esys_context = null_mut();
 
@@ -120,7 +121,7 @@ impl Context {
     ///
     /// # Errors
     /// * if either `Tss2_TctiLdr_Initiialize` or `Esys_Initialize` fail, a corresponding
-    /// Tss2ResponseCode will be returned
+    ///   Tss2ResponseCode will be returned
     pub fn new_with_tabrmd(tabrmd_conf: TabrmdConfig) -> Result<Self> {
         Context::new(TctiNameConf::Tabrmd(tabrmd_conf))
     }

--- a/tss-esapi/src/context/general_esys_tr.rs
+++ b/tss-esapi/src/context/general_esys_tr.rs
@@ -408,7 +408,7 @@ impl Context {
     /// # Errors
     /// * if the TPM cannot serialize the handle, a TSS error is returned.
     /// * if the buffer length cannot be converted to a `usize`, an `InvalidParam`
-    /// wrapper error is returned.
+    ///   wrapper error is returned.
     ///
     /// ```rust
     /// # use tss_esapi::{
@@ -476,7 +476,7 @@ impl Context {
     /// # Errors
     /// * if the TPM cannot deserialize the buffer, a TSS error is returned.
     /// * if the buffer length cannot be converted to a `usize`, an `InvalidParam`
-    /// wrapper error is returned.
+    ///   wrapper error is returned.
     ///
     /// ```rust
     /// # use tss_esapi::{

--- a/tss-esapi/src/context/tpm_commands/capability_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/capability_commands.rs
@@ -78,7 +78,7 @@ impl Context {
     ///
     /// # Errors
     /// * if any of the public parameters is not compatible with the TPM,
-    /// an `Err` containing the specific unmarshalling error will be returned.
+    ///   an `Err` containing the specific unmarshalling error will be returned.
     pub fn test_parms(&mut self, public_parmeters: PublicParameters) -> Result<()> {
         ReturnCode::ensure_success(
             unsafe {

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -17,7 +17,7 @@ impl Context {
     ///
     /// # Errors
     /// * if conversion from `TPMS_CONTEXT` to `TpmsContext` fails, a `WrongParamSize` error will
-    /// be returned
+    ///   be returned
     pub fn context_save(&mut self, handle: ObjectHandle) -> Result<SavedTpmContext> {
         let mut context_ptr = null_mut();
         ReturnCode::ensure_success(
@@ -33,7 +33,7 @@ impl Context {
     ///
     /// # Errors
     /// * if conversion from `TpmsContext` to the native `TPMS_CONTEXT` fails, a `WrongParamSize`
-    /// error will be returned
+    ///   error will be returned
     pub fn context_load(&mut self, context: SavedTpmContext) -> Result<ObjectHandle> {
         let mut esys_loaded_handle = ObjectHandle::None.into();
         let tpm_context = context.into();

--- a/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
@@ -23,7 +23,7 @@ impl Context {
     ///
     /// # Errors
     /// * if either of the slices is larger than the maximum size of the native objects, a
-    /// `WrongParamSize` wrapper error is returned
+    ///   `WrongParamSize` wrapper error is returned
     // TODO: Fix when compacting the arguments into a struct
     #[allow(clippy::too_many_arguments)]
     pub fn create_primary(

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -111,7 +111,7 @@ impl Context {
     ///
     /// # Arguments
     /// * `pcr_selection_list` - A [PcrSelectionList] that contains pcr slots in
-    /// different banks that is going to be read.
+    ///   different banks that is going to be read.
     ///
     /// # Details
     /// The provided [PcrSelectionList] contains the pcr slots in the different

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -41,7 +41,7 @@ impl Context {
     ///
     /// # Errors
     /// * if either of the slices is larger than the maximum size of the native objects, a
-    /// `WrongParamSize` wrapper error is returned
+    ///   `WrongParamSize` wrapper error is returned
     // TODO: Fix when compacting the arguments into a struct
     #[allow(clippy::too_many_arguments)]
     pub fn create(

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -344,7 +344,7 @@ impl Context {
     ///
     /// # Errors
     /// * if any of the public parameters is not compatible with the TPM,
-    /// an `Err` containing the specific unmarshalling error will be returned.
+    ///   an `Err` containing the specific unmarshalling error will be returned.
     pub fn hmac(
         &mut self,
         handle: ObjectHandle,

--- a/tss-esapi/src/handles/tpm.rs
+++ b/tss-esapi/src/handles/tpm.rs
@@ -15,12 +15,12 @@ use std::stringify;
 /// Enum representing the different types of tpm handles
 /// of a TPM handle.
 ///
-/// * Details
+/// # Details
 /// The TPM handles are used
 /// to reference shielded locations of various
 /// types within the TPM.
 ///
-/// * OBS
+/// N.B:
 /// Do not confuse the TpmHandles with the
 /// ESYS [ObjectHandle](crate::handles::ObjectHandle).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -67,23 +67,23 @@
 //!
 //! # Notes on code safety:
 //! * thread safety is ensured by the required mutability of the `Context` structure within the
-//! methods implemented on it; thus, in an otherwise safe app commands cannot be dispatched in
-//! parallel for the same context; whether multithreading with multiple context objects is possible
-//! depends on the TCTI used and this is the responsibility of the crate client to establish.
+//!   methods implemented on it; thus, in an otherwise safe app commands cannot be dispatched in
+//!   parallel for the same context; whether multithreading with multiple context objects is possible
+//!   depends on the TCTI used and this is the responsibility of the crate client to establish.
 //! * the `unsafe` keyword is used to denote methods that could panic, crash or cause undefined
-//! behaviour. Whenever this is the case, the properties that need to be checked against
-//! parameters before passing them in will be stated in the documentation of the method.
+//!   behaviour. Whenever this is the case, the properties that need to be checked against
+//!   parameters before passing them in will be stated in the documentation of the method.
 //! * `unsafe` blocks within this crate need to be documented through code comments if they
-//! are not covered by the points of trust described here.
+//!   are not covered by the points of trust described here.
 //! * the TSS2.0 library that this crate links to is trusted to return consistent values and to
-//! not crash or lead to undefined behaviour when presented with valid arguments.
+//!   not crash or lead to undefined behaviour when presented with valid arguments.
 //! * the `Mbox` crate is trusted to perform operations safely on the pointers provided to it, if
-//! the pointers are trusted to be valid.
+//!   the pointers are trusted to be valid.
 //! * methods not marked `unsafe` are trusted to behave safely, potentially returning appropriate
-//! error messages when encountering any problems.
+//!   error messages when encountering any problems.
 //! * whenever `unwrap`, `expect`, `panic` or derivatives of these are used, they need to be
-//! thoroughly documented and justified - preferably `unwrap` and `expect` should *never* fail
-//! during normal operation.
+//!   thoroughly documented and justified - preferably `unwrap` and `expect` should *never* fail
+//!   during normal operation.
 //! * these rules can be broken in test-only code and in tests.
 //!
 //! # Logging

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -362,20 +362,19 @@ pub mod sensitive_data {
     cfg_if::cfg_if! {
         if #[cfg(has_tpmu_sensitive_create)] {
             use crate::tss2_esys::TPMU_SENSITIVE_CREATE;
-            buffer_type!(
-                SensitiveData,
-                ::std::mem::size_of::<TPMU_SENSITIVE_CREATE>(),
-                TPM2B_SENSITIVE_DATA
-            );
+            #[allow(unused_qualifications)]
+            const TPMU_SENSITIVE_CREATE_MEM_SIZE: usize = std::mem::size_of::<TPMU_SENSITIVE_CREATE>();
         } else {
             use crate::tss2_esys::UINT16;
-            buffer_type!(
-                SensitiveData,
-                std::mem::size_of::<TPM2B_SENSITIVE_DATA>() - std::mem::size_of::<UINT16>(),
-                TPM2B_SENSITIVE_DATA
-            );
+            #[allow(unused_qualifications)]
+            const TPMU_SENSITIVE_CREATE_MEM_SIZE: usize = std::mem::size_of::<TPM2B_SENSITIVE_DATA>() - std::mem::size_of::<UINT16>();
         }
     }
+    buffer_type!(
+        SensitiveData,
+        TPMU_SENSITIVE_CREATE_MEM_SIZE,
+        TPM2B_SENSITIVE_DATA
+    );
 }
 
 pub mod symmetric_key {
@@ -393,9 +392,12 @@ pub mod timeout {
 
 pub mod tpm_context_data {
     use crate::tss2_esys::TPMS_CONTEXT_DATA;
+
+    #[allow(unused_qualifications)]
+    const TPMS_CONTEXT_DATA_MEM_SIZE: usize = std::mem::size_of::<TPMS_CONTEXT_DATA>();
     buffer_type!(
         TpmContextData,
-        std::mem::size_of::<TPMS_CONTEXT_DATA>(),
+        TPMS_CONTEXT_DATA_MEM_SIZE,
         TPM2B_CONTEXT_DATA
     );
 }

--- a/tss-esapi/src/structures/buffers/public.rs
+++ b/tss-esapi/src/structures/buffers/public.rs
@@ -24,6 +24,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 pub struct PublicBuffer(Vec<u8>);
 
 impl PublicBuffer {
+    #[allow(unused_qualifications)]
     pub const MAX_SIZE: usize = std::mem::size_of::<TPMT_PUBLIC>();
 
     pub fn value(&self) -> &[u8] {

--- a/tss-esapi/src/structures/buffers/sensitive.rs
+++ b/tss-esapi/src/structures/buffers/sensitive.rs
@@ -23,6 +23,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 pub struct SensitiveBuffer(Vec<u8>);
 
 impl SensitiveBuffer {
+    #[allow(unused_qualifications)]
     pub const MAX_SIZE: usize = std::mem::size_of::<TPMT_SENSITIVE>();
 
     pub fn value(&self) -> &[u8] {

--- a/tss-esapi/src/structures/buffers/sensitive_create.rs
+++ b/tss-esapi/src/structures/buffers/sensitive_create.rs
@@ -23,6 +23,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 pub struct SensitiveCreateBuffer(Vec<u8>);
 
 impl SensitiveCreateBuffer {
+    #[allow(unused_qualifications)]
     pub const MAX_SIZE: usize = std::mem::size_of::<TPMS_SENSITIVE_CREATE>();
     pub const MIN_SIZE: usize = 4;
 

--- a/tss-esapi/src/structures/ecc/point.rs
+++ b/tss-esapi/src/structures/ecc/point.rs
@@ -49,6 +49,7 @@ impl From<EccPoint> for TPMS_ECC_POINT {
 
 impl From<EccPoint> for TPM2B_ECC_POINT {
     fn from(ecc_point: EccPoint) -> Self {
+        #[allow(unused_qualifications)]
         let size = std::mem::size_of::<u16>()
             + ecc_point.x().len()
             + std::mem::size_of::<u16>()

--- a/tss-esapi/src/structures/nv/storage/public.rs
+++ b/tss-esapi/src/structures/nv/storage/public.rs
@@ -27,6 +27,7 @@ pub struct NvPublic {
 }
 
 impl NvPublic {
+    #[allow(unused_qualifications)]
     const MAX_SIZE: usize = std::mem::size_of::<TPMS_NV_PUBLIC>();
 
     pub fn nv_index(&self) -> NvIndexTpmHandle {
@@ -172,8 +173,8 @@ impl NvPublicBuilder {
                     Error::local_error(WrapperErrorKind::ParamsMissing)
                 })
                 .and_then(|v| {
-                    if v > std::u16::MAX.into() {
-                        error!("data area size is too large (>{})", std::u16::MAX);
+                    if v > u16::MAX.into() {
+                        error!("data area size is too large (>{})", u16::MAX);
                         return Err(Error::local_error(WrapperErrorKind::InvalidParam));
                     }
                     Ok(v)

--- a/tss-esapi/src/structures/tagged/public/ecc.rs
+++ b/tss-esapi/src/structures/tagged/public/ecc.rs
@@ -130,8 +130,8 @@ impl PublicEccParametersBuilder {
     /// # Errors
     /// * if no asymmetric scheme is set, `ParamsMissing` wrapper error is returned.
     /// * if the `for_signing`, `for_decryption` and `restricted` parameters are
-    /// inconsistent with the rest of the parameters, `InconsistentParams` wrapper
-    /// error is returned
+    ///   inconsistent with the rest of the parameters, `InconsistentParams` wrapper
+    ///   error is returned
     pub fn build(self) -> Result<PublicEccParameters> {
         let ecc_scheme = self.ecc_scheme.ok_or_else(|| {
             error!("Scheme is required and has not been set in the PublicEccParametersBuilder");

--- a/tss-esapi/src/structures/tagged/public/rsa.rs
+++ b/tss-esapi/src/structures/tagged/public/rsa.rs
@@ -135,8 +135,8 @@ impl PublicRsaParametersBuilder {
     /// # Errors
     /// * if no asymmetric scheme is set, `ParamsMissing` wrapper error is returned.
     /// * if the `for_signing`, `for_decryption` and `restricted` parameters are
-    /// inconsistent with the rest of the parameters, `InconsistentParams` wrapper
-    /// error is returned
+    ///   inconsistent with the rest of the parameters, `InconsistentParams` wrapper
+    ///   error is returned
     pub fn build(self) -> Result<PublicRsaParameters> {
         let rsa_scheme = self.rsa_scheme.ok_or_else(|| {
             error!("Scheme parameter is required and has not been set in the PublicRsaParametersBuilder");


### PR DESCRIPTION
- In Rust 1.80.0 the `size_of` function is added to the preamble which causes lint errors when used with full qualifiers in the code so for that specific function the lint error has been suppressed.

- Other unused qualifiers and documentation lint errors have been fixed.

- Fixed redundant code in build.rs

- Fixed a configuration flag not being used correctly.