### PR TITLE
rework TryFrom converting signatures to accept a ref

### DIFF
--- a/tss-esapi/src/abstraction/no_tpm/quote.rs
+++ b/tss-esapi/src/abstraction/no_tpm/quote.rs
@@ -45,7 +45,7 @@ where
     SignatureSize<C>: ArrayLength<u8>,
     FieldBytesSize<C>: ModulusSize,
 {
-    let Ok(signature) = ecdsa::Signature::<C>::try_from(signature.clone()) else {
+    let Ok(signature) = ecdsa::Signature::<C>::try_from(signature) else {
         return Ok(false);
     };
     let Ok(public) = elliptic_curve::PublicKey::<C>::try_from(public) else {
@@ -342,7 +342,7 @@ pub fn checkquote(
         }
         #[cfg(feature = "rsa")]
         (Public::Rsa { .. }, sig @ Signature::RsaSsa(pkcs_sig)) => {
-            let Ok(sig) = pkcs1v15::Signature::try_from(sig.clone()) else {
+            let Ok(sig) = pkcs1v15::Signature::try_from(sig) else {
                 return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
             };
 
@@ -353,7 +353,7 @@ pub fn checkquote(
         }
         #[cfg(feature = "rsa")]
         (Public::Rsa { .. }, sig @ Signature::RsaPss(pkcs_sig)) => {
-            let Ok(sig) = pss::Signature::try_from(sig.clone()) else {
+            let Ok(sig) = pss::Signature::try_from(sig) else {
                 return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
             };
 

--- a/tss-esapi/src/abstraction/signatures.rs
+++ b/tss-esapi/src/abstraction/signatures.rs
@@ -1,7 +1,10 @@
 // Copyright 2024 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{structures::EccSignature, Error, Result, WrapperErrorKind};
+use crate::{
+    structures::{EccSignature, Signature},
+    Error, Result, WrapperErrorKind,
+};
 
 use std::convert::TryFrom;
 
@@ -11,17 +14,14 @@ use elliptic_curve::{
     FieldBytes, FieldBytesSize, PrimeCurve,
 };
 
-#[cfg(feature = "rsa")]
-use crate::structures::Signature;
-
-impl<C> TryFrom<EccSignature> for ecdsa::Signature<C>
+impl<C> TryFrom<&EccSignature> for ecdsa::Signature<C>
 where
     C: PrimeCurve,
     SignatureSize<C>: ArrayLength<u8>,
 {
     type Error = Error;
 
-    fn try_from(signature: EccSignature) -> Result<Self> {
+    fn try_from(signature: &EccSignature) -> Result<Self> {
         let r = signature.signature_r().as_slice();
         let s = signature.signature_s().as_slice();
 
@@ -33,21 +33,36 @@ where
         }
 
         let signature = ecdsa::Signature::from_scalars(
-            FieldBytes::<C>::from_slice(r).clone(),
-            FieldBytes::<C>::from_slice(s).clone(),
+            FieldBytes::<C>::clone_from_slice(r),
+            FieldBytes::<C>::clone_from_slice(s),
         )
         .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;
         Ok(signature)
     }
 }
 
+impl<C> TryFrom<&Signature> for ecdsa::Signature<C>
+where
+    C: PrimeCurve,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    type Error = Error;
+
+    fn try_from(signature: &Signature) -> Result<Self> {
+        let Signature::EcDsa(signature) = signature else {
+            return Err(Error::local_error(WrapperErrorKind::InvalidParam));
+        };
+        Self::try_from(signature)
+    }
+}
+
 // Note: this does not implement `TryFrom<RsaSignature>` because `RsaSignature` does not carry the
 // information whether the signatures was generated using PKCS#1v1.5 or PSS.
 #[cfg(feature = "rsa")]
-impl TryFrom<Signature> for rsa::pkcs1v15::Signature {
+impl TryFrom<&Signature> for rsa::pkcs1v15::Signature {
     type Error = Error;
 
-    fn try_from(signature: Signature) -> Result<Self> {
+    fn try_from(signature: &Signature) -> Result<Self> {
         let Signature::RsaSsa(signature) = signature else {
             return Err(Error::local_error(WrapperErrorKind::InvalidParam));
         };
@@ -60,10 +75,10 @@ impl TryFrom<Signature> for rsa::pkcs1v15::Signature {
 // Note: this does not implement `TryFrom<RsaSignature>` because `RsaSignature` does not carry the
 // information whether the signatures was generated using PKCS#1v1.5 or PSS.
 #[cfg(feature = "rsa")]
-impl TryFrom<Signature> for rsa::pss::Signature {
+impl TryFrom<&Signature> for rsa::pss::Signature {
     type Error = Error;
 
-    fn try_from(signature: Signature) -> Result<Self> {
+    fn try_from(signature: &Signature) -> Result<Self> {
         let Signature::RsaPss(signature) = signature else {
             return Err(Error::local_error(WrapperErrorKind::InvalidParam));
         };

--- a/tss-esapi/src/abstraction/signer.rs
+++ b/tss-esapi/src/abstraction/signer.rs
@@ -253,7 +253,7 @@ where
             )));
         };
 
-        let signature = Signature::try_from(signature).map_err(SigError::from_source)?;
+        let signature = Signature::try_from(&signature).map_err(SigError::from_source)?;
 
         Ok(signature)
     }
@@ -453,7 +453,7 @@ mod rsa {
             let signature = self.context.sign(digest).map_err(SigError::from_source)?;
 
             let signature =
-                pkcs1v15::Signature::try_from(signature).map_err(SigError::from_source)?;
+                pkcs1v15::Signature::try_from(&signature).map_err(SigError::from_source)?;
 
             Ok(signature)
         }
@@ -581,7 +581,7 @@ mod rsa {
 
             let signature = self.context.sign(digest).map_err(SigError::from_source)?;
 
-            let signature = pss::Signature::try_from(signature).map_err(SigError::from_source)?;
+            let signature = pss::Signature::try_from(&signature).map_err(SigError::from_source)?;
 
             Ok(signature)
         }


### PR DESCRIPTION
This also introduce an implementation for transforming a generic signature to an ecdsa signature.