### PR TITLE
chore: fixup clippy lint

### DIFF
--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -526,8 +526,7 @@ impl TransientKeyContext {
                 .load_external_public(public, Hierarchy::Owner)?
         } else {
             self.context
-                .load(self.root_key_handle, material.private.try_into()?, public)
-                .map(KeyHandle::from)?
+                .load(self.root_key_handle, material.private.try_into()?, public)?
         };
         let key_auth_value = auth.unwrap_or_default();
         if !key_auth_value.is_empty() {


### PR DESCRIPTION
Clippy 1.85 released between the last time the CI ran for #537 and the time it merged.
This broke CI on main.