### PR TITLE
Add tr_sess_get_nonce_tpm interface

### DIFF
--- a/tss-esapi/src/context/session_administration.rs
+++ b/tss-esapi/src/context/session_administration.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     attributes::{SessionAttributes, SessionAttributesMask},
+    ffi::take_from_esys,
     handles::SessionHandle,
     interface_types::session_handles::AuthSession,
-    tss2_esys::{Esys_TRSess_GetAttributes, Esys_TRSess_SetAttributes},
+    structures::Nonce,
+    tss2_esys::{Esys_TRSess_GetAttributes, Esys_TRSess_GetNonceTPM, Esys_TRSess_SetAttributes},
     Context, Result, ReturnCode,
 };
 use log::error;
@@ -51,5 +53,63 @@ impl Context {
         Ok(SessionAttributes(flags))
     }
 
-    // Missing function: Esys_TRSess_GetNonceTPM
+    /// Get the TPM nonce from a session.
+    ///
+    /// # Arguments
+    /// * `session` - An [AuthSession] handle to the authentication session from which to retrieve
+    ///   the TPM nonce.
+    ///
+    /// # Returns
+    /// The TPM nonce as a [Nonce] struct on success.
+    ///
+    /// # Details
+    /// This function retrieves the nonceTPM value from an authentication session.
+    ///
+    /// Extracted nonceTPM can be useful in some scenarios. For example, a TPM object protected by a
+    /// PolicySigned policy requires the nonceTPM value to be extracted and included in the signed
+    /// digest to satisfy the policy.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::constants::SessionType;
+    /// # use tss_esapi::interface_types::algorithm::HashingAlgorithm;
+    /// # use tss_esapi::structures::SymmetricDefinition;
+    ///
+    /// let mut context = Context::new(
+    ///     TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// ).expect("Failed to create context");
+    ///
+    /// let session = context
+    ///     .start_auth_session(
+    ///         None,
+    ///         None,
+    ///         None,
+    ///         SessionType::Policy,
+    ///         SymmetricDefinition::AES_256_CFB,
+    ///         HashingAlgorithm::Sha256,
+    ///     )
+    ///     .expect("Failed to create session")
+    ///     .expect("Received invalid handle");
+    /// let nonce_tpm = context.tr_sess_get_nonce_tpm(session).expect("Failed to get nonceTPM");
+    /// // Use the nonce_tpm value as needed
+    /// ```
+    pub fn tr_sess_get_nonce_tpm(&mut self, session: AuthSession) -> Result<Nonce> {
+        let mut nonce_ptr = std::ptr::null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_TRSess_GetNonceTPM(
+                    self.mut_context(),
+                    SessionHandle::from(session).into(),
+                    &mut nonce_ptr,
+                )
+            },
+            |ret| {
+                error!("Error when getting session nonceTPM: {:#010X}", ret);
+            },
+        )?;
+
+        let nonce_tpm = unsafe { take_from_esys(nonce_ptr)? };
+        nonce_tpm.try_into()
+    }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/session_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/session_commands_tests.rs
@@ -138,6 +138,30 @@ mod test_start_auth_session {
             .unwrap_err();
         });
     }
+
+    #[test]
+    fn test_get_nonce_tpm() {
+        let mut context = create_ctx_without_session();
+        let session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Policy,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .unwrap()
+            .expect("Received invalid handle");
+
+        // Get the TPM nonce from the session
+        let nonce_tpm = context
+            .tr_sess_get_nonce_tpm(session)
+            .expect("Failed to get nonceTPM");
+
+        // Verify the nonce is not empty
+        assert!(!nonce_tpm.as_bytes().is_empty());
+    }
 }
 
 mod test_policy_restart {


### PR DESCRIPTION
The Rust interface wrapping `Esys_TRSess_GetNonceTPM` has been missing. This PR adds implementation of this wrapper and export the interface for external use.