### PR TITLE
fix(esapi): make session args required in `Esys_*` commands

### DIFF
--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -400,7 +400,7 @@ impl Context {
                 Esys_Quote(
                     self.mut_context(),
                     signing_key_handle.into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                     &qualifying_data.into(),

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -716,7 +716,7 @@ impl Context {
                     AuthHandle::from(auth_handle).into(),
                     nv_index_handle.into(),
                     SessionHandle::from(policy_session).into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                 )

--- a/tss-esapi/src/context/tpm_commands/hash_hmac_event_sequences.rs
+++ b/tss-esapi/src/context/tpm_commands/hash_hmac_event_sequences.rs
@@ -124,7 +124,7 @@ impl Context {
                 Esys_HMAC_Start(
                     self.mut_context(),
                     handle.into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                     &auth.unwrap_or_default().into(),
@@ -258,7 +258,7 @@ impl Context {
                 Esys_SequenceUpdate(
                     self.mut_context(),
                     sequence_handle.into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                     &data.into(),
@@ -289,7 +289,7 @@ impl Context {
                 Esys_SequenceComplete(
                     self.mut_context(),
                     sequence_handle.into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                     &data.into(),

--- a/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
@@ -52,7 +52,7 @@ impl Context {
                 Esys_CreatePrimary(
                     self.mut_context(),
                     ObjectHandle::from(primary_handle).into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                     &sensitive_create.try_into()?,

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -93,7 +93,7 @@ impl Context {
                 Esys_PCR_Extend(
                     self.mut_context(),
                     pcr_handle.into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                     &digests.try_into()?,
@@ -243,7 +243,7 @@ impl Context {
                 Esys_PCR_Reset(
                     self.mut_context(),
                     pcr_handle.into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                 )

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -69,7 +69,7 @@ impl Context {
                 Esys_Create(
                     self.mut_context(),
                     input_parameters.ffi_in_parent_handle(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                     input_parameters.ffi_in_sensitive(),
@@ -104,7 +104,7 @@ impl Context {
                 Esys_Load(
                     self.mut_context(),
                     parent_handle.into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                     &private.into(),
@@ -372,7 +372,7 @@ impl Context {
                 Esys_Unseal(
                     self.mut_context(),
                     item_handle.into(),
-                    self.optional_session_1(),
+                    self.required_session_1()?,
                     self.optional_session_2(),
                     self.optional_session_3(),
                     &mut out_data_ptr,


### PR DESCRIPTION
Some `Esys_*` commands have session arguments that are optional in `tss-esapi`, but they are actually required according to the [TCG specification](https://trustedcomputinggroup.org/wp-content/uploads/TSS_ESAPI_v1p0_r14_pub10012021.pdf).

This commit makes those session arguments required in the `Esys_*` commands. I have reviewed all the code in the tss-esapi/src/context directory and fixed these types of errors.

Full list of changes:

- `Esys_Quote`: session 1 = "signHandleSession1" (TCG spec section 11.3.42)
- `Esys_PolicyAuthorizeNV`: session 1 = "authHandleSession1" (11.3.77)
- `Esys_HMAC_Start`: session 1 = "handleSession1" (11.3.33)
- `Esys_SequenceUpdate`: session 1 = "sequenceHandleSession1" (11.3.36)
- `Esys_SequenceComplete`: session 1 = "sequenceHandleSession1" (11.3.37)
- `Esys_CreatePrimary`: session 1 = "primaryHandleSession1" (11.3.78)
- `Esys_PCR_Extend`: session 1 = "pcrHandleSession1" (11.3.51)
- `Esys_PCR_Reset`: session 1 = "pcrHandleSession1" (11.3.57)
- `Esys_Create`: session 1 = "parentHandleSession1" (11.3.8)
- `Esys_Load`: session 1 = "parentHandleSession1" (11.3.9)
- `Esys_Unseal`: session 1 = "itemHandleSession1" (11.3.14)