### PR TITLE
Makes sensitive part in load_external optional.

### DIFF
--- a/tss-esapi/examples/certify.rs
+++ b/tss-esapi/examples/certify.rs
@@ -267,7 +267,7 @@ fn main() {
     // challenge encryption.
     let (_public, ak_name, _qualified_name) = context_2
         .execute_with_nullauth_session(|ctx| {
-            let ak_handle = ctx.load_external_public(ak_public.clone(), Hierarchy::Null)?;
+            let ak_handle = ctx.load_external(None, ak_public.clone(), Hierarchy::Null)?;
             let r = ctx.read_public(ak_handle);
             ctx.flush_context(ak_handle.into())?;
             r
@@ -291,7 +291,7 @@ fn main() {
     // Now we load the ek_public, and create our encrypted challenge.
     let (idobject, encrypted_secret) = context_2
         .execute_with_nullauth_session(|ctx| {
-            let ek_handle = ctx.load_external_public(ek_public, Hierarchy::Null)?;
+            let ek_handle = ctx.load_external(None, ek_public, Hierarchy::Null)?;
             let r = ctx.make_credential(ek_handle, challenge.clone(), ak_name);
             ctx.flush_context(ek_handle.into())?;
             r
@@ -510,7 +510,8 @@ fn main() {
     // First, load the public from the aik
     let ak_handle = context_2
         .execute_with_nullauth_session(|ctx| {
-            ctx.load_external_public(
+            ctx.load_external(
+                None,
                 ak_public,
                 // We put it into the null hierarchy as this is ephemeral.
                 Hierarchy::Null,

--- a/tss-esapi/examples/duplication.rs
+++ b/tss-esapi/examples/duplication.rs
@@ -303,7 +303,7 @@ fn main() {
         .execute_without_session(|ctx| {
             // Ensure we load the new parent handle before we start
             let new_parent_handle = ctx
-                .load_external_public(primary_key_2_public, Hierarchy::Null)
+                .load_external(None, primary_key_2_public, Hierarchy::Null)
                 .unwrap();
 
             // IMPORTANT! After you start the policy session, you can't do *anything* else except

--- a/tss-esapi/examples/rsa_oaep.rs
+++ b/tss-esapi/examples/rsa_oaep.rs
@@ -90,7 +90,7 @@ fn main() {
     let encrypted_data = context
         .execute_with_nullauth_session(|ctx| {
             let rsa_pub_key = ctx
-                .load_external_public(public.clone(), Hierarchy::Null)
+                .load_external(None, public.clone(), Hierarchy::Null)
                 .unwrap();
 
             ctx.rsa_encrypt(

--- a/tss-esapi/src/abstraction/transient/mod.rs
+++ b/tss-esapi/src/abstraction/transient/mod.rs
@@ -194,9 +194,7 @@ impl TransientKeyContext {
     ) -> Result<KeyMaterial> {
         let public = TransientKeyContext::get_public_from_params(params, Some(public_key.clone()))?;
         self.set_session_attrs()?;
-        let key_handle = self
-            .context
-            .load_external_public(public, Hierarchy::Owner)?;
+        let key_handle = self.context.load_external(None, public, Hierarchy::Owner)?;
         self.context.flush_context(key_handle.into())?;
         Ok(KeyMaterial {
             public: public_key,
@@ -522,8 +520,7 @@ impl TransientKeyContext {
 
         self.set_session_attrs()?;
         let key_handle = if material.private.is_empty() {
-            self.context
-                .load_external_public(public, Hierarchy::Owner)?
+            self.context.load_external(None, public, Hierarchy::Owner)?
         } else {
             self.context
                 .load(self.root_key_handle, material.private.try_into()?, public)?

--- a/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
@@ -558,7 +558,7 @@ fn ctx_migration_test() {
     let key_context = basic_ctx.context_save(key_handle.into()).unwrap();
 
     let pub_key_handle = basic_ctx
-        .load_external_public(result.out_public.clone(), Hierarchy::Owner)
+        .load_external(None, result.out_public.clone(), Hierarchy::Owner)
         .unwrap();
     let pub_key_context = basic_ctx.context_save(pub_key_handle.into()).unwrap();
 
@@ -672,7 +672,7 @@ fn activate_credential() {
         panic!("Wrong Public type");
     };
     let pub_handle = basic_ctx
-        .load_external_public(key_pub, Hierarchy::Owner)
+        .load_external(None, key_pub, Hierarchy::Owner)
         .unwrap();
 
     // Credential to expect back as proof for attestation
@@ -799,7 +799,7 @@ fn activate_credential_wrong_key() {
         panic!("Wrong Public type");
     };
     let pub_handle = basic_ctx
-        .load_external_public(key_pub, Hierarchy::Owner)
+        .load_external(None, key_pub, Hierarchy::Owner)
         .unwrap();
 
     // Credential to expect back as proof for attestation


### PR DESCRIPTION
The TPM2 specification specifies that the sensitive portion of the key is optional. This changes the API of the `load_external` context method in order to better reflect this fact.

This in turn makes the `load_external_public` context method unnecessary and there for it has been removed.