### PR TITLE
Fixest lint errors for the 7.x.y branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,7 +422,7 @@
 **Implemented enhancements:**
 
 - Add evict\_control API to context [\#135](https://github.com/parallaxsecond/rust-tss-esapi/issues/135)
-- Depoly Session [\#126](https://github.com/parallaxsecond/rust-tss-esapi/issues/126)
+- Deploy Session [\#126](https://github.com/parallaxsecond/rust-tss-esapi/issues/126)
 - No private key analog to `load\_external\_rsa\_public\_key` [\#123](https://github.com/parallaxsecond/rust-tss-esapi/issues/123)
 - Have two builds with two different TSS lib versions in CI [\#110](https://github.com/parallaxsecond/rust-tss-esapi/issues/110)
 - Split between tss-esapi and tss-esapi-sys [\#75](https://github.com/parallaxsecond/rust-tss-esapi/issues/75)

--- a/tss-esapi/src/abstraction/pcr/data.rs
+++ b/tss-esapi/src/abstraction/pcr/data.rs
@@ -101,6 +101,12 @@ impl PcrData {
     }
 }
 
+impl Default for PcrData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl IntoIterator for PcrData {
     type Item = (HashingAlgorithm, PcrBank);
     type IntoIter = ::std::vec::IntoIter<(HashingAlgorithm, PcrBank)>;

--- a/tss-esapi/src/abstraction/transient/key_attestation.rs
+++ b/tss-esapi/src/abstraction/transient/key_attestation.rs
@@ -31,7 +31,7 @@ use std::convert::TryFrom;
 ///
 /// * it includes all the public parameters of the attested key
 /// * can be hashed (in its marshaled form) with the name hash
-/// (found by unmarshaling it) to obtain `name`
+///   (found by unmarshaling it) to obtain `name`
 pub struct MakeCredParams {
     /// TPM name of the object being attested
     pub name: Vec<u8>,
@@ -47,10 +47,8 @@ impl TransientKeyContext {
     ///
     /// # Parameters
     ///
-    /// * `object` - the object whose TPM name will be included in
-    /// the credential
-    /// * `key` - the key to be used to encrypt the secret that wraps
-    /// the credential
+    /// * `object` - the object whose TPM name will be included in the credential
+    /// * `key` - the key to be used to encrypt the secret that wraps the credential
     ///
     /// **Note**: If no `key` is given, the default Endorsement Key
     /// will be used.  
@@ -87,8 +85,7 @@ impl TransientKeyContext {
     ///
     /// * `object` - the object whose TPM name is included in the credential
     /// * `key` - the key used to encrypt the secret that wraps the credential
-    /// * `credential_blob` - encrypted credential that will be returned by the
-    /// TPM
+    /// * `credential_blob` - encrypted credential that will be returned by the TPM
     /// * `secret` - encrypted secret that was used to encrypt the credential
     ///
     /// **Note**: if no `key` is given, the default Endorsement Key

--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -95,10 +95,8 @@ impl KeyMaterial {
 /// Structure containing all the defining elements of a TPM key
 ///
 /// - `material` identifies the numeric value of the key object
-/// - `params` identifies the algorithm to use on the key and other relevant
-/// parameters
-/// - `auth` identifies the optional authentication value to be used with the
-/// key
+/// - `params` identifies the algorithm to use on the key and other relevant parameters
+/// - `auth` identifies the optional authentication value to be used with the key
 #[derive(Debug, Clone)]
 pub struct ObjectWrapper {
     pub material: KeyMaterial,
@@ -662,10 +660,10 @@ impl TransientKeyContextBuilder {
     ///
     /// # Errors
     /// * errors are returned if any method calls return an error: `Context::start_auth_session`
-    /// `Context::create_primary`, `Context::flush_context`, `Context::set_handle_auth`
-    /// or if an internal error occurs when getting random numbers from the local machine
+    ///   `Context::create_primary`, `Context::flush_context`, `Context::set_handle_auth`
+    ///   or if an internal error occurs when getting random numbers from the local machine
     /// * if the root key authentication size is given greater than 32 or if the root key size is
-    /// not 1024, 2048, 3072 or 4096, a `InvalidParam` wrapper error is returned
+    ///   not 1024, 2048, 3072 or 4096, a `InvalidParam` wrapper error is returned
     pub fn build(mut self) -> Result<TransientKeyContext> {
         if self.root_key_auth_size > 32 {
             return Err(Error::local_error(ErrorKind::WrongParamSize));

--- a/tss-esapi/src/attributes/command_code.rs
+++ b/tss-esapi/src/attributes/command_code.rs
@@ -143,3 +143,9 @@ impl CommandCodeAttributesBuilder {
         self.command_code_attributes.0.try_into()
     }
 }
+
+impl Default for CommandCodeAttributesBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tss-esapi/src/attributes/locality.rs
+++ b/tss-esapi/src/attributes/locality.rs
@@ -125,3 +125,9 @@ impl LocalityAttributesBuilder {
         Ok(locality_attributes)
     }
 }
+
+impl Default for LocalityAttributesBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -33,11 +33,11 @@ use std::ptr::null_mut;
 ///
 /// Code safety-wise, the methods should cover the two kinds of problems that might arise:
 /// * in terms of memory safety, all parameters passed down to the TSS are verified and the library
-/// stack is then trusted to provide back valid outputs
+///   stack is then trusted to provide back valid outputs
 /// * in terms of thread safety, all methods require a mutable reference to the context object,
-/// ensuring that no two threads can use the context at the same time for an operation (barring use
-/// of `unsafe` constructs on the client side)
-/// More testing and verification will be added to ensure this.
+///   ensuring that no two threads can use the context at the same time for an operation (barring use
+///   of `unsafe` constructs on the client side)
+///   More testing and verification will be added to ensure this.
 ///
 /// For most methods, if the wrapped TSS call fails and returns a non-zero `TPM2_RC`, a
 /// corresponding `Tss2ResponseCode` will be created and returned as an `Error`. Wherever this is
@@ -86,7 +86,7 @@ impl Context {
     ///
     /// # Errors
     /// * if either `Tss2_TctiLdr_Initiialize` or `Esys_Initialize` fail, a corresponding
-    /// Tss2ResponseCode will be returned
+    ///   Tss2ResponseCode will be returned
     pub fn new(tcti_name_conf: TctiNameConf) -> Result<Self> {
         let mut esys_context = null_mut();
 
@@ -122,7 +122,7 @@ impl Context {
     ///
     /// # Errors
     /// * if either `Tss2_TctiLdr_Initiialize` or `Esys_Initialize` fail, a corresponding
-    /// Tss2ResponseCode will be returned
+    ///   Tss2ResponseCode will be returned
     pub fn new_with_tabrmd(tabrmd_conf: TabrmdConfig) -> Result<Self> {
         Context::new(TctiNameConf::Tabrmd(tabrmd_conf))
     }

--- a/tss-esapi/src/context/tpm_commands/capability_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/capability_commands.rs
@@ -79,7 +79,7 @@ impl Context {
     ///
     /// # Errors
     /// * if any of the public parameters is not compatible with the TPM,
-    /// an `Err` containing the specific unmarshalling error will be returned.
+    ///   an `Err` containing the specific unmarshalling error will be returned.
     pub fn test_parms(&mut self, public_parmeters: PublicParameters) -> Result<()> {
         let ret = unsafe {
             Esys_TestParms(

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -17,7 +17,7 @@ impl Context {
     ///
     /// # Errors
     /// * if conversion from `TPMS_CONTEXT` to `TpmsContext` fails, a `WrongParamSize` error will
-    /// be returned
+    ///   be returned
     pub fn context_save(&mut self, handle: ObjectHandle) -> Result<TpmsContext> {
         let mut context_ptr = null_mut();
         let ret = unsafe { Esys_ContextSave(self.mut_context(), handle.into(), &mut context_ptr) };
@@ -34,7 +34,7 @@ impl Context {
     ///
     /// # Errors
     /// * if conversion from `TpmsContext` to the native `TPMS_CONTEXT` fails, a `WrongParamSize`
-    /// error will be returned
+    ///   error will be returned
     pub fn context_load(&mut self, context: TpmsContext) -> Result<ObjectHandle> {
         let mut loaded_handle = ObjectHandle::None.into();
         let ret = unsafe {

--- a/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
@@ -15,8 +15,11 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use std::convert::{TryFrom, TryInto};
-use std::ptr::null_mut;
+use std::{
+    convert::{TryFrom, TryInto},
+    mem::size_of,
+    ptr::null_mut,
+};
 
 impl Context {
     /// Create a primary key and return the handle.
@@ -26,7 +29,7 @@ impl Context {
     ///
     /// # Errors
     /// * if either of the slices is larger than the maximum size of the native objects, a
-    /// `WrongParamSize` wrapper error is returned
+    ///   `WrongParamSize` wrapper error is returned
     // TODO: Fix when compacting the arguments into a struct
     #[allow(clippy::too_many_arguments)]
     pub fn create_primary(
@@ -39,9 +42,7 @@ impl Context {
         creation_pcrs: Option<PcrSelectionList>,
     ) -> Result<CreatePrimaryKeyResult> {
         let sensitive_create = TPM2B_SENSITIVE_CREATE {
-            size: std::mem::size_of::<TPMS_SENSITIVE_CREATE>()
-                .try_into()
-                .unwrap(),
+            size: size_of::<TPMS_SENSITIVE_CREATE>().try_into().unwrap(),
             sensitive: TPMS_SENSITIVE_CREATE {
                 userAuth: auth_value.unwrap_or_default().into(),
                 data: initial_data.unwrap_or_default().into(),

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -114,7 +114,7 @@ impl Context {
     ///
     /// # Arguments
     /// * `pcr_selection_list` - A [PcrSelectionList] that contains pcr slots in
-    /// different banks that is going to be read.
+    ///   different banks that is going to be read.
     ///
     /// # Details
     /// The provided [PcrSelectionList] contains the pcr slots in the different

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -16,8 +16,11 @@ use crate::{
     Context, Error, Result,
 };
 use log::error;
-use std::convert::{TryFrom, TryInto};
-use std::ptr::{null, null_mut};
+use std::{
+    convert::{TryFrom, TryInto},
+    mem::size_of,
+    ptr::{null, null_mut},
+};
 
 impl Context {
     /// Create a key and return the handle.
@@ -37,7 +40,7 @@ impl Context {
     ///
     /// # Errors
     /// * if either of the slices is larger than the maximum size of the native objects, a
-    /// `WrongParamSize` wrapper error is returned
+    ///   `WrongParamSize` wrapper error is returned
     // TODO: Fix when compacting the arguments into a struct
     #[allow(clippy::too_many_arguments)]
     pub fn create(
@@ -50,9 +53,8 @@ impl Context {
         creation_pcrs: Option<PcrSelectionList>,
     ) -> Result<CreateKeyResult> {
         let sensitive_create = TPM2B_SENSITIVE_CREATE {
-            size: std::mem::size_of::<TPMS_SENSITIVE_CREATE>()
-                .try_into()
-                .unwrap(), // will not fail on targets of at least 16 bits
+            #[allow(unused_qualifications)]
+            size: size_of::<TPMS_SENSITIVE_CREATE>().try_into().unwrap(), // will not fail on targets of at least 16 bits
             sensitive: TPMS_SENSITIVE_CREATE {
                 userAuth: auth_value.unwrap_or_default().into(),
                 data: sensitive_data.unwrap_or_default().into(),
@@ -146,6 +148,7 @@ impl Context {
     ) -> Result<KeyHandle> {
         let mut object_handle = ObjectHandle::None.into();
         let ret = unsafe {
+            #[allow(unexpected_cfgs)]
             Esys_LoadExternal(
                 self.mut_context(),
                 self.optional_session_1(),
@@ -183,6 +186,7 @@ impl Context {
     ) -> Result<KeyHandle> {
         let mut object_handle = ObjectHandle::None.into();
         let ret = unsafe {
+            #[allow(unexpected_cfgs)]
             Esys_LoadExternal(
                 self.mut_context(),
                 self.optional_session_1(),

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -268,6 +268,7 @@ impl Context {
         let mut out_hash_ptr = null_mut();
         let mut validation_ptr = null_mut();
         let ret = unsafe {
+            #[allow(unexpected_cfgs)]
             Esys_Hash(
                 self.mut_context(),
                 self.optional_session_1(),
@@ -345,7 +346,7 @@ impl Context {
     ///
     /// # Errors
     /// * if any of the public parameters is not compatible with the TPM,
-    /// an `Err` containing the specific unmarshalling error will be returned.
+    ///   an `Err` containing the specific unmarshalling error will be returned.
     pub fn hmac(
         &mut self,
         handle: ObjectHandle,

--- a/tss-esapi/src/handles/tpm.rs
+++ b/tss-esapi/src/handles/tpm.rs
@@ -15,12 +15,12 @@ use std::stringify;
 /// Enum representing the different types of tpm handles
 /// of a TPM handle.
 ///
-/// * Details
+/// # Details
 /// The TPM handles are used
 /// to reference shielded locations of various
 /// types within the TPM.
 ///
-/// * OBS
+/// N.B:
 /// Do not confuse the TpmHandles with the
 /// ESYS [ObjectHandle](crate::handles::ObjectHandle).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -61,23 +61,23 @@
 //!
 //! # Notes on code safety:
 //! * thread safety is ensured by the required mutability of the `Context` structure within the
-//! methods implemented on it; thus, in an otherwise safe app commands cannot be dispatched in
-//! parallel for the same context; whether multithreading with multiple context objects is possible
-//! depends on the TCTI used and this is the responsibility of the crate client to establish.
+//!   methods implemented on it; thus, in an otherwise safe app commands cannot be dispatched in
+//!   parallel for the same context; whether multithreading with multiple context objects is possible
+//!   depends on the TCTI used and this is the responsibility of the crate client to establish.
 //! * the `unsafe` keyword is used to denote methods that could panic, crash or cause undefined
-//! behaviour. Whenever this is the case, the properties that need to be checked against
-//! parameters before passing them in will be stated in the documentation of the method.
+//!   behaviour. Whenever this is the case, the properties that need to be checked against
+//!   parameters before passing them in will be stated in the documentation of the method.
 //! * `unsafe` blocks within this crate need to be documented through code comments if they
-//! are not covered by the points of trust described here.
+//!   are not covered by the points of trust described here.
 //! * the TSS2.0 library that this crate links to is trusted to return consistent values and to
-//! not crash or lead to undefined behaviour when presented with valid arguments.
+//!   not crash or lead to undefined behaviour when presented with valid arguments.
 //! * the `Mbox` crate is trusted to perform operations safely on the pointers provided to it, if
-//! the pointers are trusted to be valid.
+//!   the pointers are trusted to be valid.
 //! * methods not marked `unsafe` are trusted to behave safely, potentially returning appropriate
-//! error messages when encountering any problems.
+//!   error messages when encountering any problems.
 //! * whenever `unwrap`, `expect`, `panic` or derivatives of these are used, they need to be
-//! thoroughly documented and justified - preferably `unwrap` and `expect` should *never* fail
-//! during normal operation.
+//!   thoroughly documented and justified - preferably `unwrap` and `expect` should *never* fail
+//!   during normal operation.
 //! * these rules can be broken in test-only code and in tests.
 //!
 //! # Logging

--- a/tss-esapi/src/structures/attestation/attest.rs
+++ b/tss-esapi/src/structures/attestation/attest.rs
@@ -10,7 +10,10 @@ use crate::{
     Error, Result, WrapperErrorKind,
 };
 use log::error;
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    mem::size_of,
+};
 
 /// Type for holding attestation data
 ///
@@ -119,7 +122,7 @@ impl TryFrom<TPMS_ATTEST> for Attest {
 }
 
 impl Marshall for Attest {
-    const BUFFER_SIZE: usize = std::mem::size_of::<TPMS_ATTEST>();
+    const BUFFER_SIZE: usize = size_of::<TPMS_ATTEST>();
 
     /// Produce a marshalled [`TPMS_ATTEST`]
     fn marshall(&self) -> Result<Vec<u8>> {

--- a/tss-esapi/src/structures/buffers/public.rs
+++ b/tss-esapi/src/structures/buffers/public.rs
@@ -10,6 +10,7 @@ use crate::{
 use log::error;
 use std::{
     convert::{TryFrom, TryInto},
+    mem::size_of,
     ops::Deref,
 };
 use zeroize::Zeroize;
@@ -25,7 +26,8 @@ use zeroize::Zeroize;
 pub struct PublicBuffer(Vec<u8>);
 
 impl PublicBuffer {
-    pub const MAX_SIZE: usize = std::mem::size_of::<TPMT_PUBLIC>();
+    #[allow(unused_qualifications)]
+    pub const MAX_SIZE: usize = size_of::<TPMT_PUBLIC>();
 
     pub fn value(&self) -> &[u8] {
         &self.0
@@ -117,7 +119,7 @@ impl TryFrom<Public> for PublicBuffer {
 }
 
 impl Marshall for PublicBuffer {
-    const BUFFER_SIZE: usize = std::mem::size_of::<TPM2B_PUBLIC>();
+    const BUFFER_SIZE: usize = size_of::<TPM2B_PUBLIC>();
 
     /// Produce a marshalled [`TPM2B_PUBLIC`]
     fn marshall(&self) -> Result<Vec<u8>> {

--- a/tss-esapi/src/structures/buffers/sensitive.rs
+++ b/tss-esapi/src/structures/buffers/sensitive.rs
@@ -9,6 +9,7 @@ use crate::{
 use log::error;
 use std::{
     convert::{TryFrom, TryInto},
+    mem::size_of,
     ops::Deref,
 };
 use zeroize::Zeroize;
@@ -24,7 +25,7 @@ use zeroize::Zeroize;
 pub struct SensitiveBuffer(Vec<u8>);
 
 impl SensitiveBuffer {
-    pub const MAX_SIZE: usize = std::mem::size_of::<TPMT_SENSITIVE>();
+    pub const MAX_SIZE: usize = size_of::<TPMT_SENSITIVE>();
 
     pub fn value(&self) -> &[u8] {
         &self.0
@@ -116,7 +117,7 @@ impl TryFrom<Sensitive> for SensitiveBuffer {
 }
 
 impl Marshall for SensitiveBuffer {
-    const BUFFER_SIZE: usize = std::mem::size_of::<TPM2B_SENSITIVE>();
+    const BUFFER_SIZE: usize = size_of::<TPM2B_SENSITIVE>();
 
     /// Produce a marshalled [`TPM2B_SENSITIVE`]
     fn marshall(&self) -> Result<Vec<u8>> {

--- a/tss-esapi/src/structures/ecc/point.rs
+++ b/tss-esapi/src/structures/ecc/point.rs
@@ -3,7 +3,10 @@ use tss_esapi_sys::TPM2B_ECC_POINT;
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{structures::EccParameter, tss2_esys::TPMS_ECC_POINT, Error, Result};
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    mem::size_of,
+};
 
 /// Structure holding ecc point information
 ///
@@ -49,10 +52,7 @@ impl From<EccPoint> for TPMS_ECC_POINT {
 
 impl From<EccPoint> for TPM2B_ECC_POINT {
     fn from(ecc_point: EccPoint) -> Self {
-        let size = std::mem::size_of::<u16>()
-            + ecc_point.x().len()
-            + std::mem::size_of::<u16>()
-            + ecc_point.y().len();
+        let size = size_of::<u16>() + ecc_point.x().len() + size_of::<u16>() + ecc_point.y().len();
         TPM2B_ECC_POINT {
             size: size as u16,
             point: ecc_point.into(),

--- a/tss-esapi/src/structures/nv/storage/public.rs
+++ b/tss-esapi/src/structures/nv/storage/public.rs
@@ -10,7 +10,10 @@ use crate::{
     Error, Result, WrapperErrorKind,
 };
 use log::error;
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    mem::size_of,
+};
 
 /// Representation of the public parameters of a non-volatile
 /// space allocation.
@@ -27,7 +30,7 @@ pub struct NvPublic {
 }
 
 impl NvPublic {
-    const MAX_SIZE: usize = std::mem::size_of::<TPMS_NV_PUBLIC>();
+    const MAX_SIZE: usize = size_of::<TPMS_NV_PUBLIC>();
 
     pub fn nv_index(&self) -> NvIndexTpmHandle {
         self.nv_index
@@ -172,8 +175,8 @@ impl NvPublicBuilder {
                     Error::local_error(WrapperErrorKind::ParamsMissing)
                 })
                 .and_then(|v| {
-                    if v > std::u16::MAX.into() {
-                        error!("data area size is too large (>{})", std::u16::MAX);
+                    if v > u16::MAX.into() {
+                        error!("data area size is too large (>{})", u16::MAX);
                         return Err(Error::local_error(WrapperErrorKind::InvalidParam));
                     }
                     Ok(v)

--- a/tss-esapi/src/structures/tagged/public.rs
+++ b/tss-esapi/src/structures/tagged/public.rs
@@ -18,7 +18,10 @@ use keyed_hash::PublicKeyedHashParameters;
 use rsa::PublicRsaParameters;
 
 use log::error;
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    mem::size_of,
+};
 use tss_esapi_sys::{TPMU_PUBLIC_ID, TPMU_PUBLIC_PARMS};
 
 /// A builder for the [Public] type.
@@ -288,6 +291,12 @@ impl PublicBuilder {
     }
 }
 
+impl Default for PublicBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Enum representing the Public structure.
 ///
 /// # Details
@@ -492,7 +501,7 @@ impl TryFrom<TPMT_PUBLIC> for Public {
 }
 
 impl Marshall for Public {
-    const BUFFER_SIZE: usize = std::mem::size_of::<TPMT_PUBLIC>();
+    const BUFFER_SIZE: usize = size_of::<TPMT_PUBLIC>();
 
     /// Produce a marshalled [TPMT_PUBLIC]
     ///

--- a/tss-esapi/src/structures/tagged/public/ecc.rs
+++ b/tss-esapi/src/structures/tagged/public/ecc.rs
@@ -130,8 +130,8 @@ impl PublicEccParametersBuilder {
     /// # Errors
     /// * if no asymmetric scheme is set, `ParamsMissing` wrapper error is returned.
     /// * if the `for_signing`, `for_decryption` and `restricted` parameters are
-    /// inconsistent with the rest of the parameters, `InconsistentParams` wrapper
-    /// error is returned
+    ///   inconsistent with the rest of the parameters, `InconsistentParams` wrapper
+    ///   error is returned
     pub fn build(self) -> Result<PublicEccParameters> {
         let ecc_scheme = self.ecc_scheme.ok_or_else(|| {
             error!("Scheme is required nad has not been set in the PublicEccParametersBuilder");

--- a/tss-esapi/src/structures/tagged/public/rsa.rs
+++ b/tss-esapi/src/structures/tagged/public/rsa.rs
@@ -36,7 +36,7 @@ impl PublicRsaParametersBuilder {
     }
 
     /// Creates a [PublicRsaParametersBuilder] that is setup
-    /// to build a restructed decryption key.
+    /// to build a restricted decryption key.
     pub const fn new_restricted_decryption_key(
         symmetric: SymmetricDefinitionObject,
         key_bits: RsaKeyBits,
@@ -135,8 +135,8 @@ impl PublicRsaParametersBuilder {
     /// # Errors
     /// * if no asymmetric scheme is set, `ParamsMissing` wrapper error is returned.
     /// * if the `for_signing`, `for_decryption` and `restricted` parameters are
-    /// inconsistent with the rest of the parameters, `InconsistentParams` wrapper
-    /// error is returned
+    ///   inconsistent with the rest of the parameters, `InconsistentParams` wrapper
+    ///   error is returned
     pub fn build(self) -> Result<PublicRsaParameters> {
         let rsa_scheme = self.rsa_scheme.ok_or_else(|| {
             error!("Scheme parameter is required and has not been set in the PublicRsaParametersBuilder");

--- a/tss-esapi/src/structures/tagged/sensitive.rs
+++ b/tss-esapi/src/structures/tagged/sensitive.rs
@@ -8,7 +8,10 @@ use crate::{
     Error, Result, WrapperErrorKind,
 };
 use log::error;
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    mem::size_of,
+};
 
 /// Enum describing the Sensitive part of an object.
 ///
@@ -164,7 +167,7 @@ impl TryFrom<TPMT_SENSITIVE> for Sensitive {
 }
 
 impl Marshall for Sensitive {
-    const BUFFER_SIZE: usize = std::mem::size_of::<TPMT_SENSITIVE>();
+    const BUFFER_SIZE: usize = size_of::<TPMT_SENSITIVE>();
 
     /// Produce a marshalled [`TPMT_SENSITIVE`]
     ///

--- a/tss-esapi/src/structures/tagged/signature.rs
+++ b/tss-esapi/src/structures/tagged/signature.rs
@@ -8,7 +8,10 @@ use crate::{
     Error, Result, WrapperErrorKind,
 };
 use log::error;
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    mem::size_of,
+};
 use tss_esapi_sys::{Tss2_MU_TPMT_SIGNATURE_Marshal, Tss2_MU_TPMT_SIGNATURE_Unmarshal};
 
 /// Enum representing a Signature
@@ -130,7 +133,8 @@ impl TryFrom<TPMT_SIGNATURE> for Signature {
 }
 
 impl Marshall for Signature {
-    const BUFFER_SIZE: usize = std::mem::size_of::<TPMT_SIGNATURE>();
+    #[allow(unused_qualifications)]
+    const BUFFER_SIZE: usize = size_of::<TPMT_SIGNATURE>();
 
     /// Produce a marshalled [`TPMT_SIGNATURE`]
     fn marshall(&self) -> Result<Vec<u8>> {


### PR DESCRIPTION
This commit addresses most of the problems
reported by the Clippy lint tool when building
with rust version 1.80 for the code in the 7.x.y
branch.