### PR TITLE
integration_tests: don't swallow error while creating ubuntu docker image

### DIFF
--- a/tss-esapi/src/structures/lists/digest.rs
+++ b/tss-esapi/src/structures/lists/digest.rs
@@ -14,7 +14,7 @@ pub struct DigestList {
 impl DigestList {
     pub const MAX_SIZE: usize = 8;
 
-    /// Creates a nnew empty DigestList
+    /// Creates a new empty DigestList
     pub const fn new() -> Self {
         DigestList {
             digests: Vec::new(),

--- a/tss-esapi/tests/Dockerfile-ubuntu
+++ b/tss-esapi/tests/Dockerfile-ubuntu
@@ -2,7 +2,7 @@ FROM ghcr.io/tpm2-software/ubuntu-20.04:latest AS base
 
 FROM base AS rust-toolchain
 # Install Rust toolchain
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN (curl https://sh.rustup.rs -sSf || exit 1) | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 FROM rust-toolchain AS tpm2-tss


### PR DESCRIPTION
When there is an error fetching the script and the result is empty, bash does not complain.
The result is a broken image.