### PR TITLE
Fix Windows DLL boundary issues

### DIFF
--- a/tss-esapi/src/context/general_esys_tr.rs
+++ b/tss-esapi/src/context/general_esys_tr.rs
@@ -139,7 +139,7 @@ impl Context {
                 error!("Error in getting name: {:#010X}", ret);
             },
         )?;
-        Name::try_from(Context::ffi_data_to_owned(name_ptr))
+        Name::try_from(Context::ffi_data_to_owned(name_ptr)?)
     }
 
     /// Used to construct an esys object from the resources inside the TPM.

--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -39,7 +39,7 @@ impl Context {
                 error!("Error when performing RSA encryption: {:#010X}", ret);
             },
         )?;
-        PublicKeyRsa::try_from(Context::ffi_data_to_owned(out_data_ptr))
+        PublicKeyRsa::try_from(Context::ffi_data_to_owned(out_data_ptr)?)
     }
 
     /// Perform an asymmetric RSA decryption.
@@ -69,7 +69,7 @@ impl Context {
                 error!("Error when performing RSA decryption: {:#010X}", ret);
             },
         )?;
-        PublicKeyRsa::try_from(Context::ffi_data_to_owned(message_ptr))
+        PublicKeyRsa::try_from(Context::ffi_data_to_owned(message_ptr)?)
     }
 
     /// Generate an ephemeral key pair.
@@ -199,8 +199,8 @@ impl Context {
             },
         )?;
 
-        let z_point = Context::ffi_data_to_owned(z_point_ptr);
-        let pub_point = Context::ffi_data_to_owned(pub_point_ptr);
+        let z_point = Context::ffi_data_to_owned(z_point_ptr)?;
+        let pub_point = Context::ffi_data_to_owned(pub_point_ptr)?;
         Ok((
             EccPoint::try_from(z_point.point)?,
             EccPoint::try_from(pub_point.point)?,
@@ -335,7 +335,7 @@ impl Context {
                 error!("Error when performing ECDH ZGen: {:#010X}", ret);
             },
         )?;
-        let out_point = Context::ffi_data_to_owned(out_point_ptr);
+        let out_point = Context::ffi_data_to_owned(out_point_ptr)?;
         EccPoint::try_from(out_point.point)
     }
 

--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -147,8 +147,8 @@ impl Context {
             },
         )?;
 
-        let certify_info = Context::ffi_data_to_owned(certify_info_ptr);
-        let signature = Context::ffi_data_to_owned(signature_ptr);
+        let certify_info = Context::ffi_data_to_owned(certify_info_ptr)?;
+        let signature = Context::ffi_data_to_owned(signature_ptr)?;
         Ok((
             Attest::try_from(AttestBuffer::try_from(certify_info)?)?,
             Signature::try_from(signature)?,
@@ -272,8 +272,8 @@ impl Context {
             },
         )?;
 
-        let certify_info = Context::ffi_data_to_owned(certify_info_ptr);
-        let signature = Context::ffi_data_to_owned(signature_ptr);
+        let certify_info = Context::ffi_data_to_owned(certify_info_ptr)?;
+        let signature = Context::ffi_data_to_owned(signature_ptr)?;
         Ok((
             Attest::try_from(AttestBuffer::try_from(certify_info)?)?,
             Signature::try_from(signature)?,
@@ -313,8 +313,8 @@ impl Context {
             },
         )?;
 
-        let quoted = Context::ffi_data_to_owned(quoted_ptr);
-        let signature = Context::ffi_data_to_owned(signature_ptr);
+        let quoted = Context::ffi_data_to_owned(quoted_ptr)?;
+        let signature = Context::ffi_data_to_owned(signature_ptr)?;
         Ok((
             Attest::try_from(AttestBuffer::try_from(quoted)?)?,
             Signature::try_from(signature)?,
@@ -426,8 +426,8 @@ impl Context {
             },
         )?;
 
-        let timeinfo = Context::ffi_data_to_owned(timeinfo_ptr);
-        let signature = Context::ffi_data_to_owned(signature_ptr);
+        let timeinfo = Context::ffi_data_to_owned(timeinfo_ptr)?;
+        let signature = Context::ffi_data_to_owned(signature_ptr)?;
         Ok((
             Attest::try_from(AttestBuffer::try_from(timeinfo)?)?,
             Signature::try_from(signature)?,

--- a/tss-esapi/src/context/tpm_commands/capability_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/capability_commands.rs
@@ -69,7 +69,7 @@ impl Context {
         )?;
 
         Ok((
-            CapabilityData::try_from(Context::ffi_data_to_owned(capability_data_ptr))?,
+            CapabilityData::try_from(Context::ffi_data_to_owned(capability_data_ptr)?)?,
             YesNo::try_from(more_data)?.into(),
         ))
     }

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -26,7 +26,7 @@ impl Context {
                 error!("Error in saving context: {:#010X}", ret);
             },
         )?;
-        SavedTpmContext::try_from(Context::ffi_data_to_owned(context_ptr))
+        SavedTpmContext::try_from(Context::ffi_data_to_owned(context_ptr)?)
     }
 
     /// Load a previously saved context into the TPM and return the object handle.

--- a/tss-esapi/src/context/tpm_commands/duplication_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/duplication_commands.rs
@@ -327,9 +327,9 @@ impl Context {
         )?;
 
         Ok((
-            Data::try_from(Context::ffi_data_to_owned(encryption_key_out_ptr))?,
-            Private::try_from(Context::ffi_data_to_owned(duplicate_ptr))?,
-            EncryptedSecret::try_from(Context::ffi_data_to_owned(out_sym_seed_ptr))?,
+            Data::try_from(Context::ffi_data_to_owned(encryption_key_out_ptr)?)?,
+            Private::try_from(Context::ffi_data_to_owned(duplicate_ptr)?)?,
+            EncryptedSecret::try_from(Context::ffi_data_to_owned(out_sym_seed_ptr)?)?,
         ))
     }
 
@@ -683,6 +683,6 @@ impl Context {
                 error!("Error when performing import: {:#010X}", ret);
             },
         )?;
-        Private::try_from(Context::ffi_data_to_owned(out_private_ptr))
+        Private::try_from(Context::ffi_data_to_owned(out_private_ptr)?)
     }
 }

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -64,8 +64,8 @@ impl Context {
             },
         )?;
         Ok((
-            Timeout::try_from(Context::ffi_data_to_owned(out_timeout_ptr))?,
-            AuthTicket::try_from(Context::ffi_data_to_owned(out_policy_ticket_ptr))?,
+            Timeout::try_from(Context::ffi_data_to_owned(out_timeout_ptr)?)?,
+            AuthTicket::try_from(Context::ffi_data_to_owned(out_policy_ticket_ptr)?)?,
         ))
     }
 
@@ -106,8 +106,8 @@ impl Context {
             },
         )?;
         Ok((
-            Timeout::try_from(Context::ffi_data_to_owned(out_timeout_ptr))?,
-            AuthTicket::try_from(Context::ffi_data_to_owned(out_policy_ticket_ptr))?,
+            Timeout::try_from(Context::ffi_data_to_owned(out_timeout_ptr)?)?,
+            AuthTicket::try_from(Context::ffi_data_to_owned(out_policy_ticket_ptr)?)?,
         ))
     }
 
@@ -533,7 +533,7 @@ impl Context {
             },
         )?;
 
-        Digest::try_from(Context::ffi_data_to_owned(policy_digest_ptr))
+        Digest::try_from(Context::ffi_data_to_owned(policy_digest_ptr)?)
     }
 
     /// Cause conditional gating of a policy based on NV written state.

--- a/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
@@ -70,10 +70,10 @@ impl Context {
                 error!("Error in creating primary key: {:#010X}", ret);
             },
         )?;
-        let out_public_owned = Context::ffi_data_to_owned(out_public_ptr);
-        let creation_data_owned = Context::ffi_data_to_owned(creation_data_ptr);
-        let creation_hash_owned = Context::ffi_data_to_owned(creation_hash_ptr);
-        let creation_ticket_owned = Context::ffi_data_to_owned(creation_ticket_ptr);
+        let out_public_owned = Context::ffi_data_to_owned(out_public_ptr)?;
+        let creation_data_owned = Context::ffi_data_to_owned(creation_data_ptr)?;
+        let creation_hash_owned = Context::ffi_data_to_owned(creation_hash_ptr)?;
+        let creation_ticket_owned = Context::ffi_data_to_owned(creation_ticket_ptr)?;
         let primary_key_handle = KeyHandle::from(object_handle);
         self.handle_manager
             .add_handle(primary_key_handle.into(), HandleDropAction::Flush)?;

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -175,8 +175,8 @@ impl Context {
 
         Ok((
             pcr_update_counter,
-            PcrSelectionList::try_from(Context::ffi_data_to_owned(pcr_selection_out_ptr))?,
-            DigestList::try_from(Context::ffi_data_to_owned(pcr_values_ptr))?,
+            PcrSelectionList::try_from(Context::ffi_data_to_owned(pcr_selection_out_ptr)?)?,
+            DigestList::try_from(Context::ffi_data_to_owned(pcr_values_ptr)?)?,
         ))
     }
 

--- a/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
+++ b/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
@@ -476,8 +476,8 @@ impl Context {
         )?;
 
         Ok((
-            NvPublic::try_from(Context::ffi_data_to_owned(nv_public_ptr))?,
-            Name::try_from(Context::ffi_data_to_owned(nv_name_ptr))?,
+            NvPublic::try_from(Context::ffi_data_to_owned(nv_public_ptr)?)?,
+            Name::try_from(Context::ffi_data_to_owned(nv_name_ptr)?)?,
         ))
     }
 
@@ -825,7 +825,7 @@ impl Context {
                 error!("Error when reading NV: {:#010X}", ret);
             },
         )?;
-        MaxNvBuffer::try_from(Context::ffi_data_to_owned(data_ptr))
+        MaxNvBuffer::try_from(Context::ffi_data_to_owned(data_ptr)?)
     }
 
     // Missing function: NV_ReadLock

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -216,9 +216,9 @@ impl Context {
             },
         )?;
         Ok((
-            Public::try_from(Context::ffi_data_to_owned(out_public_ptr))?,
-            Name::try_from(Context::ffi_data_to_owned(name_ptr))?,
-            Name::try_from(Context::ffi_data_to_owned(qualified_name_ptr))?,
+            Public::try_from(Context::ffi_data_to_owned(out_public_ptr)?)?,
+            Name::try_from(Context::ffi_data_to_owned(name_ptr)?)?,
+            Name::try_from(Context::ffi_data_to_owned(qualified_name_ptr)?)?,
         ))
     }
 
@@ -250,7 +250,7 @@ impl Context {
             },
         )?;
 
-        Digest::try_from(Context::ffi_data_to_owned(cert_info_ptr))
+        Digest::try_from(Context::ffi_data_to_owned(cert_info_ptr)?)
     }
 
     /// Perform actions to create a [IdObject] containing an activation credential.
@@ -283,8 +283,8 @@ impl Context {
             },
         )?;
         Ok((
-            IdObject::try_from(Context::ffi_data_to_owned(credential_blob_ptr))?,
-            EncryptedSecret::try_from(Context::ffi_data_to_owned(secret_ptr))?,
+            IdObject::try_from(Context::ffi_data_to_owned(credential_blob_ptr)?)?,
+            EncryptedSecret::try_from(Context::ffi_data_to_owned(secret_ptr)?)?,
         ))
     }
 
@@ -307,7 +307,7 @@ impl Context {
                 error!("Error in unsealing: {:#010X}", ret);
             },
         )?;
-        SensitiveData::try_from(Context::ffi_data_to_owned(out_data_ptr))
+        SensitiveData::try_from(Context::ffi_data_to_owned(out_data_ptr)?)
     }
 
     /// Change authorization for a TPM-resident object.
@@ -335,7 +335,7 @@ impl Context {
                 error!("Error changing object auth: {:#010X}", ret);
             },
         )?;
-        Private::try_from(Context::ffi_data_to_owned(out_private_ptr))
+        Private::try_from(Context::ffi_data_to_owned(out_private_ptr)?)
     }
 
     // Missing function: CreateLoaded

--- a/tss-esapi/src/context/tpm_commands/random_number_generator.rs
+++ b/tss-esapi/src/context/tpm_commands/random_number_generator.rs
@@ -33,7 +33,7 @@ impl Context {
                 error!("Error in getting random bytes: {:#010X}", ret);
             },
         )?;
-        Digest::try_from(Context::ffi_data_to_owned(random_bytes_ptr))
+        Digest::try_from(Context::ffi_data_to_owned(random_bytes_ptr)?)
     }
 
     /// Add additional information into the TPM RNG state

--- a/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
+++ b/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
@@ -36,7 +36,7 @@ impl Context {
                 error!("Error when verifying signature: {:#010X}", ret);
             },
         )?;
-        VerifiedTicket::try_from(Context::ffi_data_to_owned(validation_ptr))
+        VerifiedTicket::try_from(Context::ffi_data_to_owned(validation_ptr)?)
     }
 
     /// Sign a digest with a key present in the TPM and return the signature.
@@ -118,6 +118,6 @@ impl Context {
                 error!("Error when signing: {:#010X}", ret);
             },
         )?;
-        Signature::try_from(Context::ffi_data_to_owned(signature_ptr))
+        Signature::try_from(Context::ffi_data_to_owned(signature_ptr)?)
     }
 }

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -215,8 +215,8 @@ impl Context {
             },
         )?;
         Ok((
-            MaxBuffer::try_from(Context::ffi_data_to_owned(out_data_ptr))?,
-            InitialValue::try_from(Context::ffi_data_to_owned(iv_out_ptr))?,
+            MaxBuffer::try_from(Context::ffi_data_to_owned(out_data_ptr)?)?,
+            InitialValue::try_from(Context::ffi_data_to_owned(iv_out_ptr)?)?,
         ))
     }
 
@@ -290,8 +290,8 @@ impl Context {
             },
         )?;
         Ok((
-            Digest::try_from(Context::ffi_data_to_owned(out_hash_ptr))?,
-            HashcheckTicket::try_from(Context::ffi_data_to_owned(validation_ptr))?,
+            Digest::try_from(Context::ffi_data_to_owned(out_hash_ptr)?)?,
+            HashcheckTicket::try_from(Context::ffi_data_to_owned(validation_ptr)?)?,
         ))
     }
 
@@ -369,7 +369,7 @@ impl Context {
                 error!("Error in hmac: {:#010X}", ret);
             },
         )?;
-        Digest::try_from(Context::ffi_data_to_owned(out_hmac_ptr))
+        Digest::try_from(Context::ffi_data_to_owned(out_hmac_ptr)?)
     }
 
     // Missing function: MAC

--- a/tss-esapi/src/context/tpm_commands/testing.rs
+++ b/tss-esapi/src/context/tpm_commands/testing.rs
@@ -75,7 +75,7 @@ impl Context {
             },
         )?;
         Ok((
-            MaxBuffer::try_from(Context::ffi_data_to_owned(out_data_ptr))?,
+            MaxBuffer::try_from(Context::ffi_data_to_owned(out_data_ptr)?)?,
             ReturnCode::ensure_success(test_result, |_| {}),
         ))
     }


### PR DESCRIPTION
On Windows, if DLL 'A' for example mallocs, it must be DLL 'A' that makes the free call in order to ensure the proper runtime. Currently Windows builds crash due to this problem. To reproduce (on Windows):

```rust
let mut ctx = Context::new(TctiNameConf::Tbs).context("init TBS TCTI")?;
let rnd = ctx.get_random(16).context("TPM2_GetRandom failed")?; 
```

This MR uses `Esys_Free` to free allocated data. I may have missed some areas, so would love pointers. It's a bit tricky to test all the stuff here.