### PR TITLE
Fix `cargo test` compilation 

### DIFF
--- a/tss-esapi/README.md
+++ b/tss-esapi/README.md
@@ -27,6 +27,7 @@ The crate currently offers the following features:
 * `abstraction` (enabled by default) - provides a set of abstracted primitives
   on top of the basic Rust-native ESAPI API provided by the crate. This feature
   can be turned off to reduce the number of dependencies built.
+* `serde` - enable serde `Serialize`/`Deserialize` traits for types
 
 ## Cross compiling
 

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -110,6 +110,7 @@ pub mod tcti_ldr;
 pub mod traits;
 pub mod utils;
 
+#[cfg(feature = "abstraction")]
 pub use abstraction::transient::TransientKeyContext;
 pub use context::Context;
 pub use error::{Error, Result, ReturnCode, WrapperErrorKind};

--- a/tss-esapi/tests/integration_tests/abstraction_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/mod.rs
@@ -1,9 +1,13 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(feature = "abstraction")]
 mod ak_tests;
 mod ek_tests;
+#[cfg(feature = "abstraction")]
 mod nv_tests;
+#[cfg(feature = "abstraction")]
 mod pcr_data_tests;
 mod pcr_tests;
 mod public_tests;
+#[cfg(feature = "abstraction")]
 mod transient_key_context_tests;

--- a/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/pcr_tests.rs
@@ -7,6 +7,7 @@ use tss_esapi::{
     structures::{PcrSelectionListBuilder, PcrSlot},
 };
 
+#[cfg(feature = "abstraction")]
 #[test]
 fn test_pcr_read_all() {
     let mut context = create_ctx_without_session();

--- a/tss-esapi/tests/integration_tests/abstraction_tests/public_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/public_tests.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "abstraction")]
 mod public_rsa_test {
     use picky_asn1::wrapper::IntegerAsn1;
     use picky_asn1_x509::{AlgorithmIdentifier, PublicKey, SubjectPublicKeyInfo};
@@ -102,6 +103,7 @@ mod public_rsa_test {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod public_ecc_test {
     use picky_asn1::bit_string::BitString;
     use picky_asn1_x509::{AlgorithmIdentifier, EcParameters, PublicKey, SubjectPublicKeyInfo};

--- a/tss-esapi/tests/integration_tests/common/mod.rs
+++ b/tss-esapi/tests/integration_tests/common/mod.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use tss_esapi::{
-    abstraction::{cipher::Cipher, pcr::PcrData},
     attributes::ObjectAttributes,
     attributes::{NvIndexAttributesBuilder, ObjectAttributesBuilder, SessionAttributesBuilder},
     constants::SessionType,
@@ -18,19 +17,23 @@ use tss_esapi::{
         algorithm::{HashingAlgorithm, PublicAlgorithm, RsaSchemeAlgorithm},
         key_bits::RsaKeyBits,
         key_bits::{AesKeyBits, Sm4KeyBits},
-        reserved_handles::{Hierarchy, NvAuth, Provision},
-        session_handles::PolicySession,
+        reserved_handles::{NvAuth, Provision},
     },
     structures::{
         Digest, EccParameter, EccPoint, EccScheme, EccSignature, HashAgile, HashScheme, HmacScheme,
-        KeyDerivationFunctionScheme, KeyedHashScheme, MaxBuffer, MaxNvBuffer, NvPublicBuilder,
-        PcrSelectionListBuilder, PcrSlot, Public, PublicBuilder, PublicEccParameters, PublicKeyRsa,
-        PublicKeyedHashParameters, PublicRsaParameters, RsaExponent, RsaScheme, RsaSignature,
-        Sensitive, Signature, SymmetricCipherParameters, SymmetricDefinition,
-        SymmetricDefinitionObject,
+        KeyDerivationFunctionScheme, KeyedHashScheme, MaxNvBuffer, NvPublicBuilder, Public,
+        PublicBuilder, PublicEccParameters, PublicKeyRsa, PublicKeyedHashParameters,
+        PublicRsaParameters, RsaExponent, RsaScheme, RsaSignature, Sensitive, Signature,
+        SymmetricCipherParameters, SymmetricDefinition, SymmetricDefinitionObject,
     },
     tcti_ldr::TctiNameConf,
     utils, Context,
+};
+
+#[cfg(feature = "abstraction")]
+use tss_esapi::{
+    abstraction::{cipher::Cipher, pcr::PcrData},
+    interface_types::{reserved_handles::Hierarchy, session_handles::PolicySession},
 };
 
 mod marshall;
@@ -231,6 +234,7 @@ pub fn create_ctx_with_session() -> Context {
     ctx
 }
 
+#[cfg(feature = "abstraction")]
 #[allow(dead_code)]
 pub fn decryption_key_pub() -> Public {
     utils::create_restricted_decryption_rsa_public(
@@ -263,6 +267,7 @@ pub fn signing_key_pub() -> Public {
     .expect("Failed to create an unrestricted signing rsa public structure")
 }
 
+#[cfg(feature = "abstraction")]
 #[allow(dead_code)]
 pub fn get_pcr_policy_digest(
     context: &mut Context,

--- a/tss-esapi/tests/integration_tests/common/mod.rs
+++ b/tss-esapi/tests/integration_tests/common/mod.rs
@@ -34,12 +34,14 @@ use tss_esapi::{
 };
 
 mod marshall;
+#[cfg(feature = "serde")]
 mod serde;
 mod tpm2b_types_equality_checks;
 mod tpma_types_equality_checks;
 mod tpml_types_equality_checks;
 mod tpms_types_equality_checks;
 mod tpmt_types_equality_checks;
+#[cfg(feature = "serde")]
 pub use self::serde::*;
 pub use marshall::*;
 pub use tpm2b_types_equality_checks::*;

--- a/tss-esapi/tests/integration_tests/context_tests/general_esys_tr_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/general_esys_tr_tests.rs
@@ -1,17 +1,29 @@
-use crate::common::{create_ctx_with_session, create_ctx_without_session, decryption_key_pub};
+use crate::common::create_ctx_without_session;
+
+#[cfg(feature = "abstraction")]
+use crate::common::{create_ctx_with_session, decryption_key_pub};
+
 use tss_esapi::{
     attributes::NvIndexAttributesBuilder,
     constants::{tss::TPM2_NV_INDEX_FIRST, CapabilityType},
-    handles::{NvIndexHandle, NvIndexTpmHandle, ObjectHandle, PersistentTpmHandle, TpmHandle},
+    handles::{NvIndexHandle, NvIndexTpmHandle, ObjectHandle},
     interface_types::{
         algorithm::HashingAlgorithm,
-        data_handles::Persistent,
-        reserved_handles::{Hierarchy, NvAuth, Provision},
+        reserved_handles::{NvAuth, Provision},
         session_handles::AuthSession,
     },
     structures::{Auth, CapabilityData, MaxNvBuffer, NvPublicBuilder},
     tss2_esys::TPM2_HANDLE,
-    Context, Error,
+    Context,
+};
+
+#[cfg(feature = "abstraction")]
+use tss_esapi::{
+    handles::{PersistentTpmHandle, TpmHandle},
+    interface_types::{data_handles::Persistent, reserved_handles::Hierarchy},
+    structures::{Auth, CapabilityData, MaxNvBuffer, NvPublicBuilder},
+    tss2_esys::TPM2_HANDLE,
+    Error,
 };
 
 use std::convert::TryFrom;
@@ -449,6 +461,7 @@ mod test_tr_from_tpm_public {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_tr_serialize_tr_deserialize {
     use super::*;
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
@@ -1,21 +1,26 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod test_quote {
-    use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
+    use crate::common::{create_ctx_with_session, signing_key_pub};
+
+    #[cfg(feature = "abstraction")]
+    use crate::common::decryption_key_pub;
+
     use std::convert::TryFrom;
+    use tss_esapi::{
+        interface_types::{
+            algorithm::HashingAlgorithm, reserved_handles::Hierarchy,
+            structure_tags::AttestationType,
+        },
+        structures::{AttestInfo, Data, PcrSelectionListBuilder, PcrSlot, SignatureScheme},
+    };
+
+    #[cfg(feature = "abstraction")]
     use tss_esapi::{
         constants::StructureTag,
         handles::KeyHandle,
-        interface_types::{
-            algorithm::{HashingAlgorithm, SignatureSchemeAlgorithm},
-            reserved_handles::Hierarchy,
-            session_handles::AuthSession,
-            structure_tags::AttestationType,
-        },
-        structures::{
-            AttestInfo, Data, HashScheme, MaxBuffer, PcrSelectionListBuilder, PcrSlot,
-            SignatureScheme, Ticket,
-        },
+        interface_types::{algorithm::SignatureSchemeAlgorithm, session_handles::AuthSession},
+        structures::{HashScheme, MaxBuffer, Ticket},
         traits::Marshall,
     };
 
@@ -65,6 +70,7 @@ mod test_quote {
         }
     }
 
+    #[cfg(feature = "abstraction")]
     #[test]
     fn certify() {
         let mut context = create_ctx_with_session();
@@ -126,6 +132,7 @@ mod test_quote {
         assert_eq!(attest.extra_data().as_bytes(), qualifying_data);
     }
 
+    #[cfg(feature = "abstraction")]
     #[test]
     fn certify_null() {
         let mut context = create_ctx_with_session();
@@ -167,6 +174,7 @@ mod test_quote {
         assert_eq!(signature.algorithm(), SignatureSchemeAlgorithm::Null);
     }
 
+    #[cfg(feature = "abstraction")]
     #[test]
     fn certify_creation() {
         let mut context = create_ctx_with_session();

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
@@ -1,7 +1,11 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod test_ctx_save {
-    use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
+    use crate::common::{create_ctx_with_session, signing_key_pub};
+
+    #[cfg(feature = "abstraction")]
+    use crate::common::decryption_key_pub;
+
     use tss_esapi::{interface_types::reserved_handles::Hierarchy, structures::Auth};
 
     #[test]
@@ -25,6 +29,7 @@ mod test_ctx_save {
         let _ = context.context_save(key_handle.into()).unwrap();
     }
 
+    #[cfg(feature = "abstraction")]
     #[test]
     fn test_ctx_save_leaf() {
         let mut context = create_ctx_with_session();
@@ -63,6 +68,7 @@ mod test_ctx_save {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_ctx_load {
     use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
     use tss_esapi::{
@@ -109,7 +115,11 @@ mod test_ctx_load {
 }
 
 mod test_flush_context {
-    use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
+    use crate::common::{create_ctx_with_session, signing_key_pub};
+
+    #[cfg(feature = "abstraction")]
+    use crate::common::decryption_key_pub;
+
     use tss_esapi::{interface_types::reserved_handles::Hierarchy, structures::Auth};
 
     #[test]
@@ -134,6 +144,7 @@ mod test_flush_context {
         assert!(context.read_public(key_handle).is_err());
     }
 
+    #[cfg(feature = "abstraction")]
     #[test]
     fn test_flush_parent_ctx() {
         let mut context = create_ctx_with_session();
@@ -172,6 +183,7 @@ mod test_flush_context {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_evict_control {
     use crate::common::{create_ctx_without_session, decryption_key_pub};
     use std::convert::TryFrom;

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -138,6 +138,7 @@ mod test_policy_secret {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_policy_or {
     use crate::common::{create_ctx_without_session, get_pcr_policy_digest};
     use std::convert::TryFrom;
@@ -190,6 +191,7 @@ mod test_policy_or {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_policy_pcr {
     use crate::common::create_ctx_without_session;
     use std::convert::TryFrom;
@@ -525,6 +527,7 @@ mod test_policy_name_hash {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_policy_authorize {
     use crate::common::{create_ctx_with_session, get_pcr_policy_digest, signing_key_pub};
     use std::convert::TryFrom;
@@ -675,6 +678,7 @@ mod test_policy_password {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_policy_get_digest {
     use crate::common::create_ctx_without_session;
     use std::convert::TryFrom;

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(feature = "abstraction")]
 mod test_create_primary {
     use crate::common::{create_ctx_with_session, decryption_key_pub};
     use tss_esapi::{
@@ -56,13 +57,16 @@ mod test_clear_control {
 }
 
 mod test_change_auth {
-    use crate::common::{create_ctx_with_session, decryption_key_pub};
-    use tss_esapi::{
-        handles::AuthHandle, interface_types::reserved_handles::Hierarchy, structures::Auth,
-    };
+    use crate::common::create_ctx_with_session;
 
+    use tss_esapi::{handles::AuthHandle, structures::Auth};
+
+    #[cfg(feature = "abstraction")]
     #[test]
     fn test_object_change_auth() {
+        use crate::common::decryption_key_pub;
+        use tss_esapi::interface_types::reserved_handles::Hierarchy;
+
         let mut context = create_ctx_with_session();
 
         let prim_key_handle = context

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(feature = "abstraction")]
 mod test_pcr_extend_reset {
     use crate::common::create_ctx_with_session;
     use std::convert::TryFrom;

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/object_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/object_commands_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(feature = "abstraction")]
 mod test_create {
     use crate::common::{create_ctx_with_session, decryption_key_pub};
     use tss_esapi::{interface_types::reserved_handles::Hierarchy, structures::Auth};
@@ -36,6 +37,7 @@ mod test_create {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_load {
     use crate::common::{create_ctx_with_session, decryption_key_pub, signing_key_pub};
     use tss_esapi::{interface_types::reserved_handles::Hierarchy, structures::Auth};
@@ -256,6 +258,7 @@ mod test_read_public {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_make_credential {
     use crate::common::{create_ctx_with_session, decryption_key_pub};
     use std::convert::TryInto;
@@ -289,6 +292,7 @@ mod test_make_credential {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_activate_credential {
     use crate::common::{create_ctx_with_session, decryption_key_pub};
     use std::convert::{TryFrom, TryInto};
@@ -374,6 +378,7 @@ mod test_activate_credential {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_unseal {
     use crate::common::{create_ctx_with_session, create_public_sealed_object, decryption_key_pub};
     use std::convert::TryFrom;

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/session_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/session_commands_tests.rs
@@ -1,14 +1,21 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod test_start_auth_session {
-    use crate::common::{create_ctx_with_session, create_ctx_without_session, decryption_key_pub};
+    use crate::common::create_ctx_without_session;
+
+    #[cfg(feature = "abstraction")]
+    use crate::common::{create_ctx_with_session, decryption_key_pub};
+
     use std::convert::TryFrom;
     use tss_esapi::{
         attributes::SessionAttributesBuilder,
         constants::SessionType,
-        interface_types::{algorithm::HashingAlgorithm, reserved_handles::Hierarchy},
+        interface_types::algorithm::HashingAlgorithm,
         structures::{Nonce, SymmetricDefinition},
     };
+
+    #[cfg(feature = "abstraction")]
+    use tss_esapi::interface_types::reserved_handles::Hierarchy;
 
     #[test]
     fn test_simple_sess() {
@@ -48,6 +55,7 @@ mod test_start_auth_session {
             .unwrap();
     }
 
+    #[cfg(feature = "abstraction")]
     #[test]
     fn test_bound_sess() {
         let mut context = create_ctx_with_session();
@@ -140,6 +148,7 @@ mod test_start_auth_session {
     }
 }
 
+#[cfg(feature = "abstraction")]
 mod test_policy_restart {
     use crate::common::{create_ctx_without_session, get_pcr_policy_digest};
     use std::convert::TryFrom;

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/symmetric_primitives_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/symmetric_primitives_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(feature = "abstraction")]
 mod test_encrypt_decrypt_2 {
     use crate::common::create_ctx_without_session;
     use std::convert::{TryFrom, TryInto};

--- a/tss-esapi/tests/integration_tests/error_tests/return_code_tests/esapi_tests.rs
+++ b/tss-esapi/tests/integration_tests/error_tests/return_code_tests/esapi_tests.rs
@@ -1,10 +1,11 @@
 // Copyright 2022 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.
 
+#[cfg(feature = "abstraction")]
 use crate::common::{create_ctx_with_session, decryption_key_pub};
+
 use std::convert::TryFrom;
 use tss_esapi::{
-    attributes::SessionAttributesBuilder,
     constants::{
         tss::{
             TSS2_BASE_RC_ABI_MISMATCH, TSS2_BASE_RC_BAD_CONTEXT, TSS2_BASE_RC_BAD_REFERENCE,
@@ -17,13 +18,19 @@ use tss_esapi::{
             TSS2_BASE_RC_NO_DECRYPT_PARAM, TSS2_BASE_RC_NO_ENCRYPT_PARAM, TSS2_BASE_RC_TRY_AGAIN,
             TSS2_ESYS_RC_LAYER,
         },
-        BaseError, SessionType,
+        BaseError,
     },
     error::{BaseReturnCode, EsapiReturnCode, ReturnCode},
-    interface_types::{algorithm::HashingAlgorithm, reserved_handles::Hierarchy},
-    structures::{Auth, SymmetricDefinition},
     tss2_esys::TSS2_RC,
     Error, WrapperErrorKind,
+};
+
+#[cfg(feature = "abstraction")]
+use tss_esapi::{
+    attributes::SessionAttributesBuilder,
+    constants::SessionType,
+    interface_types::{algorithm::HashingAlgorithm, reserved_handles::Hierarchy},
+    structures::{Auth, SymmetricDefinition},
 };
 
 macro_rules! test_valid_conversion {
@@ -128,6 +135,7 @@ fn test_invalid_conversions() {
     );
 }
 
+#[cfg(feature = "abstraction")]
 #[test]
 fn test_esapi_error_from_context_method() {
     let mut context = create_ctx_with_session();

--- a/tss-esapi/tests/integration_tests/main.rs
+++ b/tss-esapi/tests/integration_tests/main.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(feature = "integration-tests")]
+
 #[path = "common/mod.rs"]
 mod common;
 

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/private.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/private.rs
@@ -12,6 +12,7 @@ fn marshall_unmarshall() {
 }
 
 #[test]
+#[cfg(feature = "serde")]
 fn serialise_deserialise() {
     crate::common::check_serialise_deserialise(&Private::default());
     let private = Private::try_from([0xff; 100].to_vec()).unwrap();

--- a/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/public.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/tagged_tests/public.rs
@@ -15,6 +15,7 @@ fn marshall_unmarshall() {
 }
 
 #[test]
+#[cfg(feature = "serde")]
 fn serialise_deserialise() {
     crate::common::publics()
         .iter()


### PR DESCRIPTION
If "serde" or "abstraction" features were not set, then the tests would not compile