### PR TITLE
support for pure-rust make credentials

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = .git,target,Cargo.lock
-ignore-words-list = acsend,crate,inout,keypair,daa,de,ser
+ignore-words-list = acsend,crate,keypair,inout,daa,de,ser

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -35,6 +35,11 @@ regex = "1.3.9"
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.7.0-alpha.1" }
 x509-cert = { version = "0.3", optional = true }
+aes = { version = "0.9", optional = true }
+byte-strings = { version = "0.3.1", optional = true }
+cfb-mode = { version = "0.9", optional = true }
+cipher = { version = "0.5", optional = true }
+des = { version = "0.9", optional = true }
 ecdsa = { version = "0.17", features = [
     "algorithm",
     "der",
@@ -43,12 +48,14 @@ elliptic-curve = { version = "0.14.1", optional = true, features = [
     "alloc",
     "pkcs8",
 ] }
+hmac = { version = "0.13", optional = true }
 p192 = { version = "0.14.0-rc.15", optional = true }
 p224 = { version = "0.14.0-rc.15", optional = true }
 p256 = { version = "0.14", optional = true }
 p384 = { version = "0.14", optional = true }
 p521 = { version = "0.14", optional = true }
 pkcs8 = { version = "0.11", optional = true }
+rand = { version = "0.10", optional = true }
 rsa = { version = "0.10.0-rc.18", optional = true }
 sha1 = { version = "0.11", optional = true }
 sha2 = { version = "0.11", optional = true }
@@ -60,6 +67,8 @@ signature = { version = "3", features = [
     "alloc",
     "digest",
 ], optional = true }
+kbkdf = { version = "0.1.0-rc.1", optional = true }
+one-step-kdf = { version = "0.1.0-rc.0", optional = true }
 cfg-if = "1.0.0"
 strum = { version = "0.28.0", optional = true }
 strum_macros = { version = "0.28.0", optional = true }
@@ -67,7 +76,11 @@ paste = "1.0.14"
 getrandom = "0.4.0"
 
 [dev-dependencies]
+aes = "0.9"
+assert_fs = "1.1.3"
 env_logger = "0.11.5"
+hex-literal = "1"
+rsa = { version = "0.10.0-rc.18" }
 serde_json = "^1.0.108"
 sha2 = { version = "0.11", features = ["oid"] }
 socket2 = "0.6.3"
@@ -90,16 +103,26 @@ default = ["abstraction"]
 generate-bindings = ["tss-esapi-sys/generate-bindings"]
 abstraction = ["rustcrypto"]
 integration-tests = ["strum", "strum_macros"]
+
 rustcrypto = [
+    "byte-strings",
+    "cfb-mode",
+    "cipher",
+    "one-step-kdf",
     "digest",
     "ecdsa",
-    "elliptic-curve",
+    "elliptic-curve/ecdh",
+    "hmac",
+    "kbkdf",
     "pkcs8",
+    "rand",
     "signature",
     "x509-cert",
 ]
 rustcrypto-full = [
     "rustcrypto",
+    "aes",
+    "des",
     "p192",
     "p224",
     "p256",
@@ -112,6 +135,8 @@ rustcrypto-full = [
     "sm2",
     "sm3",
 ]
+ 
+rsa = ["dep:rsa", "kbkdf"]
 sha1 = ["dep:sha1", "rsa?/sha1"]
 sha2 = ["dep:sha2", "rsa?/sha2"]
 bundled = ["tss-esapi-sys/bundled"]

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -35,6 +35,11 @@ regex = "1.3.9"
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.7.0-alpha.1" }
 x509-cert = { version = "0.3", optional = true }
+aes = { version = "0.9", optional = true }
+byte-strings = { version = "0.3.1", optional = true }
+cfb-mode = { version = "0.9", optional = true }
+cipher = { version = "0.5", optional = true }
+des = { version = "0.9", optional = true }
 ecdsa = { version = "0.17", features = [
     "algorithm",
     "der",
@@ -43,12 +48,14 @@ elliptic-curve = { version = "0.14.1", optional = true, features = [
     "alloc",
     "pkcs8",
 ] }
+hmac = { version = "0.13", optional = true }
 p192 = { version = "0.14.0-rc.15", optional = true }
 p224 = { version = "0.14.0-rc.15", optional = true }
 p256 = { version = "0.14", optional = true }
 p384 = { version = "0.14", optional = true }
 p521 = { version = "0.14", optional = true }
 pkcs8 = { version = "0.11", optional = true }
+rand = { version = "0.10", optional = true }
 rsa = { version = "0.10.0-rc.18", optional = true }
 sha1 = { version = "0.11", optional = true }
 sha2 = { version = "0.11", optional = true }
@@ -60,6 +67,8 @@ signature = { version = "3", features = [
     "alloc",
     "digest",
 ], optional = true }
+kbkdf = { version = "0.1.0-rc.1", optional = true }
+one-step-kdf = { version = "0.1.0-rc.0", optional = true }
 cfg-if = "1.0.0"
 strum = { version = "0.28.0", optional = true }
 strum_macros = { version = "0.28.0", optional = true }
@@ -68,7 +77,10 @@ getrandom = "0.4.0"
 
 [dev-dependencies]
 assert_fs = "1.1.3"
+aes = "0.9"
 env_logger = "0.11.5"
+hex-literal = "1"
+rsa = { version = "0.10.0-rc.18" }
 serde_json = "^1.0.108"
 sha2 = { version = "0.11", features = ["oid"] }
 socket2 = "0.6.3"
@@ -90,16 +102,26 @@ default = ["abstraction"]
 generate-bindings = ["tss-esapi-sys/generate-bindings"]
 abstraction = ["rustcrypto"]
 integration-tests = ["strum", "strum_macros"]
+
 rustcrypto = [
+    "byte-strings",
+    "cfb-mode",
+    "cipher",
+    "one-step-kdf",
     "digest",
     "ecdsa",
-    "elliptic-curve",
+    "elliptic-curve/ecdh",
+    "hmac",
+    "kbkdf",
     "pkcs8",
+    "rand",
     "signature",
     "x509-cert",
 ]
 rustcrypto-full = [
     "rustcrypto",
+    "aes",
+    "des",
     "p192",
     "p224",
     "p256",
@@ -112,6 +134,8 @@ rustcrypto-full = [
     "sm2",
     "sm3",
 ]
+ 
+rsa = ["dep:rsa", "kbkdf"]
 sha1 = ["dep:sha1", "rsa?/sha1"]
 sha2 = ["dep:sha2", "rsa?/sha2"]
 bundled = ["tss-esapi-sys/bundled"]

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -32,44 +32,45 @@ num-derive = "0.4.2"
 num-traits = "0.2.12"
 hostname-validator = "1.1.0"
 regex = "1.3.9"
-zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
+zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.7.0-alpha.1" }
-x509-cert = { version = "0.2.0", optional = true }
-ecdsa = { version = "0.16.9", features = [
+x509-cert = { version = "0.3", optional = true }
+ecdsa = { version = "0.17", features = [
+    "algorithm",
     "der",
-    "hazmat",
-    "arithmetic",
-    "verifying",
 ], optional = true }
-elliptic-curve = { version = "0.13.8", optional = true, features = [
+elliptic-curve = { version = "0.14.1", optional = true, features = [
     "alloc",
     "pkcs8",
 ] }
-p192 = { version = "0.13.0", optional = true }
-p224 = { version = "0.13.2", optional = true }
-p256 = { version = "0.13.2", optional = true }
-p384 = { version = "0.13.0", optional = true }
-p521 = { version = "0.13.3", optional = true }
-pkcs8 = { version = "0.10.2", optional = true }
-rsa = { version = "0.9", optional = true }
-sha1 = { version = "0.10.6", optional = true }
-sha2 = { version = "0.10.8", optional = true }
-sha3 = { version = "0.10.8", optional = true }
-sm2 = { version = "0.13.3", optional = true }
-sm3 = { version = "0.4.2", optional = true }
-digest = { version = "0.10.7", optional = true }
-signature = { version = "2.2.0", features = ["std"], optional = true }
+p192 = { version = "0.14.0-rc.15", optional = true }
+p224 = { version = "0.14.0-rc.15", optional = true }
+p256 = { version = "0.14", optional = true }
+p384 = { version = "0.14", optional = true }
+p521 = { version = "0.14", optional = true }
+pkcs8 = { version = "0.11", optional = true }
+rsa = { version = "0.10.0-rc.18", optional = true }
+sha1 = { version = "0.11", optional = true }
+sha2 = { version = "0.11", optional = true }
+sha3 = { version = "0.12", optional = true }
+sm2 = { version = "0.14.0-rc.15", optional = true }
+sm3 = { version = "0.5", optional = true }
+digest = { version = "0.11.1", optional = true }
+signature = { version = "3", features = [
+    "alloc",
+    "digest",
+], optional = true }
 cfg-if = "1.0.0"
 strum = { version = "0.28.0", optional = true }
 strum_macros = { version = "0.28.0", optional = true }
 paste = "1.0.14"
-getrandom = "0.2.11"
+getrandom = "0.4.0"
 
 [dev-dependencies]
 assert_fs = "1.1.3"
 env_logger = "0.11.5"
 serde_json = "^1.0.108"
-sha2 = { version = "0.10.8", features = ["oid"] }
+sha2 = { version = "0.11", features = ["oid"] }
 socket2 = "0.6.3"
 tss-esapi = { path = ".", features = [
     "integration-tests",
@@ -77,7 +78,9 @@ tss-esapi = { path = ".", features = [
     "abstraction",
     "rustcrypto-full",
 ] }
-x509-cert = { version = "0.2.0", features = ["builder"] }
+p256 = { version = "0.14", features = ["ecdh"] }
+rand = "0.10"
+x509-cert = { version = "0.3", features = ["builder"] }
 
 [build-dependencies]
 semver = "1.0.7"

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -32,43 +32,44 @@ num-derive = "0.4.2"
 num-traits = "0.2.12"
 hostname-validator = "1.1.0"
 regex = "1.3.9"
-zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
+zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.7.0-alpha.1" }
-x509-cert = { version = "0.2.0", optional = true }
-ecdsa = { version = "0.16.9", features = [
+x509-cert = { version = "0.3", optional = true }
+ecdsa = { version = "0.17", features = [
+    "algorithm",
     "der",
-    "hazmat",
-    "arithmetic",
-    "verifying",
 ], optional = true }
-elliptic-curve = { version = "0.13.8", optional = true, features = [
+elliptic-curve = { version = "0.14.1", optional = true, features = [
     "alloc",
     "pkcs8",
 ] }
-p192 = { version = "0.13.0", optional = true }
-p224 = { version = "0.13.2", optional = true }
-p256 = { version = "0.13.2", optional = true }
-p384 = { version = "0.13.0", optional = true }
-p521 = { version = "0.13.3", optional = true }
-pkcs8 = { version = "0.10.2", optional = true }
-rsa = { version = "0.9", optional = true }
-sha1 = { version = "0.10.6", optional = true }
-sha2 = { version = "0.10.8", optional = true }
-sha3 = { version = "0.10.8", optional = true }
-sm2 = { version = "0.13.3", optional = true }
-sm3 = { version = "0.4.2", optional = true }
-digest = { version = "0.10.7", optional = true }
-signature = { version = "2.2.0", features = ["std"], optional = true }
+p192 = { version = "0.14.0-rc.15", optional = true }
+p224 = { version = "0.14.0-rc.15", optional = true }
+p256 = { version = "0.14", optional = true }
+p384 = { version = "0.14", optional = true }
+p521 = { version = "0.14", optional = true }
+pkcs8 = { version = "0.11", optional = true }
+rsa = { version = "0.10.0-rc.18", optional = true }
+sha1 = { version = "0.11", optional = true }
+sha2 = { version = "0.11", optional = true }
+sha3 = { version = "0.12", optional = true }
+sm2 = { version = "0.14.0-rc.15", optional = true }
+sm3 = { version = "0.5", optional = true }
+digest = { version = "0.11.1", optional = true }
+signature = { version = "3", features = [
+    "alloc",
+    "digest",
+], optional = true }
 cfg-if = "1.0.0"
 strum = { version = "0.28.0", optional = true }
 strum_macros = { version = "0.28.0", optional = true }
 paste = "1.0.14"
-getrandom = "0.2.11"
+getrandom = "0.4.0"
 
 [dev-dependencies]
 env_logger = "0.11.5"
 serde_json = "^1.0.108"
-sha2 = { version = "0.10.8", features = ["oid"] }
+sha2 = { version = "0.11", features = ["oid"] }
 socket2 = "0.6.3"
 tempfile = "3.27.0"
 tss-esapi = { path = ".", features = [
@@ -77,7 +78,9 @@ tss-esapi = { path = ".", features = [
     "abstraction",
     "rustcrypto-full",
 ] }
-x509-cert = { version = "0.2.0", features = ["builder"] }
+p256 = { version = "0.14", features = ["ecdh"] }
+rand = "0.10"
+x509-cert = { version = "0.3", features = ["builder"] }
 
 [build-dependencies]
 semver = "1.0.7"

--- a/tss-esapi/src/abstraction/no_tpm/quote.rs
+++ b/tss-esapi/src/abstraction/no_tpm/quote.rs
@@ -13,19 +13,16 @@ use digest::{Digest, DynDigest};
 #[cfg(any(feature = "p224", feature = "p256", feature = "p384"))]
 use crate::{abstraction::public::AssociatedTpmCurve, structures::EccSignature};
 #[cfg(any(feature = "p224", feature = "p256", feature = "p384"))]
-use ecdsa::{
-    PrimeCurve, SignatureSize, VerifyingKey,
-    hazmat::{DigestPrimitive, VerifyPrimitive},
-};
+use ecdsa::{DigestAlgorithm, PrimeCurve, SignatureSize, VerifyingKey};
 #[cfg(any(feature = "p224", feature = "p256", feature = "p384"))]
 use elliptic_curve::{
     CurveArithmetic, FieldBytesSize,
-    generic_array::ArrayLength,
+    array::ArraySize,
     point::AffinePoint,
-    sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint},
+    sec1::{FromSec1Point, ModulusSize, ToSec1Point},
 };
 #[cfg(any(feature = "p224", feature = "p256", feature = "p384"))]
-use signature::hazmat::PrehashVerifier;
+use signature::DigestVerifier;
 
 #[cfg(feature = "rsa")]
 use rsa::{RsaPublicKey, pkcs1v15, pss};
@@ -40,9 +37,9 @@ fn verify_ecdsa<C>(
     hashing_algorithm: HashingAlgorithm,
 ) -> Result<bool>
 where
-    C: PrimeCurve + CurveArithmetic + DigestPrimitive + AssociatedTpmCurve,
-    AffinePoint<C>: VerifyPrimitive<C> + FromEncodedPoint<C> + ToEncodedPoint<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    C: PrimeCurve + CurveArithmetic + DigestAlgorithm + AssociatedTpmCurve,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
+    SignatureSize<C>: ArraySize,
     FieldBytesSize<C>: ModulusSize,
 {
     let Ok(signature) = ecdsa::Signature::<C>::try_from(signature) else {
@@ -56,25 +53,45 @@ where
 
     match hashing_algorithm {
         #[cfg(feature = "sha1")]
-        HashingAlgorithm::Sha1 => {
-            let hash = sha1::Sha1::digest(message);
-            Ok(verifying_key.verify_prehash(&hash, &signature).is_ok())
-        }
+        HashingAlgorithm::Sha1 => Ok(verifying_key
+            .verify_digest(
+                |d: &mut sha1::Sha1| {
+                    Digest::update(d, message);
+                    Ok(())
+                },
+                &signature,
+            )
+            .is_ok()),
         #[cfg(feature = "sha2")]
-        HashingAlgorithm::Sha256 => {
-            let hash = sha2::Sha256::digest(message);
-            Ok(verifying_key.verify_prehash(&hash, &signature).is_ok())
-        }
+        HashingAlgorithm::Sha256 => Ok(verifying_key
+            .verify_digest(
+                |d: &mut sha2::Sha256| {
+                    Digest::update(d, message);
+                    Ok(())
+                },
+                &signature,
+            )
+            .is_ok()),
         #[cfg(feature = "sha2")]
-        HashingAlgorithm::Sha384 => {
-            let hash = sha2::Sha384::digest(message);
-            Ok(verifying_key.verify_prehash(&hash, &signature).is_ok())
-        }
+        HashingAlgorithm::Sha384 => Ok(verifying_key
+            .verify_digest(
+                |d: &mut sha2::Sha384| {
+                    Digest::update(d, message);
+                    Ok(())
+                },
+                &signature,
+            )
+            .is_ok()),
         #[cfg(feature = "sha2")]
-        HashingAlgorithm::Sha512 => {
-            let hash = sha2::Sha512::digest(message);
-            Ok(verifying_key.verify_prehash(&hash, &signature).is_ok())
-        }
+        HashingAlgorithm::Sha512 => Ok(verifying_key
+            .verify_digest(
+                |d: &mut sha2::Sha512| {
+                    Digest::update(d, message);
+                    Ok(())
+                },
+                &signature,
+            )
+            .is_ok()),
         _ => Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam)),
     }
 }

--- a/tss-esapi/src/abstraction/public.rs
+++ b/tss-esapi/src/abstraction/public.rs
@@ -9,8 +9,8 @@ use crate::{Error, WrapperErrorKind};
 use core::convert::TryFrom;
 use elliptic_curve::{
     AffinePoint, CurveArithmetic, FieldBytesSize, PublicKey,
-    generic_array::typenum::Unsigned,
-    sec1::{EncodedPoint, FromEncodedPoint, ModulusSize, ToEncodedPoint},
+    array::typenum::Unsigned,
+    sec1::{FromSec1Point, ModulusSize, Sec1Point, ToSec1Point},
 };
 
 use x509_cert::spki::SubjectPublicKeyInfoOwned;
@@ -18,7 +18,7 @@ use x509_cert::spki::SubjectPublicKeyInfoOwned;
 #[cfg(feature = "rsa")]
 use {
     crate::structures::RsaExponent,
-    rsa::{BigUint, RsaPublicKey},
+    rsa::{BoxedUint, RsaPublicKey},
 };
 
 #[cfg(any(
@@ -41,7 +41,7 @@ impl<C> TryFrom<&Public> for PublicKey<C>
 where
     C: CurveArithmetic + AssociatedTpmCurve,
     FieldBytesSize<C>: ModulusSize,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
 {
     type Error = Error;
 
@@ -57,15 +57,13 @@ where
                 let x = unique.x().as_bytes();
                 let y = unique.y().as_bytes();
 
-                if x.len() != FieldBytesSize::<C>::USIZE {
-                    return Err(Error::local_error(WrapperErrorKind::InvalidParam));
-                }
-                if y.len() != FieldBytesSize::<C>::USIZE {
-                    return Err(Error::local_error(WrapperErrorKind::InvalidParam));
-                }
-
-                let encoded_point =
-                    EncodedPoint::<C>::from_affine_coordinates(x.into(), y.into(), false);
+                let encoded_point = Sec1Point::<C>::from_affine_coordinates(
+                    x.try_into()
+                        .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?,
+                    y.try_into()
+                        .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?,
+                    false,
+                );
                 let public_key = PublicKey::<C>::try_from(&encoded_point)
                     .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;
 
@@ -86,10 +84,10 @@ impl TryFrom<&Public> for RsaPublicKey {
                 unique, parameters, ..
             } => {
                 let exponent = match parameters.exponent() {
-                    RsaExponent::ZERO_EXPONENT => BigUint::from(RSA_DEFAULT_EXP),
-                    _ => BigUint::from(parameters.exponent().value()),
+                    RsaExponent::ZERO_EXPONENT => BoxedUint::from(RSA_DEFAULT_EXP),
+                    _ => BoxedUint::from(parameters.exponent().value()),
                 };
-                let modulus = BigUint::from_bytes_be(unique.as_bytes());
+                let modulus = BoxedUint::from_be_slice_vartime(unique.as_bytes());
 
                 let public_key = RsaPublicKey::new(modulus, exponent)
                     .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;
@@ -163,7 +161,7 @@ impl<C> TryFrom<&TpmPublicKey> for PublicKey<C>
 where
     C: CurveArithmetic + AssociatedTpmCurve,
     FieldBytesSize<C>: ModulusSize,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
 {
     type Error = Error;
 
@@ -173,8 +171,6 @@ where
                 let x = x.as_slice();
                 let y = y.as_slice();
 
-                // TODO: When elliptic_curve bumps to 0.14, we can use the TryFrom implementation instead
-                // of checking lengths manually
                 if x.len() != FieldBytesSize::<C>::USIZE {
                     return Err(Error::local_error(WrapperErrorKind::InvalidParam));
                 }
@@ -182,8 +178,14 @@ where
                     return Err(Error::local_error(WrapperErrorKind::InvalidParam));
                 }
 
-                let encoded_point =
-                    EncodedPoint::<C>::from_affine_coordinates(x.into(), y.into(), false);
+                let encoded_point = Sec1Point::<C>::from_affine_coordinates(
+                    x.try_into()
+                        .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?,
+                    y.try_into()
+                        .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?,
+                    false,
+                );
+
                 let public_key = PublicKey::<C>::try_from(&encoded_point)
                     .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;
 
@@ -201,8 +203,8 @@ impl TryFrom<&TpmPublicKey> for RsaPublicKey {
     fn try_from(value: &TpmPublicKey) -> Result<Self, Self::Error> {
         match value {
             TpmPublicKey::Rsa(modulus) => {
-                let exponent = BigUint::from(RSA_DEFAULT_EXP);
-                let modulus = BigUint::from_bytes_be(modulus.as_slice());
+                let exponent = BoxedUint::from(RSA_DEFAULT_EXP);
+                let modulus = BoxedUint::from_be_slice_vartime(modulus.as_slice());
 
                 let public_key = RsaPublicKey::new(modulus, exponent)
                     .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;

--- a/tss-esapi/src/abstraction/signatures.rs
+++ b/tss-esapi/src/abstraction/signatures.rs
@@ -8,16 +8,16 @@ use crate::{
 
 use std::convert::TryFrom;
 
-use ecdsa::SignatureSize;
+use ecdsa::{EcdsaCurve, SignatureSize};
 use elliptic_curve::{
     FieldBytes, FieldBytesSize, PrimeCurve,
-    generic_array::{ArrayLength, typenum::Unsigned},
+    array::{ArraySize, typenum::Unsigned},
 };
 
 impl<C> TryFrom<&EccSignature> for ecdsa::Signature<C>
 where
-    C: PrimeCurve,
-    SignatureSize<C>: ArrayLength<u8>,
+    C: PrimeCurve + EcdsaCurve,
+    SignatureSize<C>: ArraySize,
 {
     type Error = Error;
 
@@ -33,8 +33,10 @@ where
         }
 
         let signature = ecdsa::Signature::from_scalars(
-            FieldBytes::<C>::clone_from_slice(r),
-            FieldBytes::<C>::clone_from_slice(s),
+            FieldBytes::<C>::try_from(r)
+                .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?,
+            FieldBytes::<C>::try_from(s)
+                .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?,
         )
         .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;
         Ok(signature)
@@ -43,8 +45,8 @@ where
 
 impl<C> TryFrom<&Signature> for ecdsa::Signature<C>
 where
-    C: PrimeCurve,
-    SignatureSize<C>: ArrayLength<u8>,
+    C: PrimeCurve + EcdsaCurve,
+    SignatureSize<C>: ArraySize,
 {
     type Error = Error;
 

--- a/tss-esapi/src/abstraction/signer.rs
+++ b/tss-esapi/src/abstraction/signer.rs
@@ -23,15 +23,14 @@ use std::{convert::TryFrom, ops::Add, sync::Mutex};
 
 use digest::{Digest, FixedOutput, Output};
 use ecdsa::{
-    Signature, SignatureSize, VerifyingKey,
+    DigestAlgorithm, EcdsaCurve, Signature, SignatureSize, VerifyingKey,
     der::{MaxOverhead, MaxSize, Signature as DerSignature},
-    hazmat::{DigestPrimitive, SignPrimitive},
 };
 use elliptic_curve::{
     AffinePoint, CurveArithmetic, FieldBytesSize, PrimeCurve, PublicKey, Scalar,
-    generic_array::ArrayLength,
+    array::ArraySize,
     ops::Invert,
-    sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint},
+    sec1::{FromSec1Point, ModulusSize, ToSec1Point},
     subtle::CtOption,
 };
 use log::error;
@@ -139,7 +138,7 @@ impl TpmSigner
 #[derive(Debug)]
 pub struct EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve,
 {
     context: Ctx,
     verifying_key: VerifyingKey<C>,
@@ -147,10 +146,10 @@ where
 
 impl<C, Ctx> EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve,
     C: AssociatedTpmCurve,
     FieldBytesSize<C>: ModulusSize,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     Ctx: TpmSigner,
 {
     pub fn new(context: Ctx) -> Result<Self, Error> {
@@ -178,17 +177,17 @@ where
 
 impl<C, Ctx> EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve,
     C: AssociatedTpmCurve,
 {
-    /// Key parameters for this curve, selected digest is the one selected by DigestPrimitive
+    /// Key parameters for this curve, selected digest is the one selected by DigestAlgorithm
     pub fn key_params_default() -> KeyParams
     where
-        C: DigestPrimitive,
-        <C as DigestPrimitive>::Digest: FixedOutput<OutputSize = FieldBytesSize<C>>,
-        <C as DigestPrimitive>::Digest: AssociatedHashingAlgorithm,
+        C: DigestAlgorithm,
+        <C as DigestAlgorithm>::Digest: FixedOutput,
+        <C as DigestAlgorithm>::Digest: AssociatedHashingAlgorithm,
     {
-        Self::key_params::<<C as DigestPrimitive>::Digest>()
+        Self::key_params::<<C as DigestAlgorithm>::Digest>()
     }
 
     /// Key parameters for this curve
@@ -198,7 +197,7 @@ where
     /// The hashing algorithm `D` is the digest that will be used for signatures (SHA-256, SHA3-256, ...).
     pub fn key_params<D>() -> KeyParams
     where
-        D: FixedOutput<OutputSize = FieldBytesSize<C>>,
+        D: FixedOutput,
         D: AssociatedHashingAlgorithm,
     {
         KeyParams::Ecc {
@@ -211,9 +210,9 @@ where
 
 impl<C, Ctx> AsRef<VerifyingKey<C>> for EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
+    SignatureSize<C>: ArraySize,
 {
     fn as_ref(&self) -> &VerifyingKey<C> {
         &self.verifying_key
@@ -222,25 +221,30 @@ where
 
 impl<C, Ctx> KeypairRef for EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
+    SignatureSize<C>: ArraySize,
 {
     type VerifyingKey = VerifyingKey<C>;
 }
 
 impl<C, Ctx, D> DigestSigner<D, Signature<C>> for EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve,
     C: AssociatedTpmCurve,
-    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    D: Digest + FixedOutput,
     D: AssociatedHashingAlgorithm,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
+    SignatureSize<C>: ArraySize,
     TpmDigest: From<Output<D>>,
     Ctx: TpmSigner,
 {
-    fn try_sign_digest(&self, digest: D) -> Result<Signature<C>, SigError> {
+    fn try_sign_digest<F: Fn(&mut D) -> Result<(), SigError>>(
+        &self,
+        f: F,
+    ) -> Result<Signature<C>, SigError> {
+        let mut digest = D::new();
+        f(&mut digest)?;
         let digest = TpmDigest::from(digest.finalize_fixed());
 
         //let key_params = Self::key_params::<D>();
@@ -260,60 +264,69 @@ where
 
 impl<C, Ctx, D> DigestSigner<D, DerSignature<C>> for EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve,
     C: AssociatedTpmCurve,
-    D: Digest + FixedOutput<OutputSize = FieldBytesSize<C>>,
+    D: Digest + FixedOutput,
     D: AssociatedHashingAlgorithm,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
+    SignatureSize<C>: ArraySize,
     TpmDigest: From<Output<D>>,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
     Ctx: TpmSigner,
 {
-    fn try_sign_digest(&self, digest: D) -> Result<DerSignature<C>, SigError> {
-        let signature: Signature<_> = self.try_sign_digest(digest)?;
+    fn try_sign_digest<F: Fn(&mut D) -> Result<(), SigError>>(
+        &self,
+        f: F,
+    ) -> Result<DerSignature<C>, SigError> {
+        let signature: Signature<_> = self.try_sign_digest(f)?;
         Ok(signature.to_der())
     }
 }
 
 impl<C, Ctx> Signer<Signature<C>> for EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic + DigestPrimitive,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve + DigestAlgorithm,
     C: AssociatedTpmCurve,
-    <C as DigestPrimitive>::Digest: AssociatedHashingAlgorithm,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-    TpmDigest: From<Output<<C as DigestPrimitive>::Digest>>,
+    <C as DigestAlgorithm>::Digest: AssociatedHashingAlgorithm + FixedOutput,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
+    SignatureSize<C>: ArraySize,
+    TpmDigest: From<Output<<C as DigestAlgorithm>::Digest>>,
     Ctx: TpmSigner,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<Signature<C>, SigError> {
-        self.try_sign_digest(C::Digest::new_with_prefix(msg))
+        self.try_sign_digest(|d: &mut C::Digest| {
+            Digest::update(d, msg);
+            Ok(())
+        })
     }
 }
 
 impl<C, Ctx> Signer<DerSignature<C>> for EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic + DigestPrimitive,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve + DigestAlgorithm,
     C: AssociatedTpmCurve,
-    <C as DigestPrimitive>::Digest: AssociatedHashingAlgorithm,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-    TpmDigest: From<Output<<C as DigestPrimitive>::Digest>>,
-    MaxSize<C>: ArrayLength<u8>,
-    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArrayLength<u8>,
+    <C as DigestAlgorithm>::Digest: AssociatedHashingAlgorithm + FixedOutput,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
+    SignatureSize<C>: ArraySize,
+    TpmDigest: From<Output<<C as DigestAlgorithm>::Digest>>,
+    MaxSize<C>: ArraySize,
+    <FieldBytesSize<C> as Add>::Output: Add<MaxOverhead> + ArraySize,
     Ctx: TpmSigner,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<DerSignature<C>, SigError> {
-        self.try_sign_digest(C::Digest::new_with_prefix(msg))
+        self.try_sign_digest(|d: &mut C::Digest| {
+            Digest::update(d, msg);
+            Ok(())
+        })
     }
 }
 
 impl<C, Ctx> SignatureAlgorithmIdentifier for EcSigner<C, Ctx>
 where
-    C: PrimeCurve + CurveArithmetic,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
+    C: PrimeCurve + CurveArithmetic + EcdsaCurve,
+    Scalar<C>: Invert<Output = CtOption<Scalar<C>>>,
+    SignatureSize<C>: ArraySize,
     Signature<C>: AssociatedAlgorithmIdentifier<Params = AnyRef<'static>>,
 {
     type Params = AnyRef<'static>;
@@ -440,7 +453,12 @@ mod rsa {
         TpmDigest: From<Output<D>>,
         Ctx: TpmSigner,
     {
-        fn try_sign_digest(&self, digest: D) -> Result<pkcs1v15::Signature, SigError> {
+        fn try_sign_digest<F: Fn(&mut D) -> Result<(), SigError>>(
+            &self,
+            f: F,
+        ) -> Result<pkcs1v15::Signature, SigError> {
+            let mut digest = D::new();
+            f(&mut digest)?;
             let digest = TpmDigest::from(digest.finalize_fixed());
 
             //let key_params = Self::key_params::<D>();
@@ -461,10 +479,10 @@ mod rsa {
         Ctx: TpmSigner,
     {
         fn try_sign(&self, msg: &[u8]) -> Result<pkcs1v15::Signature, SigError> {
-            let mut d = D::new();
-            Digest::update(&mut d, msg);
-
-            self.try_sign_digest(d)
+            self.try_sign_digest(|d: &mut D| {
+                Digest::update(d, msg);
+                Ok(())
+            })
         }
     }
 
@@ -570,7 +588,12 @@ mod rsa {
         TpmDigest: From<Output<D>>,
         Ctx: TpmSigner,
     {
-        fn try_sign_digest(&self, digest: D) -> Result<pss::Signature, SigError> {
+        fn try_sign_digest<F: Fn(&mut D) -> Result<(), SigError>>(
+            &self,
+            f: F,
+        ) -> Result<pss::Signature, SigError> {
+            let mut digest = D::new();
+            f(&mut digest)?;
             let digest = TpmDigest::from(digest.finalize_fixed());
 
             let signature = self.context.sign(digest).map_err(SigError::from_source)?;
@@ -589,10 +612,10 @@ mod rsa {
         Ctx: TpmSigner,
     {
         fn try_sign(&self, msg: &[u8]) -> Result<pss::Signature, SigError> {
-            let mut d = D::new();
-            Digest::update(&mut d, msg);
-
-            self.try_sign_digest(d)
+            self.try_sign_digest(|d: &mut D| {
+                Digest::update(d, msg);
+                Ok(())
+            })
         }
     }
 

--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -154,7 +154,7 @@ impl TransientKeyContext {
         let key_auth = if auth_size > 0 {
             self.set_session_attrs()?;
             let mut random_bytes = vec![0u8; auth_size];
-            getrandom::getrandom(&mut random_bytes).map_err(|_| {
+            getrandom::fill(&mut random_bytes).map_err(|_| {
                 log::error!("Failed to obtain a random authvalue for key creation");
                 Error::WrapperError(ErrorKind::InternalError)
             })?;
@@ -671,7 +671,7 @@ impl TransientKeyContextBuilder {
 
         let root_key_auth = if self.root_key_auth_size > 0 {
             let mut random = vec![0u8; self.root_key_auth_size];
-            getrandom::getrandom(&mut random).map_err(|_| {
+            getrandom::fill(&mut random).map_err(|_| {
                 log::error!("Failed to obtain a random value for root key authentication");
                 Error::WrapperError(ErrorKind::InternalError)
             })?;

--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -87,7 +87,7 @@ impl Context {
     /// #     .expect("Failed to set attributes on session");
     /// # context.set_sessions((Some(session), None, None));
     /// # let mut random_digest = vec![0u8; 16];
-    /// # getrandom::getrandom(&mut random_digest).unwrap();
+    /// # getrandom::fill(&mut random_digest).unwrap();
     /// # let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
     /// #
     /// # let object_attributes = ObjectAttributesBuilder::new()
@@ -248,7 +248,7 @@ impl Context {
     /// #     .expect("Failed to set attributes on session");
     /// # context.set_sessions((Some(session), None, None));
     /// # let mut random_digest = vec![0u8; 16];
-    /// # getrandom::getrandom(&mut random_digest).unwrap();
+    /// # getrandom::fill(&mut random_digest).unwrap();
     /// # let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
     /// #
     /// # let object_attributes = ObjectAttributesBuilder::new()
@@ -370,6 +370,7 @@ impl Context {
     /// #        RsaDecryptionScheme, HashScheme, SymmetricDefinition,
     /// #    },
     /// # };
+    /// # use rand::Rng;
     /// # use std::{env, str::FromStr, convert::TryFrom};
     /// # // Create context
     /// # let mut context =
@@ -396,7 +397,8 @@ impl Context {
     /// #     .expect("Failed to set attributes on session");
     /// # context.set_sessions((Some(session), None, None));
     /// # let mut random_digest = vec![0u8; 16];
-    /// # getrandom::getrandom(&mut random_digest).unwrap();
+    /// # let mut rng = rand::rng();
+    /// # rng.fill_bytes(&mut random_digest);
     /// # let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
     /// #
     /// // Create a key suitable for ECDH key generation
@@ -506,6 +508,7 @@ impl Context {
     /// #        RsaDecryptionScheme, HashScheme, SymmetricDefinition,
     /// #    },
     /// # };
+    /// # use rand::Rng;
     /// # use std::{env, str::FromStr, convert::TryFrom};
     /// # // Create context
     /// # let mut context =
@@ -532,7 +535,8 @@ impl Context {
     /// #     .expect("Failed to set attributes on session");
     /// # context.set_sessions((Some(session), None, None));
     /// # let mut random_digest = vec![0u8; 16];
-    /// # getrandom::getrandom(&mut random_digest).unwrap();
+    /// # let mut rng = rand::rng();
+    /// # rng.fill_bytes(&mut random_digest);
     /// # let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
     /// #
     /// // Create a key suitable for ECDH key generation
@@ -716,7 +720,7 @@ impl Context {
     /// #     .expect("Failed to set attributes on session");
     /// # context.set_sessions((Some(session), None, None));
     /// # let mut random_digest = vec![0u8; 16];
-    /// # getrandom::getrandom(&mut random_digest).expect("Failed to get random bytes");
+    /// # getrandom::fill(&mut random_digest).expect("Failed to get random bytes");
     /// # let key_auth = Auth::from_bytes(random_digest.as_slice()).expect("Failed to create key auth");
     /// #
     /// # let ecc_parms = PublicEccParametersBuilder::new()

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -108,7 +108,7 @@ impl Context {
     /// // Execute context methods using the session
     /// context.execute_with_session(Some(session), |ctx| {
     ///     let mut random_digest = vec![0u8; 16];
-    ///     getrandom::getrandom(&mut random_digest).expect("Call to getrandom failed");
+    ///     getrandom::fill(&mut random_digest).expect("Call to getrandom failed");
     ///     let key_auth = Auth::from_bytes(random_digest.as_slice()).expect("Failed to create Auth");
     ///     let key_handle = ctx
     ///         .create_primary(

--- a/tss-esapi/src/context/tpm_commands/ephemeral_ec_keys.rs
+++ b/tss-esapi/src/context/tpm_commands/ephemeral_ec_keys.rs
@@ -78,7 +78,7 @@ impl Context {
     /// #     .expect("Failed to set attributes on session");
     /// # context.set_sessions((Some(session), None, None));
     /// # let mut random_digest = vec![0u8; 16];
-    /// # getrandom::getrandom(&mut random_digest).expect("Failed to get random bytes");
+    /// # getrandom::fill(&mut random_digest).expect("Failed to get random bytes");
     /// # let key_auth
     /// #     = Auth::from_bytes(random_digest.as_slice()).expect("Failed to create key auth");
     /// #

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -57,7 +57,7 @@ impl Context {
     /// #     .expect("Failed to set auth to empty for owner");
     /// # // Create primary key auth
     /// # let mut random_digest = vec![0u8; 16];
-    /// # getrandom::getrandom(&mut random_digest).expect("get_rand call failed");
+    /// # getrandom::fill(&mut random_digest).expect("get_rand call failed");
     /// # let primary_key_auth = Auth::from_bytes(
     /// #     random_digest
     /// #         .as_slice()
@@ -103,7 +103,7 @@ impl Context {
     /// #     .expect("Failed to create public for symmetric key public");
     /// # // Create auth for the symmetric key
     /// # let mut random_digest = vec![0u8; 16];
-    /// # getrandom::getrandom(&mut random_digest).expect("get_rand call failed");
+    /// # getrandom::fill(&mut random_digest).expect("get_rand call failed");
     /// # let symmetric_key_auth = Auth::from_bytes(
     /// #     random_digest
     /// #         .as_slice()

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -225,8 +225,8 @@ pub mod digest {
     #[cfg(feature = "rustcrypto")]
     mod rustcrypto {
         use digest::{
+            array::Array,
             consts::{U20, U32, U48, U64},
-            generic_array::GenericArray,
             typenum::Unsigned,
         };
 
@@ -234,15 +234,15 @@ pub mod digest {
 
         macro_rules! impl_from_digest {
             ($($size:ty),+) => {
-                $(impl From<GenericArray<u8, $size>> for Digest {
-                    fn from(mut value: GenericArray<u8, $size>) -> Self {
+                $(impl From<Array<u8, $size>> for Digest {
+                    fn from(mut value: Array<u8, $size>) -> Self {
                         let value_as_vec = value.as_slice().to_vec();
                         value.zeroize();
                         Digest(value_as_vec.into())
                     }
                 }
 
-                impl TryFrom<Digest> for GenericArray<u8, $size> {
+                impl TryFrom<Digest> for Array<u8, $size> {
                     type Error = Error;
 
                     fn try_from(value: Digest) -> Result<Self> {

--- a/tss-esapi/src/utils/credential.rs
+++ b/tss-esapi/src/utils/credential.rs
@@ -1,0 +1,430 @@
+// Copyright 2025 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::{
+    fmt,
+    ops::{Add, Mul},
+};
+
+use cfb_mode::cipher::BlockCipherEncrypt;
+use digest::{
+    Digest, FixedOutputReset, Key, KeyInit, Mac, OutputSizeUser,
+    array::ArraySize,
+    common::{BlockSizeUser, Iv, KeyIvInit, KeySizeUser},
+    consts::{B1, U8},
+    typenum::{
+        Unsigned,
+        operator_aliases::{Add1, Sum},
+    },
+};
+use ecdsa::elliptic_curve::{
+    AffinePoint, Curve, CurveArithmetic, FieldBytesSize, PublicKey,
+    sec1::{FromSec1Point, ModulusSize, ToSec1Point},
+};
+use hmac::SimpleHmac;
+use log::error;
+use rand::rng;
+use zeroize::Zeroizing;
+
+#[cfg(feature = "rsa")]
+use rsa::RsaPublicKey;
+
+use crate::{
+    error::{Error, Result, WrapperErrorKind},
+    structures::{EncryptedSecret, IdObject, Name},
+    utils::{TpmHmac, kdf, secret_sharing},
+};
+
+/// Test if a key is considered weak according to TCG.
+///
+/// TCG will require weak keys to be re-generated,  
+/// See:
+/// ```text
+/// 11.4.10.4 Rejection of weak keys
+/// https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-1-Architecture.pdf#page=82
+/// The Key was considered weak, and we should re-run the creation of the encrypted
+/// secret.
+/// ```
+pub trait TcgKeyTest: KeyInit {
+    fn tcg_weak_key_test(key: &Key<Self>) -> core::result::Result<(), WeakKeyError>;
+}
+
+/// The error type returned when a key is found to be weak.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct WeakKeyError;
+
+impl fmt::Display for WeakKeyError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("WeakKey")
+    }
+}
+
+impl core::error::Error for WeakKeyError {}
+
+type WeakResult<T> = core::result::Result<T, WeakKeyError>;
+
+#[cfg(feature = "aes")]
+mod key_test_aes {
+    use cipher::{Key, KeySizeUser, typenum::Unsigned};
+    use elliptic_curve::subtle::{Choice, ConstantTimeGreater};
+
+    use super::{TcgKeyTest, WeakKeyError};
+
+    macro_rules! weak_key_test {
+        ($k: ty) => {
+            impl TcgKeyTest for $k {
+                fn tcg_weak_key_test(key: &Key<Self>) -> Result<(), WeakKeyError> {
+                    // Check if any bit of the upper half of the key is set
+                    //
+                    // This follows the in terpretation laid out in section `11.4.10.4 Reject of weak keys`
+                    // from the TPM specification:
+                    // ```
+                    // In the case of AES, at least one bit in the upper half of the key must be set
+                    // ```
+                    // See: https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-1-Architecture.pdf#page=82
+                    let mut weak = Choice::from(0);
+
+                    for v in &key[..(<<$k as KeySizeUser>::KeySize as Unsigned>::USIZE / 2)] {
+                        weak |= <_ as ConstantTimeGreater>::ct_gt(v, &0);
+                    }
+
+                    if weak.unwrap_u8() == 0 {
+                        Err(WeakKeyError)
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        };
+    }
+
+    weak_key_test!(aes::Aes128);
+    weak_key_test!(aes::Aes192);
+    weak_key_test!(aes::Aes256);
+}
+
+#[cfg(feature = "des")]
+mod key_test_des {
+    use cipher::{Key, KeyInit, KeySizeUser, typenum::Unsigned};
+    use des::{Des, TdesEde2, TdesEde3, TdesEee2, TdesEee3};
+    use elliptic_curve::subtle::{Choice, ConstantTimeEq};
+
+    use super::{TcgKeyTest, WeakKeyError};
+
+    static WEAK_KEYS: [[u8; 8]; 64] = [
+        [0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01],
+        [0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE],
+        [0xE0, 0xE0, 0xE0, 0xE0, 0xF1, 0xF1, 0xF1, 0xF1],
+        [0x1F, 0x1F, 0x1F, 0x1F, 0x0E, 0x0E, 0x0E, 0x0E],
+        [0x01, 0x1F, 0x01, 0x1F, 0x01, 0x0E, 0x01, 0x0E],
+        [0x1F, 0x01, 0x1F, 0x01, 0x0E, 0x01, 0x0E, 0x01],
+        [0x01, 0xE0, 0x01, 0xE0, 0x01, 0xF1, 0x01, 0xF1],
+        [0xE0, 0x01, 0xE0, 0x01, 0xF1, 0x01, 0xF1, 0x01],
+        [0x01, 0xFE, 0x01, 0xFE, 0x01, 0xFE, 0x01, 0xFE],
+        [0xFE, 0x01, 0xFE, 0x01, 0xFE, 0x01, 0xFE, 0x01],
+        [0x1F, 0xE0, 0x1F, 0xE0, 0x0E, 0xF1, 0x0E, 0xF1],
+        [0xE0, 0x1F, 0xE0, 0x1F, 0xF1, 0x0E, 0xF1, 0x0E],
+        [0x1F, 0xFE, 0x1F, 0xFE, 0x0E, 0xFE, 0x0E, 0xFE],
+        [0xFE, 0x1F, 0xFE, 0x1F, 0xFE, 0x0E, 0xFE, 0x0E],
+        [0xE0, 0xFE, 0xE0, 0xFE, 0xF1, 0xFE, 0xF1, 0xFE],
+        [0xFE, 0xE0, 0xFE, 0xE0, 0xFE, 0xF1, 0xFE, 0xF1],
+        [0x01, 0x01, 0x1F, 0x1F, 0x01, 0x01, 0x0E, 0x0E],
+        [0x1F, 0x1F, 0x01, 0x01, 0x0E, 0x0E, 0x01, 0x01],
+        [0xE0, 0xE0, 0x1F, 0x1F, 0xF1, 0xF1, 0x0E, 0x0E],
+        [0x01, 0x01, 0xE0, 0xE0, 0x01, 0x01, 0xF1, 0xF1],
+        [0x1F, 0x1F, 0xE0, 0xE0, 0x0E, 0x0E, 0xF1, 0xF1],
+        [0xE0, 0xE0, 0xFE, 0xFE, 0xF1, 0xF1, 0xFE, 0xFE],
+        [0x01, 0x01, 0xFE, 0xFE, 0x01, 0x01, 0xFE, 0xFE],
+        [0x1F, 0x1F, 0xFE, 0xFE, 0x0E, 0x0E, 0xFE, 0xFE],
+        [0xE0, 0xFE, 0x01, 0x1F, 0xF1, 0xFE, 0x01, 0x0E],
+        [0x01, 0x1F, 0x1F, 0x01, 0x01, 0x0E, 0x0E, 0x01],
+        [0x1F, 0xE0, 0x01, 0xFE, 0x0E, 0xF1, 0x01, 0xFE],
+        [0xE0, 0xFE, 0x1F, 0x01, 0xF1, 0xFE, 0x0E, 0x01],
+        [0x01, 0x1F, 0xE0, 0xFE, 0x01, 0x0E, 0xF1, 0xFE],
+        [0x1F, 0xE0, 0xE0, 0x1F, 0x0E, 0xF1, 0xF1, 0x0E],
+        [0xE0, 0xFE, 0xFE, 0xE0, 0xF1, 0xFE, 0xFE, 0xF1],
+        [0x01, 0x1F, 0xFE, 0xE0, 0x01, 0x0E, 0xFE, 0xF1],
+        [0x1F, 0xE0, 0xFE, 0x01, 0x0E, 0xF1, 0xFE, 0x01],
+        [0xFE, 0x01, 0x01, 0xFE, 0xFE, 0x01, 0x01, 0xFE],
+        [0x01, 0xE0, 0x1F, 0xFE, 0x01, 0xF1, 0x0E, 0xFE],
+        [0x1F, 0xFE, 0x01, 0xE0, 0x0E, 0xFE, 0x01, 0xF1],
+        [0xFE, 0x01, 0x1F, 0xE0, 0xFE, 0x01, 0x0E, 0xF1],
+        [0xFE, 0x01, 0xE0, 0x1F, 0xFE, 0x01, 0xF1, 0x0E],
+        [0x1F, 0xFE, 0xE0, 0x01, 0x0E, 0xFE, 0xF1, 0x01],
+        [0xFE, 0x1F, 0x01, 0xE0, 0xFE, 0x0E, 0x01, 0xF1],
+        [0x01, 0xE0, 0xE0, 0x01, 0x01, 0xF1, 0xF1, 0x01],
+        [0x1F, 0xFE, 0xFE, 0x1F, 0x0E, 0xFE, 0xFE, 0x0E],
+        [0xFE, 0x1F, 0xE0, 0x01, 0xFE, 0x0E, 0xF1, 0x01],
+        [0x01, 0xE0, 0xFE, 0x1F, 0x01, 0xF1, 0xFE, 0x0E],
+        [0xE0, 0x01, 0x01, 0xE0, 0xF1, 0x01, 0x01, 0xF1],
+        [0xFE, 0x1F, 0x1F, 0xFE, 0xFE, 0x0E, 0x0E, 0xFE],
+        [0x01, 0xFE, 0x1F, 0xE0, 0x01, 0xFE, 0x0E, 0xF1],
+        [0xE0, 0x01, 0x1F, 0xFE, 0xF1, 0x01, 0x0E, 0xFE],
+        [0xFE, 0xE0, 0x01, 0x1F, 0xFE, 0xF1, 0x01, 0x0E],
+        [0x01, 0xFE, 0xE0, 0x1F, 0x01, 0xFE, 0xF1, 0x0E],
+        [0xE0, 0x01, 0xFE, 0x1F, 0xF1, 0x01, 0xFE, 0x0E],
+        [0xFE, 0xE0, 0x1F, 0x01, 0xFE, 0xF1, 0x0E, 0x01],
+        [0x01, 0xFE, 0xFE, 0x01, 0x01, 0xFE, 0xFE, 0x01],
+        [0xE0, 0x1F, 0x01, 0xFE, 0xF1, 0x0E, 0x01, 0xFE],
+        [0xFE, 0xE0, 0xE0, 0xFE, 0xFE, 0xF1, 0xF1, 0xFE],
+        [0x1F, 0x01, 0x01, 0x1F, 0x0E, 0x01, 0x01, 0x0E],
+        [0xE0, 0x1F, 0x1F, 0xE0, 0xF1, 0x0E, 0x0E, 0xF1],
+        [0xFE, 0xFE, 0x01, 0x01, 0xFE, 0xFE, 0x01, 0x01],
+        [0x1F, 0x01, 0xE0, 0xFE, 0x0E, 0x01, 0xF1, 0xFE],
+        [0xE0, 0x1F, 0xFE, 0x01, 0xF1, 0x0E, 0xFE, 0x01],
+        [0xFE, 0xFE, 0x1F, 0x1F, 0xFE, 0xFE, 0x0E, 0x0E],
+        [0x1F, 0x01, 0xFE, 0xE0, 0x0E, 0x01, 0xFE, 0xF1],
+        [0xE0, 0xE0, 0x01, 0x01, 0xF1, 0xF1, 0x01, 0x01],
+        [0xFE, 0xFE, 0xE0, 0xE0, 0xFE, 0xFE, 0xF1, 0xF1],
+    ];
+
+    impl TcgKeyTest for Des {
+        #[inline]
+        fn tcg_weak_key_test(key: &Key<Self>) -> Result<(), WeakKeyError> {
+            let mut weak = Choice::from(0);
+
+            for weak_key in &WEAK_KEYS {
+                weak |= key.ct_eq(weak_key.into());
+            }
+
+            if weak.unwrap_u8() == 0 {
+                Ok(())
+            } else {
+                Err(WeakKeyError)
+            }
+        }
+    }
+
+    #[inline]
+    fn weak_key_test<const SIZE: usize, U: KeyInit>(key: &Key<U>) -> Result<(), WeakKeyError> {
+        let mut tmp = Key::<U>::default();
+
+        for i in 0..<U as KeySizeUser>::KeySize::USIZE {
+            // count number of set bits in byte, excluding the low-order bit - SWAR method
+            let mut c = key[i] & 0xFE;
+
+            c = (c & 0x55) + ((c >> 1) & 0x55);
+            c = (c & 0x33) + ((c >> 2) & 0x33);
+            c = (c & 0x0F) + ((c >> 4) & 0x0F);
+
+            // if count is even, set low key bit to 1, otherwise 0
+            tmp[i] = (key[i] & 0xFE) | u8::from(c & 0x01 != 0x01);
+        }
+
+        let mut des_key = Key::<Des>::default();
+        for i in 0..SIZE {
+            des_key.copy_from_slice(
+                &tmp.as_slice()[i * <Des as KeySizeUser>::KeySize::USIZE
+                    ..(i + 1) * <Des as KeySizeUser>::KeySize::USIZE],
+            );
+            Des::tcg_weak_key_test(&des_key)?;
+        }
+        Ok(())
+    }
+
+    impl TcgKeyTest for TdesEde3 {
+        #[inline]
+        fn tcg_weak_key_test(key: &Key<Self>) -> Result<(), WeakKeyError> {
+            weak_key_test::<3, Self>(key)
+        }
+    }
+
+    impl TcgKeyTest for TdesEee3 {
+        #[inline]
+        fn tcg_weak_key_test(key: &Key<Self>) -> Result<(), WeakKeyError> {
+            weak_key_test::<3, Self>(key)
+        }
+    }
+
+    impl TcgKeyTest for TdesEde2 {
+        #[inline]
+        fn tcg_weak_key_test(key: &Key<Self>) -> Result<(), WeakKeyError> {
+            weak_key_test::<2, Self>(key)
+        }
+    }
+
+    impl TcgKeyTest for TdesEee2 {
+        #[inline]
+        fn tcg_weak_key_test(key: &Key<Self>) -> Result<(), WeakKeyError> {
+            weak_key_test::<2, Self>(key)
+        }
+    }
+}
+
+/// [`make_credential_ecc`] creates a credential that will only be decrypted by the target
+/// elliptic-curve EK.
+///
+/// # Parameters
+///
+/// * `ek_public` is the EC Public key of the Endorsement Key,
+/// * `secret` is the serialization of the credential,
+/// * `name` will usually be the AK held on the TPM.
+pub fn make_credential_ecc<C, EkHash, EkCipher>(
+    ek_public: PublicKey<C>,
+    secret: &[u8],
+    key_name: Name,
+) -> Result<(IdObject, EncryptedSecret)>
+where
+    C: Curve + CurveArithmetic,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
+    FieldBytesSize<C>: ModulusSize,
+    <FieldBytesSize<C> as Add>::Output: Add<FieldBytesSize<C>>,
+    Sum<FieldBytesSize<C>, FieldBytesSize<C>>: ArraySize,
+    Sum<FieldBytesSize<C>, FieldBytesSize<C>>: Add<U8>,
+    Sum<Sum<FieldBytesSize<C>, FieldBytesSize<C>>, U8>: Add<B1>,
+    Add1<Sum<Sum<FieldBytesSize<C>, FieldBytesSize<C>>, U8>>: ArraySize,
+    EkHash: Digest + BlockSizeUser + FixedOutputReset,
+    <EkHash as OutputSizeUser>::OutputSize: Mul<U8>,
+    <<EkHash as OutputSizeUser>::OutputSize as Mul<U8>>::Output: Unsigned,
+    <EkHash as OutputSizeUser>::OutputSize: ArraySize + Mul<U8>,
+    <<EkHash as OutputSizeUser>::OutputSize as Mul<U8>>::Output: Unsigned,
+    EkCipher: KeySizeUser + BlockCipherEncrypt + KeyInit + TcgKeyTest,
+    <EkCipher as KeySizeUser>::KeySize: Mul<U8>,
+    <<EkCipher as KeySizeUser>::KeySize as Mul<U8>>::Output: ArraySize,
+{
+    let mut rng = rng();
+
+    loop {
+        let (seed, encrypted_secret) = secret_sharing::secret_sharing_ecc_curve::<
+            _,
+            kdf::Identity,
+            C,
+            TpmHmac<EkHash>,
+            EkHash,
+        >(&mut rng, &ek_public)?;
+
+        match secret_to_credential::<EkHash, EkCipher>(&seed, secret, &key_name)? {
+            Ok(id_object) => return Ok((id_object, encrypted_secret)),
+            Err(WeakKeyError) => {
+                // 11.4.10.4 Rejection of weak keys
+                // https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-1-Architecture.pdf#page=82
+
+                // The Key was considered weak, and we should re-run the creation of the encrypted
+                // secret.
+                continue;
+            }
+        }
+    }
+}
+
+/// [`make_credential_rsa`] creates a credential that will only be decrypted by the target RSA EK.
+///
+/// # Parameters
+///
+/// * `ek_public` is the RSA Public key of the Endorsement Key,
+/// * `secret` is the serialization of the credential,
+/// * `name` will usually be the AK held on the TPM.
+#[cfg(feature = "rsa")]
+pub fn make_credential_rsa<EkHash, EkCipher>(
+    ek_public: &RsaPublicKey,
+    secret: &[u8],
+    key_name: Name,
+) -> Result<(IdObject, EncryptedSecret)>
+where
+    EkHash: Digest + BlockSizeUser + FixedOutputReset,
+    <EkHash as OutputSizeUser>::OutputSize: Mul<U8>,
+    <<EkHash as OutputSizeUser>::OutputSize as Mul<U8>>::Output: Unsigned,
+    <EkHash as OutputSizeUser>::OutputSize: ArraySize + Mul<U8>,
+    <<EkHash as OutputSizeUser>::OutputSize as Mul<U8>>::Output: Unsigned,
+    EkCipher: KeySizeUser + BlockCipherEncrypt + KeyInit + TcgKeyTest,
+    <EkCipher as KeySizeUser>::KeySize: Mul<U8>,
+    <<EkCipher as KeySizeUser>::KeySize as Mul<U8>>::Output: ArraySize,
+{
+    let mut rng = rng();
+
+    loop {
+        let (random_seed, encrypted_secret) =
+            secret_sharing::secret_sharing_rsa::<_, kdf::Identity, TpmHmac<EkHash>, EkHash>(
+                &mut rng, ek_public,
+            )?;
+
+        match secret_to_credential::<EkHash, EkCipher>(&random_seed, secret, &key_name)? {
+            Ok(id_object) => return Ok((id_object, encrypted_secret)),
+            Err(WeakKeyError) => {
+                // 11.4.10.4 Rejection of weak keys
+                // https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-1-Architecture.pdf#page=82
+
+                // The Key was considered weak, and we should re-run the creation of the encrypted
+                // secret.
+                continue;
+            }
+        }
+    }
+}
+
+fn secret_to_credential<EkHash, EkCipher>(
+    seed: &Key<TpmHmac<EkHash>>,
+    secret: &[u8],
+    key_name: &Name,
+) -> Result<WeakResult<IdObject>>
+where
+    EkHash: Digest + BlockSizeUser + FixedOutputReset,
+    <EkHash as OutputSizeUser>::OutputSize: Mul<U8>,
+    <<EkHash as OutputSizeUser>::OutputSize as Mul<U8>>::Output: Unsigned,
+    <EkHash as OutputSizeUser>::OutputSize: ArraySize + Mul<U8>,
+    <<EkHash as OutputSizeUser>::OutputSize as Mul<U8>>::Output: Unsigned,
+    EkCipher: KeySizeUser + BlockCipherEncrypt + KeyInit + TcgKeyTest,
+    <EkCipher as KeySizeUser>::KeySize: Mul<U8>,
+    <<EkCipher as KeySizeUser>::KeySize as Mul<U8>>::Output: ArraySize,
+{
+    // Prepare the sensitive data
+    // this will be then encrypted using AES-CFB (size of the symmetric key depends on the EK).
+    let mut sensitive_data = {
+        let mut out = Zeroizing::new(vec![]);
+        out.extend_from_slice(
+            &u16::try_from(secret.len())
+                .map_err(|_| {
+                    error!("secret may only be 2^16 bytes long");
+                    Error::local_error(WrapperErrorKind::WrongParamSize)
+                })?
+                .to_be_bytes()[..],
+        );
+        out.extend_from_slice(secret);
+        out
+    };
+
+    // We'll now encrypt the sensitive data, and hmac the result of the encryption
+    // https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-1-Architecture.pdf#page=201
+    // See 24.4 Symmetric Encryption
+    let sym_key = kdf::kdfa::<EkHash, kdf::Storage, EkCipher>(seed, key_name.value(), &[])?;
+
+    if EkCipher::tcg_weak_key_test(&sym_key).is_err() {
+        // 11.4.10.4 Rejection of weak keys
+        // https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-1-Architecture.pdf#page=82
+        // The Key was considered weak, and we should re-run the creation of the encrypted
+        // secret.
+
+        return Ok(Err(WeakKeyError));
+    }
+
+    let iv: Iv<cfb_mode::Encryptor<EkCipher>> = Default::default();
+
+    cfb_mode::Encryptor::<EkCipher>::new(&sym_key, &iv).encrypt(&mut sensitive_data);
+
+    // See 24.5 HMAC
+    let hmac_key = kdf::kdfa::<EkHash, kdf::Integrity, TpmHmac<EkHash>>(seed, &[], &[])?;
+    let mut hmac = SimpleHmac::<EkHash>::new_from_slice(&hmac_key).map_err(|e| {
+        error!("HMAC initialization error: {e}");
+        Error::local_error(WrapperErrorKind::WrongParamSize)
+    })?;
+    Mac::update(&mut hmac, &sensitive_data);
+    Mac::update(&mut hmac, key_name.value());
+    let hmac = hmac.finalize();
+
+    // We'll now serialize the object and get everything through the door.
+    let mut out = vec![];
+    out.extend_from_slice(
+        &u16::try_from(hmac.into_bytes().len())
+            .map_err(|_| {
+                // NOTE: this shouldn't ever trigger ... but ...
+                error!("HMAC output may only be 2^16 bytes long");
+                Error::local_error(WrapperErrorKind::WrongParamSize)
+            })?
+            .to_be_bytes()[..],
+    );
+    out.extend_from_slice(&hmac.into_bytes());
+    out.extend_from_slice(&sensitive_data);
+
+    IdObject::from_bytes(&out).map(Ok)
+}

--- a/tss-esapi/src/utils/kdf.rs
+++ b/tss-esapi/src/utils/kdf.rs
@@ -1,0 +1,282 @@
+// Copyright 2025 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::ops::Mul;
+
+use byte_strings::concat_bytes;
+use digest::{
+    Digest, FixedOutputReset, Key, OutputSizeUser,
+    array::ArraySize,
+    common::{BlockSizeUser, KeySizeUser},
+    consts::U8,
+    typenum::Unsigned,
+};
+use ecdsa::elliptic_curve::{
+    AffinePoint, Curve, CurveArithmetic, FieldBytesSize, PublicKey,
+    ecdh::SharedSecret,
+    point::AffineCoordinates,
+    sec1::{FromSec1Point, ModulusSize, ToSec1Point},
+};
+use hmac::SimpleHmac;
+use kbkdf::{Counter, Kbkdf, Params};
+use log::error;
+
+use crate::{Error, Result, WrapperErrorKind};
+
+/// Label to be applied when deriving a key with either [`kdfa`] or [`kdfe`]
+pub trait KdfLabel {
+    /// Label that should be used for a given application
+    const LABEL: &[u8];
+    /// Label for a given application encoded as C string (terminated with `\0`].
+    const C_LABEL: &[u8];
+}
+
+macro_rules! impl_kdf_label {
+    ($usage:ty, $value: expr) => {
+        impl KdfLabel for $usage {
+            const LABEL: &[u8] = $value;
+            const C_LABEL: &[u8] = concat_bytes!($value, b"\0");
+        }
+    };
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Secret;
+impl_kdf_label!(Secret, b"SECRET");
+
+#[derive(Copy, Clone, Debug)]
+pub struct Context;
+impl_kdf_label!(Context, b"CONTEXT");
+
+#[derive(Copy, Clone, Debug)]
+pub struct Obfuscate;
+impl_kdf_label!(Obfuscate, b"OBFUSCATE");
+
+#[derive(Copy, Clone, Debug)]
+pub struct Storage;
+impl_kdf_label!(Storage, b"STORAGE");
+
+#[derive(Copy, Clone, Debug)]
+pub struct Integrity;
+impl_kdf_label!(Integrity, b"INTEGRITY");
+
+#[derive(Copy, Clone, Debug)]
+pub struct Commit;
+impl_kdf_label!(Commit, b"COMMIT");
+
+#[derive(Copy, Clone, Debug)]
+pub struct Cfb;
+impl_kdf_label!(Cfb, b"CFB");
+
+#[derive(Copy, Clone, Debug)]
+pub struct Xor;
+impl_kdf_label!(Xor, b"XOR");
+
+#[derive(Copy, Clone, Debug)]
+pub struct Session;
+impl_kdf_label!(Session, b"SESSION");
+
+#[derive(Copy, Clone, Debug)]
+pub struct Identity;
+impl_kdf_label!(Identity, b"IDENTITY");
+
+/// KDFa
+///
+/// This is a counter mode KDF from SP 800-108. It uses HMAC as the pseudo-random function (PRF). It is referred
+/// to in the [specification as `KDFa()`, defined in Section 9.4.10.2 KDFa()].
+///
+/// [specification as `KDFa()`, defined in Section 9.4.10.2 KDFa()]: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-1-Version-184_pub.pdf#page=50
+///
+/// # Parameters
+///
+///  - Type parameters:
+///    - `HashAlg` is the [`Digest`] to be used,
+///    - `Label` is the indicated use of the key eg: [`Context`], [`Storage`], [`Integrity`], ...
+///    - `K` is the number of of **bytes** in the output key,
+///      Note: Spec calls for **bits** but we have no support for partial bytes,
+///
+///  - Parameters:
+///    - `key` is a variable-sized value use as Kin,
+///    - `context_u` (`contextU` in the spec), is a variable-sized value concatenated with `context_v`
+///      to create the `Context` parameter used of the Counter mode KDF,
+///    - `context_v` (`contextV` in the spec), is a variable-sized value concatenated with
+///      `context_u` (see above).
+///
+/// # Usage
+///
+/// ```ignore
+/// // KDFa(sha256, key, "STORAGE", contextU, contextV, 256)
+/// kdfa::<Sha256, Storage, Key<Aes256>>(key, contextU, contextV);
+/// ```
+// TODO: Support generation of non-complete bytes:
+// See:
+// ```
+// If KDFa() were used to produce a 521-bit ECC private key, the returned value would occupy 66 octets, with
+// the upper 7 bits of the octet at offset zero set to 0.
+// ```
+// https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-1-Version-184_pub.pdf#page=51
+pub fn kdfa<HashAlg, Label, K>(key: &[u8], context_u: &[u8], context_v: &[u8]) -> Result<Key<K>>
+where
+    Label: KdfLabel,
+    HashAlg: Digest + BlockSizeUser,
+    K: KeySizeUser,
+    K::KeySize: ArraySize + Mul<U8>,
+    <K::KeySize as Mul<U8>>::Output: Unsigned,
+    <HashAlg as OutputSizeUser>::OutputSize: ArraySize + Mul<U8>,
+    <<HashAlg as OutputSizeUser>::OutputSize as Mul<U8>>::Output: Unsigned,
+{
+    let mut context = Vec::with_capacity(context_u.len() + context_v.len());
+    context.extend_from_slice(context_u);
+    context.extend_from_slice(context_v);
+
+    let kdf = Counter::<SimpleHmac<HashAlg>, K>::default();
+    kdf.derive(
+        Params::builder(key)
+            .with_label(Label::LABEL)
+            .with_context(&context)
+            .build(),
+    )
+    .map_err(|e| {
+        error!("KDFa derivation error: {e}");
+        Error::local_error(WrapperErrorKind::InternalError)
+    })
+}
+
+/// KDFe for ECDH
+///
+/// This provides a symmetric encryption key for an ECC-protected object. It is defined in
+/// [Section 9.4.10.3 KDFe for ECDH] of the spec
+///
+/// [Section 9.4.10.3 KDFe for ECDH]: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-1-Version-184_pub.pdf#page=52
+///
+/// # Parameters
+///
+///  - Type parameters:
+///    - `Use` is the indicated use of the key eg: [`Context`], [`Storage`], [`Integrity`], ...
+///    - `HashAlg` is the [`Digest`] to be used,
+///    - `C` is the [`Curve`] used by the ECC key,
+///    - `K` is the number of of **bytes** in the output key,
+///      Note: Spec calls for **bits** but we have no support for partial bytes,
+///
+///  - Parameters:
+///    - `z` (`Z` in the spec) is the product of a public point and a private x coordinate. This will be an ECDH
+///      [`SharedSecret`] on the curve (`C`),
+///    - `party_u_info` (`PartyUInfo` in the spec), is the public point of the ephemeral used to
+///      compute `Z`,
+///    - `party_v_info` (`PartyVInfo` in the spec), is the public point of a static TPM key
+pub fn kdfe<Use, HashAlg, C, K>(
+    z: &SharedSecret<C>,
+    party_u_info: &PublicKey<C>,
+    party_v_info: &PublicKey<C>,
+) -> Result<Key<K>>
+where
+    Use: KdfLabel,
+    HashAlg: Digest + FixedOutputReset,
+    C: Curve + CurveArithmetic,
+    K: KeySizeUser,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
+    FieldBytesSize<C>: ModulusSize,
+{
+    let mut key = Key::<K>::default();
+
+    let label_size = Use::C_LABEL.len();
+    let mut other_info = vec![0; label_size + (2 * FieldBytesSize::<C>::USIZE)];
+    other_info[..label_size].copy_from_slice(Use::C_LABEL);
+    other_info[label_size..label_size + FieldBytesSize::<C>::USIZE]
+        .copy_from_slice(&party_u_info.as_affine().x());
+    other_info[label_size + FieldBytesSize::<C>::USIZE..]
+        .copy_from_slice(&party_v_info.as_affine().x());
+
+    one_step_kdf::derive_key_into::<HashAlg>(z.raw_secret_bytes(), &other_info, &mut key).map_err(
+        |e| {
+            error!("KDFe derivation error: {e}");
+            Error::local_error(WrapperErrorKind::InternalError)
+        },
+    )?;
+
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use aes::Aes256;
+    use cipher::Array;
+    use hex_literal::hex;
+    use sha2::Sha256;
+
+    #[test]
+    fn test_kdfe() {
+        struct Vector<const S: usize, const K: usize, const E: usize> {
+            shared_secret: [u8; S],
+            local_key: [u8; K],
+            remote_key: [u8; K],
+            expected: [u8; E],
+        }
+
+        // Test vectors here were manually generated from tpm2-pytss
+        static TEST_VECTORS_SHA256: [Vector<
+            { FieldBytesSize::<p256::NistP256>::USIZE },
+            { <FieldBytesSize<p256::NistP256> as ModulusSize>::CompressedPointSize::USIZE },
+            32,
+        >; 2] = [
+            Vector {
+                shared_secret: hex!(
+                    "c75afb6f49c941ef194b232d7615769f5152d20de5dee19a991067f337dd65bc"
+                ),
+                local_key: hex!(
+                    "031ba4030de068a2f07919c42ef6b19f302884f35f45e7d4e4bb90ffbb0bd9d099"
+                ),
+                remote_key: hex!(
+                    "038f2b219a29c2ff9ba69cedff2d08d33a5dbca3da6bc8af8acd3ff6f5ec4dfbef"
+                ),
+                expected: hex!("e3a0079db19724f9b76101e9364c4a149cea3501336abc3b603f94b22b6309a5"),
+            },
+            Vector {
+                shared_secret: hex!(
+                    "a90a1c095155428500ed19e87c0df078df3dd2e66a0e3bbe664ba9ff62113b4a"
+                ),
+                local_key: hex!(
+                    "03e9c7d6a853ba6176b65ec2f328bdea25f61c4e1b23a4e1c08e1da8c723381a04"
+                ),
+                remote_key: hex!(
+                    "036ccf059628d3cdf8e1b4c4ba6d14696ba51cc8d4a96df4016f0b214782d5cee6"
+                ),
+                expected: hex!("865f8093e2c4b801dc8c236eeb2806c7b1c51c2cb04101c035f7f2511ea0aeda"),
+            },
+        ];
+
+        for v in &TEST_VECTORS_SHA256 {
+            let out = kdfe::<Identity, Sha256, p256::NistP256, Aes256>(
+                &SharedSecret::from(Array::from(v.shared_secret)),
+                &PublicKey::try_from(Array::from(v.local_key)).unwrap(),
+                &PublicKey::try_from(Array::from(v.remote_key)).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(out, v.expected);
+        }
+    }
+
+    #[test]
+    fn test_kdfa() {
+        struct Vector {
+            key: &'static [u8],
+            context_u: &'static [u8],
+            context_v: &'static [u8],
+            expected: &'static [u8],
+        }
+
+        static TEST_VECTORS_SHA256: [Vector; 1] = [Vector {
+            key: &hex!("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"),
+            context_u: b"",
+            context_v: &hex!("0506070809"),
+            expected: &hex!("de275f7f5cfeaac226b30d42377903b34705f178730d96400ccafb736e3d28a4"),
+        }];
+
+        for v in &TEST_VECTORS_SHA256 {
+            let out = kdfa::<Sha256, Storage, Aes256>(v.key, v.context_u, v.context_v).unwrap();
+            assert_eq!(out.as_slice(), v.expected);
+        }
+    }
+}

--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -23,6 +23,24 @@ use crate::{Context, Error, Result, WrapperErrorKind};
 use std::convert::TryFrom;
 use zeroize::Zeroize;
 
+#[cfg(feature = "rustcrypto")]
+use {
+    core::marker::PhantomData,
+    digest::{OutputSizeUser, common::KeySizeUser},
+};
+
+#[cfg(feature = "rustcrypto")]
+mod credential;
+#[cfg(feature = "rustcrypto")]
+pub mod kdf;
+#[cfg(feature = "rustcrypto")]
+mod secret_sharing;
+
+#[cfg(feature = "rustcrypto")]
+pub use self::credential::make_credential_ecc;
+#[cfg(all(feature = "rustcrypto", feature = "rsa"))]
+pub use self::credential::make_credential_rsa;
+
 /// Create the [Public] structure for a restricted decryption key.
 ///
 /// * `symmetric` - Cipher to be used for decrypting children of the key
@@ -267,4 +285,25 @@ pub fn get_tpm_vendor(context: &mut Context) -> Result<String> {
     .map(tpm_int_to_string)
     // Collect to a single string
     .collect())
+}
+// [`TpmHmac`] intends to code for the key expected for hmac
+// in the KDFa and KDFe derivations. There are no standard sizes for hmac keys really,
+// upstream RustCrypto considers it to be [BlockSize], but TPM specification
+// has a different opinion on the matter, and expect the key to the output
+// bit size of the hash algorithm used.
+//
+// See https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-1-Architecture.pdf#page=202
+// section 24.5 HMAC:
+//   bits the number of bits in the digest produced by ekNameAlg
+//
+// [BlockSize]: https://docs.rs/hmac/0.12.1/hmac/struct.HmacCore.html#impl-KeySizeUser-for-HmacCore%3CD%3E
+#[cfg(feature = "rustcrypto")]
+pub(super) struct TpmHmac<H>(PhantomData<H>);
+
+#[cfg(feature = "rustcrypto")]
+impl<H> KeySizeUser for TpmHmac<H>
+where
+    H: OutputSizeUser,
+{
+    type KeySize = H::OutputSize;
 }

--- a/tss-esapi/src/utils/secret_sharing.rs
+++ b/tss-esapi/src/utils/secret_sharing.rs
@@ -1,0 +1,139 @@
+// Copyright 2019 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! Secret sharing
+//!
+//! This provides encryption for the seed used for credential or duplication wrappers
+
+use cipher::common::{Key, KeySizeUser, typenum::Unsigned};
+use digest::{Digest, FixedOutputReset};
+use elliptic_curve::{
+    AffinePoint, Curve, CurveArithmetic, FieldBytesSize, Generate, PublicKey,
+    ecdh::{EphemeralSecret, SharedSecret},
+    sec1::{Coordinates, FromSec1Point, ModulusSize, ToSec1Point},
+};
+use log::error;
+use rand::CryptoRng;
+use zeroize::Zeroizing;
+
+#[cfg(feature = "rsa")]
+use rsa::{Oaep, RsaPublicKey};
+
+use crate::{
+    error::{Error, Result, WrapperErrorKind},
+    structures::EncryptedSecret,
+    utils::kdf::{self, KdfLabel},
+};
+/// Generates and encrypt a seed for a given ECC Public key on the curve
+///
+/// See [B.6 Secret Sharing]
+///
+/// # Parameters
+// TODO
+///   - Type parameters
+///     - `R` a [`CryptoRng`]
+///     - `Use` an application-dependent value
+///       See [Table 27: Protection Values], for the appropriate `seed Label`
+///     - `C` is the [`Curve`] of the storage key to encrypt the seed to.
+///     - `K` is the type of [`Key`] we should provide a seed for
+///     - `NameHash` is the naming hash algorithm of the recipient key
+///   - Values
+///     - `rng` the [`CryptoRng`] to derive an ephemeral from for the ECDH
+///     - `recipient_key` is the Public key we shall encrypt the seed to.
+///
+/// [B.6 Secret Sharing]: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-1-Version-184_pub.pdf#page=284
+/// [Table 27: Protection Values]: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-1-Version-184_pub.pdf#page=155
+pub(super) fn secret_sharing_ecc_curve<R, Use, C, K, NameHash>(
+    rng: &mut R,
+    recipient_key: &PublicKey<C>,
+) -> Result<(Zeroizing<Key<K>>, EncryptedSecret)>
+where
+    R: CryptoRng + ?Sized,
+    Use: KdfLabel,
+    C: Curve + CurveArithmetic,
+    K: KeySizeUser,
+    NameHash: Digest + FixedOutputReset,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
+    FieldBytesSize<C>: ModulusSize,
+{
+    let local = EphemeralSecret::<C>::generate_from_rng(rng);
+    let ecdh_secret: SharedSecret<C> = local.diffie_hellman(recipient_key);
+    let local_public = local.public_key();
+    drop(local);
+
+    let seed = Zeroizing::new(kdf::kdfe::<Use, NameHash, C, K>(
+        &ecdh_secret,
+        &local_public,
+        recipient_key,
+    )?);
+    drop(ecdh_secret);
+
+    // The local ECDH pair is used as "encrypted seed"
+    let encoded_point = local_public.to_sec1_point(false);
+    let Coordinates::Uncompressed {
+        x: point_x,
+        y: point_y,
+    } = encoded_point.coordinates()
+    else {
+        // NOTE: The only way this could trigger would be for the local key to be identity.
+        error!("Couldn't compute coordinates for the local public key");
+        return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+    };
+    let encrypted_seed = {
+        let mut out = vec![];
+        out.extend_from_slice(&FieldBytesSize::<C>::U16.to_be_bytes()[..]);
+        out.extend_from_slice(point_x);
+        out.extend_from_slice(&FieldBytesSize::<C>::U16.to_be_bytes()[..]);
+        out.extend_from_slice(point_y);
+        out
+    };
+    let encrypted_seed = EncryptedSecret::from_bytes(&encrypted_seed)?;
+
+    Ok((seed, encrypted_seed))
+}
+
+/// Generates and encrypt a seed for a given RSA public key
+///
+/// See [A.10 Secret Sharing]
+///
+/// # Parameters
+///   - Type parameters
+///     - `R` a [`CryptoRng`]
+///     - `Use` an application-dependent value
+///       See [Table 27: Protection Values], for the appropriate `seed Label`
+///     - `K` is the type of [`Key`] we should provide a seed for
+///     - `NameHash` is the naming hash algorithm of the recipient key
+///   - Values
+///     - `rng` the [`CryptoRng`] to derive a random seed from,
+///     - `recipient_key` is the [`RsaPublicKey`] we shall encrypt the seed to.
+///
+/// [A.10 Secret Sharing]: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-1-Version-184_pub.pdf#page=284
+/// [Table 27: Protection Values]: https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-1-Version-184_pub.pdf#page=155
+#[cfg(feature = "rsa")]
+pub(super) fn secret_sharing_rsa<R, Use, K, NameHash>(
+    rng: &mut R,
+    recipient_key: &RsaPublicKey,
+) -> Result<(Zeroizing<Key<K>>, EncryptedSecret)>
+where
+    R: CryptoRng + ?Sized,
+    Use: KdfLabel,
+    K: KeySizeUser,
+    NameHash: Digest + FixedOutputReset,
+{
+    let random_seed = {
+        let mut out = Zeroizing::new(Key::<K>::default());
+        rng.fill_bytes(&mut out);
+        out
+    };
+    let encrypted_seed = {
+        let padding = Oaep::<NameHash>::new_with_label(Use::C_LABEL);
+        recipient_key
+            .encrypt(rng, padding, &random_seed)
+            .map_err(|e| {
+                error!("RSA OAEP encryption error: {e}");
+                Error::local_error(WrapperErrorKind::InternalError)
+            })?
+    };
+    let encrypted_secret = EncryptedSecret::from_bytes(&encrypted_seed)?;
+
+    Ok((random_seed, encrypted_secret))
+}

--- a/tss-esapi/tests/Cargo.lock.frozen
+++ b/tss-esapi/tests/Cargo.lock.frozen
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +185,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "byte-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002ee5531feb8450e59862fefa550eeac39b726d60b186071672751045ebc29a"
+dependencies = [
+ "byte-strings-proc_macros",
+]
+
+[[package]]
+name = "byte-strings-proc_macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f7e0e71f98d6c71bfe42b0a7a47d0f870ad808401fad2d44fa156ed5b0ae03"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfb-mode"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac64b0984be8510caae81455ea2c8c23e5af6be61c36129df62f3380d5d64e1f"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +247,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "rand_core",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -348,6 +398,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -587,6 +646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +772,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "kbkdf"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ac93c9768b8d587407881c98b0c3a5d3e3049daa73408ebe5bfb1ab1cb9c84"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -854,6 +937,15 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "one-step-kdf"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd4dc68a57d9494825faa914644f4ec754f23366f51b4f09d8feea37c64808db"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "p192"
@@ -1427,20 +1519,29 @@ dependencies = [
 name = "tss-esapi"
 version = "8.0.0-alpha.2"
 dependencies = [
+ "aes",
  "assert_fs",
  "bitfield",
+ "byte-strings",
+ "cfb-mode",
  "cfg-if",
+ "cipher",
+ "des",
  "digest",
  "ecdsa",
  "elliptic-curve",
  "enumflags2",
  "env_logger",
  "getrandom",
+ "hex-literal",
+ "hmac",
  "hostname-validator",
+ "kbkdf",
  "log",
  "malloced",
  "num-derive",
  "num-traits",
+ "one-step-kdf",
  "p192",
  "p224",
  "p256",

--- a/tss-esapi/tests/Cargo.lock.frozen
+++ b/tss-esapi/tests/Cargo.lock.frozen
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -43,29 +43,49 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_fs"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ecf5c70ca07b7f80220bce936f0556a960ca6fb00fc2bd4125b5e581b218137"
+dependencies = [
+ "anstyle",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autotools"
@@ -78,15 +98,15 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
@@ -130,31 +150,36 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "bstr"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -174,15 +199,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "clang-sys"
-version = "1.7.0"
+name = "chacha20"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
@@ -192,46 +234,103 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
+name = "crossbeam-deque"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
- "generic-array",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom",
+ "hybrid-array",
+ "num-traits",
  "rand_core",
+ "serdect",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint",
+ "rand_core",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -242,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -252,22 +351,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
+name = "difflib"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
  "digest",
@@ -275,27 +380,29 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
+ "crypto-common",
  "digest",
  "ff",
- "generic-array",
  "group",
  "hkdf",
+ "hybrid-array",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -306,18 +413,18 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.7.9"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.9"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -326,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
@@ -348,14 +455,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.13.1"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "flagset"
@@ -364,43 +505,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
- "zeroize",
-]
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "rand_core",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -410,18 +588,18 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
@@ -433,44 +611,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
+name = "hybrid-array"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "subtle",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -479,21 +702,19 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
+ "cfg-if",
  "cpufeatures",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lenient_semver"
@@ -537,31 +758,31 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.15"
+name = "linux-raw-sys"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "malloced"
@@ -571,9 +792,9 @@ checksum = "6dfebb2f9e0b39509c62eead6ec7ae0c0ed45bb61d12bbcf4e976c566c5400ec"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "minimal-lexical"
@@ -603,23 +824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,100 +835,89 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "p192"
-version = "0.13.0"
+version = "0.14.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0533bc6c238f2669aab8db75ae52879dc74e88d6bd3685bd4022a00fa85cd2"
+checksum = "5a11179a6732903ba21ca35e91fc0bc9ef22ef7acfe6156a1ff2507eff10817a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "sec1",
 ]
 
 [[package]]
 name = "p224"
-version = "0.13.2"
+version = "0.14.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c06436d66652bc2f01ade021592c80a2aad401570a18aa18b82e440d2b9aa1"
+checksum = "85577801576d9ddd06276d905db79d25cb5faae34d89d896aa140d75a2ec324f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
  "sha2",
 ]
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
  "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
  "primeorder",
  "sha2",
 ]
 
 [[package]]
 name = "p521"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct",
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "rand_core",
  "sha2",
 ]
 
@@ -736,29 +929,28 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
  "der",
- "pkcs8",
  "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -766,15 +958,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -786,85 +978,115 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
+name = "predicates"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
- "zerocopy",
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common",
+ "ff",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -874,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -885,31 +1107,30 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
 ]
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid",
+ "crypto-bigint",
+ "crypto-primes",
  "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core",
@@ -917,7 +1138,6 @@ dependencies = [
  "sha2",
  "signature",
  "spki",
- "subtle",
  "zeroize",
 ]
 
@@ -928,21 +1148,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustix"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
+ "ctutils",
  "der",
- "generic-array",
- "pkcs8",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -955,18 +1191,28 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -975,21 +1221,32 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.136"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336a0c23cf42a38d9eaa7cd22c7040d04e1228a19a933890805ffd00a16437d2"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -998,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1009,12 +1266,13 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
 dependencies = [
  "digest",
  "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -1025,9 +1283,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
  "digest",
  "rand_core",
@@ -1035,12 +1293,16 @@ dependencies = [
 
 [[package]]
 name = "sm2"
-version = "0.13.3"
+version = "0.14.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b22092ef242a118f03ee41dc46b2720c0ca076f544116dbc915cacf532cfaa"
+checksum = "7363f4a0c854c1d753db638bac877a78a3ac7149d2218ae0cf09971338b40bd8"
 dependencies = [
+ "der",
  "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
  "primeorder",
+ "rand_core",
  "rfc6979",
  "signature",
  "sm3",
@@ -1048,34 +1310,38 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb9a3b702d0a7e33bc4d85a14456633d2b165c2ad839c5fd9a8417c1ab15860"
+checksum = "da6a89ba31723d185fd7413b98c576a575f356d9b84729d8ecb6ead60000a5b6"
 dependencies = [
  "digest",
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
+name = "socket2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "strum"
@@ -1103,9 +1369,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1119,10 +1385,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
-name = "tls_codec"
-version = "0.4.1"
+name = "tempfile"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
 dependencies = [
  "tls_codec_derive",
  "zeroize",
@@ -1130,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "tls_codec_derive"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1143,6 +1427,7 @@ dependencies = [
 name = "tss-esapi"
 version = "8.0.0-alpha.2"
 dependencies = [
+ "assert_fs",
  "bitfield",
  "cfg-if",
  "digest",
@@ -1163,6 +1448,7 @@ dependencies = [
  "p521",
  "paste",
  "pkcs8",
+ "rand",
  "regex",
  "rsa",
  "semver",
@@ -1174,6 +1460,7 @@ dependencies = [
  "signature",
  "sm2",
  "sm3",
+ "socket2",
  "strum",
  "strum_macros",
  "tss-esapi",
@@ -1184,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi-sys"
-version = "0.6.0-alpha.2"
+version = "0.7.0-alpha.1"
 dependencies = [
  "autotools",
  "bindgen",
@@ -1197,15 +1484,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -1214,25 +1507,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
+name = "walkdir"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
- "windows-targets 0.48.5",
+ "same-file",
+ "winapi-util",
 ]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1240,22 +1589,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -1264,21 +1607,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1288,21 +1625,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1318,21 +1643,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1342,21 +1655,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1375,10 +1676,115 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-cert"
-version = "0.2.5"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
  "const-oid",
  "der",
@@ -1389,41 +1795,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"

--- a/tss-esapi/tests/integration_tests/abstraction_tests/credential_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/credential_tests.rs
@@ -1,0 +1,222 @@
+// Copyright 2025 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use tss_esapi::{
+    abstraction::{AsymmetricAlgorithmSelection, ak, ek},
+    attributes::SessionAttributesBuilder,
+    constants::SessionType,
+    handles::AuthHandle,
+    interface_types::{
+        algorithm::{HashingAlgorithm, SignatureSchemeAlgorithm},
+        ecc::EccCurve,
+        key_bits::RsaKeyBits,
+        session_handles::PolicySession,
+    },
+    structures::{Digest, SymmetricDefinition},
+    utils,
+};
+
+use elliptic_curve::PublicKey;
+use rsa::RsaPublicKey;
+
+use crate::common::create_ctx_without_session;
+
+#[test]
+fn test_credential_ecc() {
+    let mut context = create_ctx_without_session();
+
+    let ek_ecc = ek::create_ek_object(
+        &mut context,
+        AsymmetricAlgorithmSelection::Ecc(EccCurve::NistP256),
+        None,
+    )
+    .unwrap();
+
+    let (ek_pub, _, _) = context.read_public(ek_ecc).unwrap();
+
+    let ak_res = ak::create_ak(
+        &mut context,
+        ek_ecc,
+        HashingAlgorithm::Sha384,
+        AsymmetricAlgorithmSelection::Ecc(EccCurve::NistP384),
+        SignatureSchemeAlgorithm::EcDsa,
+        None,
+        None,
+    )
+    .unwrap();
+
+    let ak_ecc = ak::load_ak(
+        &mut context,
+        ek_ecc,
+        None,
+        ak_res.out_private,
+        ak_res.out_public,
+    )
+    .unwrap();
+
+    let (_, key_name, _) = context.read_public(ak_ecc).unwrap();
+    let cred = vec![1, 2, 3, 4, 5];
+    let expected = Digest::try_from(vec![1, 2, 3, 4, 5]).unwrap();
+
+    let (credential_blob, secret) = utils::make_credential_ecc::<_, sha2::Sha256, aes::Aes128>(
+        PublicKey::<p256::NistP256>::try_from(&ek_pub).unwrap(),
+        &cred,
+        key_name,
+    )
+    .expect("Create credential");
+
+    let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new().build();
+    let session_1 = context
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Hmac,
+            SymmetricDefinition::AES_256_CFB,
+            HashingAlgorithm::Sha256,
+        )
+        .expect("Failed to call start_auth_session")
+        .expect("Failed invalid session value");
+    context
+        .tr_sess_set_attributes(session_1, session_attributes, session_attributes_mask)
+        .unwrap();
+
+    let session_2 = context
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Policy,
+            SymmetricDefinition::AES_256_CFB,
+            HashingAlgorithm::Sha256,
+        )
+        .expect("Failed to call start_auth_session")
+        .expect("Failed invalid session value");
+    context
+        .tr_sess_set_attributes(session_2, session_attributes, session_attributes_mask)
+        .expect("Failed to call tr_sess_set_attributes");
+
+    let _ = context
+        .execute_with_session(Some(session_1), |ctx| {
+            ctx.policy_secret(
+                PolicySession::try_from(session_2)
+                    .expect("Failed to convert auth session to policy session"),
+                AuthHandle::Endorsement,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+            )
+        })
+        .unwrap();
+
+    context.set_sessions((Some(session_1), Some(session_2), None));
+    let decrypted = context
+        .activate_credential(ak_ecc, ek_ecc, credential_blob, secret)
+        .unwrap();
+
+    assert_eq!(expected, decrypted);
+
+    context.flush_context(ek_ecc.into()).unwrap();
+    context.flush_context(ak_ecc.into()).unwrap();
+}
+
+#[test]
+fn test_credential_rsa() {
+    let mut context = create_ctx_without_session();
+
+    let ek_rsa = ek::create_ek_object(
+        &mut context,
+        AsymmetricAlgorithmSelection::Rsa(RsaKeyBits::Rsa2048),
+        None,
+    )
+    .unwrap();
+
+    let (ek_pub, _, _) = context.read_public(ek_rsa).unwrap();
+
+    let ak_res = ak::create_ak(
+        &mut context,
+        ek_rsa,
+        HashingAlgorithm::Sha256,
+        AsymmetricAlgorithmSelection::Rsa(RsaKeyBits::Rsa2048),
+        SignatureSchemeAlgorithm::RsaPss,
+        None,
+        None,
+    )
+    .unwrap();
+
+    let ak_rsa = ak::load_ak(
+        &mut context,
+        ek_rsa,
+        None,
+        ak_res.out_private,
+        ak_res.out_public,
+    )
+    .unwrap();
+
+    let (_, key_name, _) = context.read_public(ak_rsa).unwrap();
+    let cred = vec![1, 2, 3, 4, 5];
+    let expected = Digest::try_from(vec![1, 2, 3, 4, 5]).unwrap();
+
+    let (credential_blob, secret) = utils::make_credential_rsa::<sha2::Sha256, aes::Aes128>(
+        &RsaPublicKey::try_from(&ek_pub).unwrap(),
+        &cred,
+        key_name,
+    )
+    .expect("Create credential");
+
+    let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new().build();
+    let session_1 = context
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Hmac,
+            SymmetricDefinition::AES_256_CFB,
+            HashingAlgorithm::Sha256,
+        )
+        .expect("Failed to call start_auth_session")
+        .expect("Failed invalid session value");
+    context
+        .tr_sess_set_attributes(session_1, session_attributes, session_attributes_mask)
+        .unwrap();
+
+    let session_2 = context
+        .start_auth_session(
+            None,
+            None,
+            None,
+            SessionType::Policy,
+            SymmetricDefinition::AES_256_CFB,
+            HashingAlgorithm::Sha256,
+        )
+        .expect("Failed to call start_auth_session")
+        .expect("Failed invalid session value");
+    context
+        .tr_sess_set_attributes(session_2, session_attributes, session_attributes_mask)
+        .expect("Failed to call tr_sess_set_attributes");
+
+    let _ = context
+        .execute_with_session(Some(session_1), |ctx| {
+            ctx.policy_secret(
+                PolicySession::try_from(session_2)
+                    .expect("Failed to convert auth session to policy session"),
+                AuthHandle::Endorsement,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+            )
+        })
+        .unwrap();
+
+    context.set_sessions((Some(session_1), Some(session_2), None));
+    let decrypted = context
+        .activate_credential(ak_rsa, ek_rsa, credential_blob, secret)
+        .unwrap();
+
+    assert_eq!(expected, decrypted);
+
+    context.flush_context(ek_rsa.into()).unwrap();
+    context.flush_context(ak_rsa.into()).unwrap();
+}

--- a/tss-esapi/tests/integration_tests/abstraction_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod ak_tests;
+mod credential_tests;
 mod ek_tests;
 mod no_tpm;
 mod nv_tests;

--- a/tss-esapi/tests/integration_tests/abstraction_tests/public_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/public_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod public_rsa_test {
-    use rsa::{BigUint, pkcs1, traits::PublicKeyParts};
+    use rsa::{BoxedUint, pkcs1, traits::PublicKeyParts};
     use std::convert::TryFrom;
     use tss_esapi::{
         attributes::ObjectAttributesBuilder,
@@ -71,11 +71,11 @@ mod public_rsa_test {
     #[test]
     fn test_public_to_decoded_key_rsa() {
         let public_rsa = get_ext_rsa_pub();
-        let default_exponent = BigUint::from(RSA_DEFAULT_EXP);
+        let default_exponent = BoxedUint::from(RSA_DEFAULT_EXP);
         let key = rsa::RsaPublicKey::try_from(&public_rsa)
             .expect("Failed to convert Public structure to DecodedKey (RSA).");
         assert_eq!(key.e(), &default_exponent, "RSA exponents are not equal.");
-        assert_eq!(key.n().to_bytes_be(), RSA_KEY);
+        assert_eq!(key.n_bytes().as_ref(), RSA_KEY);
     }
 
     #[test]
@@ -83,7 +83,7 @@ mod public_rsa_test {
         let public_rsa = get_ext_rsa_pub();
         let key = SubjectPublicKeyInfoOwned::try_from(&public_rsa)
             .expect("Failed to convert Public structure to SubjectPublicKeyInfo (RSA).");
-        let default_exponent = BigUint::from(RSA_DEFAULT_EXP);
+        let default_exponent = BoxedUint::from(RSA_DEFAULT_EXP);
         assert_eq!(key.algorithm, pkcs1::ALGORITHM_ID.ref_to_owned());
         let pkcs1_key = pkcs1::RsaPublicKey::try_from(
             key.subject_public_key
@@ -94,7 +94,7 @@ mod public_rsa_test {
 
         assert_eq!(
             pkcs1_key.public_exponent.as_bytes(),
-            default_exponent.to_bytes_be()
+            default_exponent.to_be_bytes_trimmed_vartime().as_ref()
         );
         assert_eq!(pkcs1_key.modulus.as_bytes(), RSA_KEY);
     }
@@ -168,7 +168,7 @@ mod public_ecc_test {
         let key = p256::PublicKey::try_from(&public_ecc)
             .expect("Failed to convert Public structure to DecodedKey (ECC).");
 
-        let ec_point = p256::EncodedPoint::from(key);
+        let ec_point = p256::Sec1Point::from(key);
         assert_eq!(ec_point.as_bytes(), EC_POINT.to_vec());
     }
 

--- a/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
@@ -511,7 +511,7 @@ fn ctx_migration_test() {
     // one for just the public part of the key
     let mut basic_ctx = swtpm.create_session_context();
     let mut random_digest = vec![0u8; 16];
-    getrandom::getrandom(&mut random_digest).unwrap();
+    getrandom::fill(&mut random_digest).unwrap();
     let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
     let prim_key_handle = basic_ctx
         .create_primary(
@@ -901,10 +901,10 @@ fn sign_csr() {
     let subject = Name::from_str("CN=tpm.example").expect("Parse common name");
     let signer = EcSigner::<NistP256, _>::new((Mutex::new(&mut ctx), tpm_km, key_params, None))
         .expect("Create a signer");
-    let builder = RequestBuilder::new(subject, &signer).expect("Create certificate request");
+    let builder = RequestBuilder::new(subject).expect("Create certificate request");
 
     let cert_req = builder
-        .build::<p256::ecdsa::DerSignature>()
+        .build::<_, p256::ecdsa::DerSignature>(&signer)
         .expect("Sign a CSR");
 
     println!(
@@ -926,12 +926,21 @@ fn sign_p256_sha2_256() {
         .expect("Create a signer");
 
     let payload = b"Example of ECDSA with P-256";
-    let mut hash = Sha256::new();
-    hash.update(payload);
 
-    let signature: p256::ecdsa::Signature = signer.sign_digest(hash.clone());
+    let signature: p256::ecdsa::Signature =
+        signer.sign_digest(|hash: &mut Sha256| hash.update(payload));
     let verifying_key: VerifyingKey = *signer.as_ref();
-    assert!(verifying_key.verify_digest(hash, &signature).is_ok());
+    assert!(
+        verifying_key
+            .verify_digest(
+                |hash: &mut Sha256| {
+                    hash.update(payload);
+                    Ok(())
+                },
+                &signature
+            )
+            .is_ok()
+    );
 }
 
 // NOTE(baloo): I believe this is a legitimate case, but support is not available yet in libtpms (or swtpm)
@@ -957,13 +966,21 @@ fn sign_p256_sha3_256() {
         .expect("Create a signer");
 
     let payload = b"Example of ECDSA with P-256";
-    let mut hash = Sha3_256::new();
-    hash.update(payload);
 
     let signature = <EcSigner<_, _> as DigestSigner<Sha3_256, p256::ecdsa::Signature>>::sign_digest(
         &signer,
-        hash.clone(),
+        |hash: &mut Sha3_256| hash.update(payload),
     );
     let verifying_key: VerifyingKey = *signer.as_ref();
-    assert!(verifying_key.verify_digest(hash, &signature).is_ok());
+    assert!(
+        verifying_key
+            .verify_digest(
+                |hash: &mut Sha3_256| {
+                    hash.update(payload);
+                    Ok(())
+                },
+                &signature
+            )
+            .is_ok()
+    );
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
@@ -20,7 +20,7 @@ mod test_rsa_encrypt_decrypt {
     fn test_encrypt_decrypt() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -61,7 +61,7 @@ mod test_rsa_encrypt_decrypt {
     fn test_ecdh() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let ecc_parms = PublicEccParametersBuilder::new()
@@ -126,7 +126,7 @@ mod test_zgen_2phase {
     fn test_zgen_2phase() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).expect("Failed to get random bytes");
+        getrandom::fill(&mut random_digest).expect("Failed to get random bytes");
         let key_auth =
             Auth::from_bytes(random_digest.as_slice()).expect("Failed to create key auth");
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/context_management_tests.rs
@@ -8,7 +8,7 @@ mod test_ctx_save {
     fn test_ctx_save() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -29,7 +29,7 @@ mod test_ctx_save {
     fn test_ctx_save_leaf() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let prim_key_handle = context
@@ -73,7 +73,7 @@ mod test_ctx_load {
     fn test_ctx_load() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
 
         let prim_key_handle = context
             .create_primary(
@@ -116,7 +116,7 @@ mod test_flush_context {
     fn test_flush_ctx() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -138,7 +138,7 @@ mod test_flush_context {
     fn test_flush_parent_ctx() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let prim_key_handle = context

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -518,7 +518,7 @@ mod test_policy_authorize {
     fn test_policy_authorize() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/ephemeral_ec_keys_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/ephemeral_ec_keys_tests.rs
@@ -39,7 +39,7 @@ mod test_commit {
     fn test_commit() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).expect("Failed to get random bytes");
+        getrandom::fill(&mut random_digest).expect("Failed to get random bytes");
         let key_auth =
             Auth::from_bytes(random_digest.as_slice()).expect("Failed to create key auth");
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
@@ -10,7 +10,7 @@ mod test_create_primary {
     fn test_create_primary() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -95,7 +95,7 @@ mod test_change_auth {
             .unwrap();
 
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let new_key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let new_private = context
@@ -111,7 +111,7 @@ mod test_change_auth {
         let mut context = create_ctx_with_session();
 
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let new_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         // NOTE: If this test failed on your system, you are probably running it against a

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
@@ -10,7 +10,7 @@ mod test_create_primary {
     fn test_create_primary() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -155,7 +155,7 @@ mod test_change_auth {
             .unwrap();
 
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let new_key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let new_private = context
@@ -171,7 +171,7 @@ mod test_change_auth {
         let mut context = create_ctx_with_session();
 
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let new_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         // NOTE: If this test failed on your system, you are probably running it against a

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/object_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/object_commands_tests.rs
@@ -8,7 +8,7 @@ mod test_create {
     fn test_create() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let prim_key_handle = context
@@ -44,7 +44,7 @@ mod test_load {
     fn test_load() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let prim_key_handle = context
@@ -195,7 +195,7 @@ mod test_read_public {
     fn test_read_public() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
@@ -12,7 +12,7 @@ mod test_verify_signature {
     fn test_verify_signature() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -49,7 +49,7 @@ mod test_verify_signature {
     fn test_verify_wrong_signature() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -98,7 +98,7 @@ mod test_verify_signature {
     fn test_verify_wrong_signature_2() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -137,7 +137,7 @@ mod test_verify_signature {
     fn test_verify_wrong_signature_3() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -209,7 +209,7 @@ mod test_sign {
     fn test_sign() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -238,7 +238,7 @@ mod test_sign {
     fn test_sign_empty_digest() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -267,7 +267,7 @@ mod test_sign {
     fn test_sign_large_digest() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -303,7 +303,7 @@ mod test_sign {
 
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -312,7 +312,7 @@ mod test_sign {
             .key_handle;
 
         let mut random = vec![0u8; 47];
-        getrandom::getrandom(&mut random).unwrap();
+        getrandom::fill(&mut random).unwrap();
 
         let signer = EcSigner::<NistP256, _>::new((Mutex::new(&mut *context), key_handle)).unwrap();
         let verifying_key = signer.verifying_key();
@@ -326,7 +326,7 @@ mod test_sign {
     fn test_sign_signer_rsa_pkcs() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let key_handle = context
@@ -342,7 +342,7 @@ mod test_sign {
             .key_handle;
 
         let mut payload = vec![0u8; 47];
-        getrandom::getrandom(&mut payload).unwrap();
+        getrandom::fill(&mut payload).unwrap();
 
         let signer =
             RsaPkcsSigner::<_, sha2::Sha256>::new((Mutex::new(&mut *context), key_handle)).unwrap();
@@ -351,8 +351,15 @@ mod test_sign {
 
         verifying_key.verify(&payload, &signature).unwrap();
 
-        let d = sha2::Sha256::new_with_prefix(&payload);
-        verifying_key.verify_digest(d, &signature).unwrap();
+        verifying_key
+            .verify_digest(
+                |d: &mut sha2::Sha256| {
+                    d.update(&payload);
+                    Ok(())
+                },
+                &signature,
+            )
+            .unwrap();
     }
 
     #[cfg(feature = "rsa")]
@@ -360,7 +367,7 @@ mod test_sign {
     fn test_sign_signer_rsa_pss() {
         let mut context = create_ctx_with_session();
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).unwrap();
+        getrandom::fill(&mut random_digest).unwrap();
         let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
 
         let rsa_pss = utils::create_unrestricted_signing_rsa_public(
@@ -377,7 +384,7 @@ mod test_sign {
             .key_handle;
 
         let mut payload = vec![0u8; 47];
-        getrandom::getrandom(&mut payload).unwrap();
+        getrandom::fill(&mut payload).unwrap();
 
         let signer =
             RsaPssSigner::<_, sha2::Sha256>::new((Mutex::new(&mut *context), key_handle)).unwrap();
@@ -386,7 +393,14 @@ mod test_sign {
 
         verifying_key.verify(&payload, &signature).unwrap();
 
-        let d = sha2::Sha256::new_with_prefix(&payload);
-        verifying_key.verify_digest(d, &signature).unwrap();
+        verifying_key
+            .verify_digest(
+                |d: &mut sha2::Sha256| {
+                    d.update(&payload);
+                    Ok(())
+                },
+                &signature,
+            )
+            .unwrap();
     }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/symmetric_primitives_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/symmetric_primitives_tests.rs
@@ -25,7 +25,7 @@ mod test_encrypt_decrypt_2 {
             .expect("Failed to set auth to empty for owner");
 
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).expect("get_rand call failed");
+        getrandom::fill(&mut random_digest).expect("get_rand call failed");
         let primary_key_auth =
             Auth::from_bytes(random_digest.as_slice()).expect("Failed to create primary key auth");
 
@@ -70,7 +70,7 @@ mod test_encrypt_decrypt_2 {
             .expect("Failed to create public for symmetric key public");
 
         let mut random_digest = vec![0u8; 16];
-        getrandom::getrandom(&mut random_digest).expect("get_rand call failed");
+        getrandom::fill(&mut random_digest).expect("get_rand call failed");
         let symmetric_key_auth = Auth::from_bytes(random_digest.as_slice())
             .expect("Failed to create symmetric key auth");
 

--- a/tss-esapi/tests/lint-checks.sh
+++ b/tss-esapi/tests/lint-checks.sh
@@ -20,4 +20,10 @@ fi
 ##################
 # Execute clippy #
 ##################
-cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::cargo
+LINTS=""
+LINTS="$LINTS -D clippy::all"
+LINTS="$LINTS -D clippy::cargo"
+# clippy::cargo disallows multiple versions of the crate in the tree
+# We depend on getrandom which itself will depends on both wit-bindgen 0.46 and 0.51
+LINTS="$LINTS -A clippy::multiple-crate-versions"
+cargo clippy --all-targets --all-features -- $LINTS


### PR DESCRIPTION
This brings support for a pure rust implementation of make credentials which will not involve the TPM or `tpm2-tss`.

Fixes #160