### PR TITLE
Fix versions for first 8.0.0-alpha release.

### DIFF
--- a/tss-esapi-sys/Cargo.toml
+++ b/tss-esapi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi-sys"
-version = "0.5.0"
+version = "0.6.0-alpha.1"
 authors = ["Parsec Project Contributors"]
 edition = "2021"
 description = "FFI wrapper around TSS 2.0 Enhanced System API"

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi"
-version = "8.0.0-alpha"
+version = "8.0.0-alpha.1"
 authors = ["Parsec Project Contributors"]
 edition = "2021"
 description = "Rust-native wrapper around TSS 2.0 Enhanced System API"
@@ -33,7 +33,7 @@ num-traits = "0.2.12"
 hostname-validator = "1.1.0"
 regex = "1.3.9"
 zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
-tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.5.0" }
+tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.6.0-alpha.1" }
 x509-cert = { version = "0.2.0", optional = true }
 ecdsa = { version = "0.16.9", features = [
     "der",


### PR DESCRIPTION
This commit updates the version of tss-esapi to 8.0.0-alpha.1 and the version tss-esapi-sys to 0.6.0-alpha.1