### PR TITLE
feat: ignore fake/nonsense prerelease info from tss version

### DIFF
--- a/tss-esapi/build.rs
+++ b/tss-esapi/build.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use semver::{Version, VersionReq};
+use semver::{Version, VersionReq, Prerelease};
 
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(hierarchy_is_esys_tr)");
@@ -12,9 +12,14 @@ fn main() {
     let tss_version_string = std::env::var("DEP_TSS2_ESYS_VERSION")
         .expect("Failed to parse ENV variable DEP_TSS2_ESYS_VERSION as string");
 
-    let tss_version = Version::parse(&tss_version_string)
+    let mut tss_version = Version::parse(&tss_version_string)
         .expect("Failed to parse the DEP_TSS2_ESYS_VERSION variable as a semver version");
 
+    // nuke any prerelease info, which probably is just a git repo/dirty flag
+    // like: 4.0.1-67-gb7bad346
+    tss_version.pre = Prerelease::EMPTY;
+    
+    //eprintln!("tss version: {} / {:?}", tss_version_string, tss_version);
     let supported_tss_version =
         VersionReq::parse("<5.0.0, >=2.3.3").expect("Failed to parse supported TSS version");
 


### PR DESCRIPTION
when building against a libtss from source code, the git tree is sometimes dirty, and so libtss puts that info into the VERSION file.
But, it's not exactly a correct prerelease SemVer string.... so just blank that part before comparing to required version.
