### PR TITLE
Fixes problem with running tests needing features to be specified.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["tss-esapi", "tss-esapi-sys"]
+resolver = "2"

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -15,9 +15,15 @@ rust-version = "1.66.0"
 [[example]]
 name = "hmac"
 
+[[example]]
+name = "certify"
+required-features = ["abstraction"]
+
 [dependencies]
 bitfield = "0.14"
-serde = { version = "1.0.115", features = ["derive"], optional = true, default-features = false }
+serde = { version = "1.0.115", features = [
+    "derive",
+], optional = true, default-features = false }
 malloced = "1.3.1"
 log = "0.4.11"
 enumflags2 = "0.7.7"
@@ -40,6 +46,12 @@ getrandom = "0.2.11"
 env_logger = "0.9.0"
 sha2 = "0.10.1"
 serde_json = "^1.0.108"
+tss-esapi = { path = ".", features = [
+    "integration-tests",
+    "serde",
+    "abstraction",
+] }
+
 
 [build-dependencies]
 semver = "1.0.7"

--- a/tss-esapi/README.md
+++ b/tss-esapi/README.md
@@ -27,6 +27,7 @@ The crate currently offers the following features:
 * `abstraction` (enabled by default) - provides a set of abstracted primitives
   on top of the basic Rust-native ESAPI API provided by the crate. This feature
   can be turned off to reduce the number of dependencies built.
+* `serde` - enable serde `Serialize`/`Deserialize` traits for types. 
 
 ## Cross compiling
 

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -109,7 +109,7 @@ pub mod structures;
 pub mod tcti_ldr;
 pub mod traits;
 pub mod utils;
-
+#[cfg(feature = "abstraction")]
 pub use abstraction::transient::TransientKeyContext;
 pub use context::Context;
 pub use error::{Error, Result, ReturnCode, WrapperErrorKind};

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/symmetric_primitives_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/symmetric_primitives_tests.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 mod test_encrypt_decrypt_2 {
     use crate::common::create_ctx_without_session;
-    use std::convert::{TryFrom, TryInto};
+    use std::convert::TryFrom;
     use tss_esapi::{
-        abstraction::cipher::Cipher,
         attributes::ObjectAttributesBuilder,
         interface_types::{
             algorithm::{HashingAlgorithm, PublicAlgorithm, SymmetricMode},
@@ -14,7 +13,7 @@ mod test_encrypt_decrypt_2 {
         },
         structures::{
             Auth, InitialValue, MaxBuffer, PublicBuilder, RsaExponent, SensitiveData,
-            SymmetricCipherParameters,
+            SymmetricCipherParameters, SymmetricDefinitionObject,
         },
     };
     #[test]
@@ -34,9 +33,7 @@ mod test_encrypt_decrypt_2 {
             ctx.create_primary(
                 Hierarchy::Owner,
                 tss_esapi::utils::create_restricted_decryption_rsa_public(
-                    Cipher::aes_128_cfb()
-                        .try_into()
-                        .expect("Failed to convert from Cipher"),
+                    SymmetricDefinitionObject::AES_128_CFB,
                     RsaKeyBits::Rsa2048,
                     RsaExponent::default(),
                 )
@@ -66,9 +63,7 @@ mod test_encrypt_decrypt_2 {
             .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
             .with_object_attributes(symmetric_key_object_attributes)
             .with_symmetric_cipher_parameters(SymmetricCipherParameters::new(
-                Cipher::aes_128_cfb()
-                    .try_into()
-                    .expect("Failed to create symmteric cipher parameters from cipher"),
+                SymmetricDefinitionObject::AES_128_CFB,
             ))
             .with_symmetric_cipher_unique_identifier(Default::default())
             .build()


### PR DESCRIPTION
This PR builds upon the work made in #539 and #538 and fixes a problem with running tests required
several features to be specified in order for the
tests to compile.

This has been accomplish by doing the following:
1. Tests have been refactored in order to avoid dependency on features that may and may not be available.
2. Updated workspace Cargo.toml to use version 2 resolver.
3. Updated tss-esapi Cargo.toml to use the crate it self as dev-dependency with most of the features enabled.