### PR TITLE
ESAPI: Implement missing Esys commands and partial NvDigest support

### DIFF
--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -3,9 +3,13 @@
 use crate::{
     Context, Result, ReturnCode,
     handles::KeyHandle,
+    interface_types::{algorithm::EccKeyExchangeAlgorithm, ecc::EccCurve},
     structures::Data,
-    structures::{EccPoint, PublicKeyRsa, RsaDecryptionScheme},
-    tss2_esys::{Esys_ECDH_KeyGen, Esys_ECDH_ZGen, Esys_RSA_Decrypt, Esys_RSA_Encrypt},
+    structures::{EccParameterDetails, EccPoint, PublicKeyRsa, RsaDecryptionScheme},
+    tss2_esys::{
+        Esys_ECC_Parameters, Esys_ECDH_KeyGen, Esys_ECDH_ZGen, Esys_RSA_Decrypt, Esys_RSA_Encrypt,
+        Esys_ZGen_2Phase,
+    },
 };
 use log::error;
 use std::ptr::null_mut;
@@ -603,6 +607,127 @@ impl Context {
         EccPoint::try_from(out_point.point)
     }
 
-    // Missing function: ECC_Parameters
-    // Missing function: ZGen_2Phase
+    /// Get the parameters of an ECC curve.
+    ///
+    /// # Arguments
+    ///
+    /// * `curve` - The [EccCurve] to query.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command returns the parameters of an ECC curve identified
+    /// > by its TCG-assigned curveID.
+    ///
+    /// # Returns
+    ///
+    /// An [EccParameterDetails] containing the curve parameters.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// use tss_esapi::interface_types::ecc::EccCurve;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let details = context.ecc_parameters(EccCurve::NistP256).unwrap();
+    /// assert_eq!(details.curve_id(), EccCurve::NistP256);
+    /// assert!(details.key_size() > 0);
+    /// ```
+    pub fn ecc_parameters(&mut self, curve: EccCurve) -> Result<EccParameterDetails> {
+        let mut parameters_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ECC_Parameters(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    curve.into(),
+                    &mut parameters_ptr,
+                )
+            },
+            |ret| {
+                error!("Error when getting ECC parameters: {:#010X}", ret);
+            },
+        )?;
+        EccParameterDetails::try_from(Context::ffi_data_to_owned(parameters_ptr)?)
+    }
+
+    /// Perform a two-phase ECC key exchange.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_handle` - A [KeyHandle] of the ECC key (Party A).
+    /// * `in_qs_b` - The static public key of Party B as an [EccPoint].
+    /// * `in_qe_b` - The ephemeral public key of Party B as an [EccPoint].
+    /// * `in_scheme` - The key exchange protocol as an [EccKeyExchangeAlgorithm].
+    /// * `counter` - The commit counter from the TPM.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command supports two-phase key exchange protocols. The
+    /// > command is used in combination with TPM2_EC_Ephemeral().
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(EccPoint, EccPoint)` representing `(outZ1, outZ2)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes key_handle is a loaded ECC key, in_qs_b and in_qe_b are
+    /// # // Party B's static and ephemeral public keys, and counter is from
+    /// # // a prior ec_ephemeral() call.
+    /// # // let (out_z1, out_z2) = context.zgen_2phase(
+    /// # //     key_handle, in_qs_b, in_qe_b,
+    /// # //     EccKeyExchangeAlgorithm::EcDh, counter,
+    /// # // ).unwrap();
+    /// ```
+    pub fn zgen_2phase(
+        &mut self,
+        key_handle: KeyHandle,
+        in_qs_b: EccPoint,
+        in_qe_b: EccPoint,
+        in_scheme: EccKeyExchangeAlgorithm,
+        counter: u16,
+    ) -> Result<(EccPoint, EccPoint)> {
+        let mut out_z1_ptr = null_mut();
+        let mut out_z2_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ZGen_2Phase(
+                    self.mut_context(),
+                    key_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &in_qs_b.into(),
+                    &in_qe_b.into(),
+                    in_scheme.into(),
+                    counter,
+                    &mut out_z1_ptr,
+                    &mut out_z2_ptr,
+                )
+            },
+            |ret| {
+                error!("Error in ZGen_2Phase: {:#010X}", ret);
+            },
+        )?;
+
+        let out_z1 = Context::ffi_data_to_owned(out_z1_ptr)?;
+        let out_z2 = Context::ffi_data_to_owned(out_z2_ptr)?;
+        Ok((
+            EccPoint::try_from(out_z1.point)?,
+            EccPoint::try_from(out_z2.point)?,
+        ))
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/attached_components.rs
+++ b/tss-esapi/src/context/tpm_commands/attached_components.rs
@@ -3,7 +3,7 @@
 use crate::Context;
 
 impl Context {
-    // Missing function: AC_GetCapability
-    // Missing function: AC_Send
-    // Missing function: Policy_AC_SendSelect
+    // Missing function: AC_GetCapability (requires TPM_AT, TPML_AC_CAPABILITIES wrappers)
+    // Missing function: AC_Send (requires TPMS_AC_OUTPUT wrapper)
+    // Missing function: Policy_AC_SendSelect (requires TPM2B_NAME mutable pointer handling)
 }

--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     Context, Result, ReturnCode,
-    handles::{KeyHandle, ObjectHandle},
+    handles::{KeyHandle, ObjectHandle, SessionHandle},
     structures::{
-        Attest, AttestBuffer, CreationTicket, Data, Digest, PcrSelectionList, Signature,
+        Attest, AttestBuffer, CreationTicket, Data, Digest, MaxBuffer, PcrSelectionList, Signature,
         SignatureScheme,
     },
-    tss2_esys::{Esys_Certify, Esys_CertifyCreation, Esys_GetTime, Esys_Quote},
+    tss2_esys::{
+        Esys_Certify, Esys_CertifyCreation, Esys_CertifyX509, Esys_GetCommandAuditDigest,
+        Esys_GetSessionAuditDigest, Esys_GetTime, Esys_Quote,
+    },
 };
 use log::error;
 use std::convert::TryFrom;
@@ -536,7 +539,227 @@ impl Context {
         ))
     }
 
-    // Missing function: GetSessionAuditDigest
-    // Missing function: GestCommandAuditDigest
-    // Missing function: CertifyX509
+    /// Get a signed attestation of a session audit digest.
+    ///
+    /// # Arguments
+    ///
+    /// * `privacy_admin_handle` - An [ObjectHandle] for the privacy administrator (Endorsement).
+    /// * `sign_handle` - A [KeyHandle] of the key used to sign the attestation.
+    /// * `session_handle` - A [SessionHandle] of the session to be audited.
+    /// * `qualifying_data` - [Data] to qualify the signing.
+    /// * `signing_scheme` - The [SignatureScheme] to use.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command returns the current value of the session audit digest.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(Attest, Signature)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::ObjectHandle;
+    /// # use tss_esapi::structures::{Data, SignatureScheme};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes sign_handle is a loaded signing key and session_handle is an audit session
+    /// # // let (attest, sig) = context.get_session_audit_digest(
+    /// # //     ObjectHandle::Endorsement, sign_handle, session_handle,
+    /// # //     Data::default(), SignatureScheme::Null,
+    /// # // ).unwrap();
+    /// ```
+    pub fn get_session_audit_digest(
+        &mut self,
+        privacy_admin_handle: ObjectHandle,
+        sign_handle: KeyHandle,
+        session_handle: SessionHandle,
+        qualifying_data: Data,
+        signing_scheme: SignatureScheme,
+    ) -> Result<(Attest, Signature)> {
+        let mut audit_info_ptr = null_mut();
+        let mut signature_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_GetSessionAuditDigest(
+                    self.mut_context(),
+                    privacy_admin_handle.into(),
+                    sign_handle.into(),
+                    session_handle.into(),
+                    self.required_session_1()?,
+                    self.required_session_2()?,
+                    self.optional_session_3(),
+                    &qualifying_data.into(),
+                    &signing_scheme.into(),
+                    &mut audit_info_ptr,
+                    &mut signature_ptr,
+                )
+            },
+            |ret| {
+                error!("Error getting session audit digest: {:#010X}", ret);
+            },
+        )?;
+
+        let audit_info = Context::ffi_data_to_owned(audit_info_ptr)?;
+        let signature = Context::ffi_data_to_owned(signature_ptr)?;
+        Ok((
+            Attest::try_from(AttestBuffer::try_from(audit_info)?)?,
+            Signature::try_from(signature)?,
+        ))
+    }
+
+    /// Get a signed attestation of the command audit digest.
+    ///
+    /// # Arguments
+    ///
+    /// * `privacy_handle` - An [ObjectHandle] for the privacy administrator (Endorsement).
+    /// * `sign_handle` - A [KeyHandle] of the key used to sign the attestation.
+    /// * `qualifying_data` - [Data] to qualify the signing.
+    /// * `signing_scheme` - The [SignatureScheme] to use.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command returns the current value of the command audit digest,
+    /// > a digest of the commands being audited, and the audit hash algorithm.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(Attest, Signature)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::ObjectHandle;
+    /// # use tss_esapi::structures::{Data, SignatureScheme};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes sign_handle is a loaded signing key
+    /// # // let (attest, sig) = context.get_command_audit_digest(
+    /// # //     ObjectHandle::Endorsement, sign_handle,
+    /// # //     Data::default(), SignatureScheme::Null,
+    /// # // ).unwrap();
+    /// ```
+    pub fn get_command_audit_digest(
+        &mut self,
+        privacy_handle: ObjectHandle,
+        sign_handle: KeyHandle,
+        qualifying_data: Data,
+        signing_scheme: SignatureScheme,
+    ) -> Result<(Attest, Signature)> {
+        let mut audit_info_ptr = null_mut();
+        let mut signature_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_GetCommandAuditDigest(
+                    self.mut_context(),
+                    privacy_handle.into(),
+                    sign_handle.into(),
+                    self.required_session_1()?,
+                    self.required_session_2()?,
+                    self.optional_session_3(),
+                    &qualifying_data.into(),
+                    &signing_scheme.into(),
+                    &mut audit_info_ptr,
+                    &mut signature_ptr,
+                )
+            },
+            |ret| {
+                error!("Error getting command audit digest: {:#010X}", ret);
+            },
+        )?;
+
+        let audit_info = Context::ffi_data_to_owned(audit_info_ptr)?;
+        let signature = Context::ffi_data_to_owned(signature_ptr)?;
+        Ok((
+            Attest::try_from(AttestBuffer::try_from(audit_info)?)?,
+            Signature::try_from(signature)?,
+        ))
+    }
+
+    /// Produce a signed X.509 certificate.
+    ///
+    /// # Arguments
+    ///
+    /// * `object_handle` - An [ObjectHandle] of the object to be certified.
+    /// * `sign_handle` - A [KeyHandle] of the key used to sign the certificate.
+    /// * `reserved` - Reserved for future use, should be an empty [Data].
+    /// * `signing_scheme` - The [SignatureScheme] to use.
+    /// * `partial_certificate` - A [MaxBuffer] containing the partial certificate.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > The purpose of this command is to generate an X.509 certificate that
+    /// > proves an object with a specific public key and attributes is loaded
+    /// > in the TPM.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(MaxBuffer, Digest, Signature)` containing the added-to-certificate
+    /// data, the TBS digest, and the signature.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::ObjectHandle;
+    /// # use tss_esapi::structures::{Data, MaxBuffer, SignatureScheme};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes object_handle and sign_handle are properly set up
+    /// # // let (added, tbs_digest, sig) = context.certify_x509(
+    /// # //     object_handle, sign_handle, Data::default(),
+    /// # //     SignatureScheme::Null, MaxBuffer::default(),
+    /// # // ).unwrap();
+    /// ```
+    pub fn certify_x509(
+        &mut self,
+        object_handle: ObjectHandle,
+        sign_handle: KeyHandle,
+        reserved: Data,
+        signing_scheme: SignatureScheme,
+        partial_certificate: MaxBuffer,
+    ) -> Result<(MaxBuffer, Digest, Signature)> {
+        let mut added_to_certificate_ptr = null_mut();
+        let mut tbs_digest_ptr = null_mut();
+        let mut signature_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_CertifyX509(
+                    self.mut_context(),
+                    object_handle.into(),
+                    sign_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &reserved.into(),
+                    &signing_scheme.into(),
+                    &partial_certificate.into(),
+                    &mut added_to_certificate_ptr,
+                    &mut tbs_digest_ptr,
+                    &mut signature_ptr,
+                )
+            },
+            |ret| {
+                error!("Error certifying X.509: {:#010X}", ret);
+            },
+        )?;
+
+        Ok((
+            MaxBuffer::try_from(Context::ffi_data_to_owned(added_to_certificate_ptr)?)?,
+            Digest::try_from(Context::ffi_data_to_owned(tbs_digest_ptr)?)?,
+            Signature::try_from(Context::ffi_data_to_owned(signature_ptr)?)?,
+        ))
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/authenticated_countdown_timer.rs
+++ b/tss-esapi/src/context/tpm_commands/authenticated_countdown_timer.rs
@@ -1,7 +1,48 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{Context, Result, ReturnCode, handles::ObjectHandle, tss2_esys::Esys_ACT_SetTimeout};
+use log::error;
 
 impl Context {
-    // Missing function: ACT_SetTimeout
+    /// Set the timeout for an Authenticated Countdown Timer (ACT).
+    ///
+    /// # Arguments
+    ///
+    /// * `act_handle` - An [ObjectHandle] of the ACT to set.
+    /// * `start_timeout` - The start timeout value in seconds.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to set the time remaining before an
+    /// > Authenticated Countdown Timer (ACT) expires.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // ACT handles are vendor-specific
+    /// # // context.act_set_timeout(act_handle, 60).unwrap();
+    /// ```
+    pub fn act_set_timeout(&mut self, act_handle: ObjectHandle, start_timeout: u32) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ACT_SetTimeout(
+                    self.mut_context(),
+                    act_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    start_timeout,
+                )
+            },
+            |ret| {
+                error!("Error setting ACT timeout: {:#010X}", ret);
+            },
+        )
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/clocks_and_timers.rs
+++ b/tss-esapi/src/context/tpm_commands/clocks_and_timers.rs
@@ -1,9 +1,101 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode,
+    handles::AuthHandle,
+    structures::TimeInfo,
+    tss2_esys::{Esys_ClockSet, Esys_ReadClock},
+};
+use log::error;
+use std::convert::TryFrom;
+use std::ptr::null_mut;
 
 impl Context {
-    // Missing function: ReadClock
-    // Missing function: ClockSet
-    // Missing function: ClockRateAdjust
+    /// Read the current clock, time, and NV time.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command returns the current values of Time and Clock.
+    ///
+    /// # Returns
+    ///
+    /// A [TimeInfo] structure containing the current time information.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let time_info = context.read_clock().unwrap();
+    /// println!("Time: {}", time_info.time());
+    /// ```
+    pub fn read_clock(&mut self) -> Result<TimeInfo> {
+        let mut current_time_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ReadClock(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &mut current_time_ptr,
+                )
+            },
+            |ret| {
+                error!("Error reading clock: {:#010X}", ret);
+            },
+        )?;
+        TimeInfo::try_from(Context::ffi_data_to_owned(current_time_ptr)?)
+    }
+
+    /// Set the clock to a new value.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the authorization (Owner or Platform).
+    /// * `new_time` - The new clock setting in milliseconds.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to advance the value of the TPM's Clock. The
+    /// > command will fail if newTime is less than the current value of Clock
+    /// > or if the new time is greater than 0xFFFF000000000000.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let time_info = context.read_clock().unwrap();
+    /// let new_time = time_info.clock_info().clock() + 100_000;
+    /// context.clock_set(AuthHandle::Owner, new_time).unwrap();
+    /// ```
+    pub fn clock_set(&mut self, auth_handle: AuthHandle, new_time: u64) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ClockSet(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    new_time,
+                )
+            },
+            |ret| {
+                error!("Error setting clock: {:#010X}", ret);
+            },
+        )
+    }
+
+    // Missing function: ClockRateAdjust (requires TPM2_CLOCK_ADJUST wrappe)
 }

--- a/tss-esapi/src/context/tpm_commands/command_audit.rs
+++ b/tss-esapi/src/context/tpm_commands/command_audit.rs
@@ -1,7 +1,69 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode, handles::AuthHandle, interface_types::algorithm::HashingAlgorithm,
+    structures::CommandCodeList, tss2_esys::Esys_SetCommandCodeAuditStatus,
+};
+use log::error;
 
 impl Context {
-    // Missing function: SetCommandCodeAuditStatus
+    /// Set the command code audit status.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the authorization (Owner or Platform).
+    /// * `audit_algorithm` - The [HashingAlgorithm] for the audit digest.
+    /// * `set_list` - A [CommandCodeList] of command codes to add to the audit list.
+    /// * `clear_list` - A [CommandCodeList] of command codes to remove from the audit list.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command may be used by the Privacy Administrator or platform
+    /// > to change the audit status of a command or to set the hash
+    /// > algorithm used for the audit digest.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # use tss_esapi::interface_types::algorithm::HashingAlgorithm;
+    /// # use tss_esapi::structures::CommandCodeList;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context.set_command_code_audit_status(
+    ///     AuthHandle::Owner,
+    ///     HashingAlgorithm::Sha256,
+    ///     CommandCodeList::new(),
+    ///     CommandCodeList::new(),
+    /// ).unwrap();
+    /// ```
+    pub fn set_command_code_audit_status(
+        &mut self,
+        auth_handle: AuthHandle,
+        audit_algorithm: HashingAlgorithm,
+        set_list: CommandCodeList,
+        clear_list: CommandCodeList,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_SetCommandCodeAuditStatus(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    audit_algorithm.into(),
+                    &set_list.into(),
+                    &clear_list.into(),
+                )
+            },
+            |ret| {
+                error!("Error setting command code audit status: {:#010X}", ret);
+            },
+        )
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/dictionary_attack_functions.rs
+++ b/tss-esapi/src/context/tpm_commands/dictionary_attack_functions.rs
@@ -1,8 +1,104 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode,
+    handles::AuthHandle,
+    tss2_esys::{Esys_DictionaryAttackLockReset, Esys_DictionaryAttackParameters},
+};
+use log::error;
 
 impl Context {
-    // Missing function: DictionaryAttackLockReset
-    // Missing function: DictionaryAttackParameters
+    /// Reset the dictionary attack lockout.
+    ///
+    /// # Arguments
+    ///
+    /// * `lock_handle` - An [AuthHandle] referencing the lockout authorization.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command cancels the effect of a TPM lockout due to a number of successive
+    /// > authorization failures. If this command is properly authorized, the lockout counter
+    /// > is set to zero.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context.dictionary_attack_lock_reset(AuthHandle::Lockout).unwrap();
+    /// ```
+    pub fn dictionary_attack_lock_reset(&mut self, lock_handle: AuthHandle) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_DictionaryAttackLockReset(
+                    self.mut_context(),
+                    lock_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                )
+            },
+            |ret| {
+                error!("Error resetting dictionary attack lockout: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Set the dictionary attack parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `lock_handle` - An [AuthHandle] referencing the lockout authorization.
+    /// * `new_max_tries` - Count of authorization failures before the lockout is imposed.
+    /// * `new_recovery_time` - Time in seconds before the authorization failure count is
+    ///   automatically decremented.
+    /// * `lockout_recovery` - Time in seconds after a lockoutAuth failure before use of
+    ///   lockoutAuth may be attempted.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command changes the lockout parameters.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context.dictionary_attack_parameters(AuthHandle::Lockout, 10, 300, 300).unwrap();
+    /// ```
+    pub fn dictionary_attack_parameters(
+        &mut self,
+        lock_handle: AuthHandle,
+        new_max_tries: u32,
+        new_recovery_time: u32,
+        lockout_recovery: u32,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_DictionaryAttackParameters(
+                    self.mut_context(),
+                    lock_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    new_max_tries,
+                    new_recovery_time,
+                    lockout_recovery,
+                )
+            },
+            |ret| {
+                error!("Error setting dictionary attack parameters: {:#010X}", ret);
+            },
+        )
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/duplication_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/duplication_commands.rs
@@ -4,8 +4,8 @@ use crate::Context;
 use crate::{
     Result, ReturnCode,
     handles::ObjectHandle,
-    structures::{Data, EncryptedSecret, Private, Public, SymmetricDefinitionObject},
-    tss2_esys::{Esys_Duplicate, Esys_Import},
+    structures::{Data, EncryptedSecret, Name, Private, Public, SymmetricDefinitionObject},
+    tss2_esys::{Esys_Duplicate, Esys_Import, Esys_Rewrap},
 };
 use log::error;
 
@@ -333,7 +333,76 @@ impl Context {
         ))
     }
 
-    // Missing function: Rewrap
+    /// Re-wrap a key that is already duplicated to a new parent.
+    ///
+    /// # Arguments
+    ///
+    /// * `old_parent` - An [ObjectHandle] of the old parent.
+    /// * `new_parent` - An [ObjectHandle] of the new parent.
+    /// * `in_duplicate` - The [Private] data of the duplicated object.
+    /// * `name` - The [Name] of the object being re-wrapped.
+    /// * `in_sym_seed` - The [EncryptedSecret] seed for the symmetric key.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command allows the TPM to serve in the role as an MA
+    /// > (Migration Authority).
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(Private, EncryptedSecret)` with the re-wrapped duplicate and new seed.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes old_parent, new_parent, in_duplicate, name, and in_sym_seed
+    /// # // are properly set up from a previous duplicate operation.
+    /// # // let (out_duplicate, out_sym_seed) = context.rewrap(
+    /// # //     old_parent, new_parent, in_duplicate, name, in_sym_seed,
+    /// # // ).unwrap();
+    /// ```
+    pub fn rewrap(
+        &mut self,
+        old_parent: ObjectHandle,
+        new_parent: ObjectHandle,
+        in_duplicate: Private,
+        name: Name,
+        in_sym_seed: EncryptedSecret,
+    ) -> Result<(Private, EncryptedSecret)> {
+        let mut out_duplicate_ptr = null_mut();
+        let mut out_sym_seed_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_Rewrap(
+                    self.mut_context(),
+                    old_parent.into(),
+                    new_parent.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &in_duplicate.into(),
+                    &name.into(),
+                    &in_sym_seed.into(),
+                    &mut out_duplicate_ptr,
+                    &mut out_sym_seed_ptr,
+                )
+            },
+            |ret| {
+                error!("Error when performing rewrap: {:#010X}", ret);
+            },
+        )?;
+
+        Ok((
+            Private::try_from(Context::ffi_data_to_owned(out_duplicate_ptr)?)?,
+            EncryptedSecret::try_from(Context::ffi_data_to_owned(out_sym_seed_ptr)?)?,
+        ))
+    }
 
     /// Import attaches imported object to a new parent.
     ///

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -5,17 +5,20 @@ use crate::{
     attributes::LocalityAttributes,
     constants::CommandCode,
     handles::{AuthHandle, NvIndexHandle, ObjectHandle, SessionHandle},
-    interface_types::{YesNo, reserved_handles::NvAuth, session_handles::PolicySession},
+    interface_types::{
+        ArithmeticComparison, YesNo, reserved_handles::NvAuth, session_handles::PolicySession,
+    },
     structures::{
         AuthTicket, Digest, DigestList, Name, Nonce, PcrSelectionList, Signature, Timeout,
         VerifiedTicket,
     },
     tss2_esys::{
         Esys_PolicyAuthValue, Esys_PolicyAuthorize, Esys_PolicyAuthorizeNV, Esys_PolicyCommandCode,
-        Esys_PolicyCpHash, Esys_PolicyDuplicationSelect, Esys_PolicyGetDigest, Esys_PolicyLocality,
-        Esys_PolicyNameHash, Esys_PolicyNvWritten, Esys_PolicyOR, Esys_PolicyPCR,
-        Esys_PolicyPassword, Esys_PolicyPhysicalPresence, Esys_PolicySecret, Esys_PolicySigned,
-        Esys_PolicyTemplate,
+        Esys_PolicyCounterTimer, Esys_PolicyCpHash, Esys_PolicyDuplicationSelect,
+        Esys_PolicyGetDigest, Esys_PolicyLocality, Esys_PolicyNV, Esys_PolicyNameHash,
+        Esys_PolicyNvWritten, Esys_PolicyOR, Esys_PolicyPCR, Esys_PolicyPassword,
+        Esys_PolicyPhysicalPresence, Esys_PolicySecret, Esys_PolicySigned, Esys_PolicyTemplate,
+        Esys_PolicyTicket,
     },
 };
 use log::error;
@@ -111,7 +114,69 @@ impl Context {
         ))
     }
 
-    // Missing function: PolicyTicket
+    /// Include a policy ticket in the policy evaluation.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy_session` - The [PolicySession] being extended.
+    /// * `timeout` - The [Timeout] from a previous policy command.
+    /// * `cp_hash_a` - A [Digest] of the command parameters for the command being authorized.
+    /// * `policy_ref` - A [Nonce] associated with the policy.
+    /// * `auth_name` - The [Name] of the entity that provided the authorization.
+    /// * `ticket` - The [AuthTicket] produced by a previous policy command.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is similar to TPM2_PolicySigned() except that it takes a
+    /// > ticket instead of a signed authorization. The ticket represents a
+    /// > verified authorization that had an expiration time associated with it.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::interface_types::session_handles::PolicySession;
+    /// # use tss_esapi::structures::{AuthTicket, Digest, Name, Nonce, Timeout};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes policy_session, timeout, and ticket are from a prior policy command
+    /// # // context.policy_ticket(
+    /// # //     policy_session, timeout, Digest::default(),
+    /// # //     Nonce::default(), auth_name, ticket,
+    /// # // ).unwrap();
+    /// ```
+    pub fn policy_ticket(
+        &mut self,
+        policy_session: PolicySession,
+        timeout: Timeout,
+        cp_hash_a: Digest,
+        policy_ref: Nonce,
+        auth_name: Name,
+        ticket: AuthTicket,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PolicyTicket(
+                    self.mut_context(),
+                    SessionHandle::from(policy_session).into(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &timeout.into(),
+                    &cp_hash_a.into(),
+                    &policy_ref.into(),
+                    &auth_name.into(),
+                    &ticket.try_into()?,
+                )
+            },
+            |ret| {
+                error!("Error when computing policy ticket: {:#010X}", ret);
+            },
+        )
+    }
 
     /// Cause conditional gating of a policy based on an OR'd condition.
     ///
@@ -216,8 +281,141 @@ impl Context {
         )
     }
 
-    // Missing function: PolicyNV
-    // Missing function: PolicyCounterTimer
+    /// Cause conditional gating of a policy based on the contents of an NV index.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy_session` - The [PolicySession] being extended.
+    /// * `auth_handle` - Handle indicating the source of authorization for the NV index.
+    /// * `nv_index_handle` - The [NvIndexHandle] of the NV index to check.
+    /// * `operand_b` - A [Digest] used as the second operand in the comparison.
+    /// * `offset` - The offset in the NV index for starting the operand.
+    /// * `operation` - The [ArithmeticComparison] operation.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to cause conditional gating of a policy based
+    /// > on the contents of an NV Index.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::NvIndexHandle;
+    /// # use tss_esapi::interface_types::{
+    /// #     ArithmeticComparison,
+    /// #     reserved_handles::NvAuth,
+    /// #     session_handles::PolicySession,
+    /// # };
+    /// # use tss_esapi::structures::Digest;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes policy_session and nv_index_handle are properly set up
+    /// # // let operand = Digest::try_from(vec![0u8; 8]).unwrap();
+    /// # // context.policy_nv(
+    /// # //     policy_session, NvAuth::Owner, nv_index_handle,
+    /// # //     operand, 0, ArithmeticComparison::UnsignedEq,
+    /// # // ).unwrap();
+    /// ```
+    // TODO: Fix when compacting the arguments into a struct
+    #[allow(clippy::too_many_arguments)]
+    pub fn policy_nv(
+        &mut self,
+        policy_session: PolicySession,
+        auth_handle: NvAuth,
+        nv_index_handle: NvIndexHandle,
+        operand_b: Digest,
+        offset: u16,
+        operation: ArithmeticComparison,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PolicyNV(
+                    self.mut_context(),
+                    AuthHandle::from(auth_handle).into(),
+                    nv_index_handle.into(),
+                    SessionHandle::from(policy_session).into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &operand_b.into(),
+                    offset,
+                    operation.into(),
+                )
+            },
+            |ret| {
+                error!("Error when computing policy NV: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Cause conditional gating of a policy based on the TPM's counter/timer.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy_session` - The [PolicySession] being extended.
+    /// * `operand_b` - A [Digest] used as the second operand in the comparison.
+    /// * `offset` - The offset in the TPMS_TIME_INFO structure for starting the operand.
+    /// * `operation` - The [ArithmeticComparison] operation.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to cause conditional gating of a policy based
+    /// > on the contents of the TPMS_TIME_INFO structure.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::constants::SessionType;
+    /// # use tss_esapi::interface_types::{
+    /// #     algorithm::HashingAlgorithm, ArithmeticComparison,
+    /// #     session_handles::PolicySession,
+    /// # };
+    /// # use tss_esapi::structures::{Digest, SymmetricDefinition};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # let trial_session = context.start_auth_session(
+    /// #     None, None, None, SessionType::Trial,
+    /// #     SymmetricDefinition::AES_256_CFB, HashingAlgorithm::Sha256,
+    /// # ).unwrap().unwrap();
+    /// # let policy_session = PolicySession::try_from(trial_session).unwrap();
+    /// let operand = Digest::try_from(vec![0u8; 8]).unwrap();
+    /// context.policy_counter_timer(
+    ///     policy_session, operand, 0, ArithmeticComparison::UnsignedGe,
+    /// ).unwrap();
+    /// ```
+    pub fn policy_counter_timer(
+        &mut self,
+        policy_session: PolicySession,
+        operand_b: Digest,
+        offset: u16,
+        operation: ArithmeticComparison,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PolicyCounterTimer(
+                    self.mut_context(),
+                    SessionHandle::from(policy_session).into(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &operand_b.into(),
+                    offset,
+                    operation.into(),
+                )
+            },
+            |ret| {
+                error!("Error when computing policy counter timer: {:#010X}", ret);
+            },
+        )
+    }
 
     /// Cause conditional gating of a policy based on command code of authorized command.
     ///

--- a/tss-esapi/src/context/tpm_commands/ephemeral_ec_keys.rs
+++ b/tss-esapi/src/context/tpm_commands/ephemeral_ec_keys.rs
@@ -1,8 +1,157 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode,
+    handles::KeyHandle,
+    interface_types::ecc::EccCurve,
+    structures::{EccParameter, EccPoint, SensitiveData},
+    tss2_esys::{Esys_Commit, Esys_EC_Ephemeral},
+};
+use log::error;
+use std::convert::TryFrom;
+use std::ptr::null;
+use std::ptr::null_mut;
 
 impl Context {
-    // Missing function: Commit
-    // Missing function: EC_Ephemeral
+    /// Perform an ECC commit to generate ephemeral key pair (K, L) and counter.
+    ///
+    /// # Arguments
+    ///
+    /// * `sign_handle` - A [KeyHandle] of the ECC key for which the commit is being generated.
+    /// * `p1` - An optional point on the curve used by `sign_handle`.
+    /// * `s2` - An optional octet array used in the commit computation.
+    /// * `y2` - An optional ECC parameter used in the commit computation.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > TPM2_Commit() performs the first part of an ECC anonymous signing operation. The TPM will
+    /// > perform the point multiplications on the provided points and return intermediate signing
+    /// > values.
+    ///
+    /// > The TPM shall return TPM_RC_ATTRIBUTES if the sign attribute is not SET in the key
+    /// > referenced by signHandle.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(K, L, E, counter)` where K, L, E are [EccPoint] values
+    /// and counter is a `u16` value to be used in the signing operation.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes sign_handle is a loaded ECC key with sign attribute set
+    /// # // let (k, l, e, counter) = context.commit(sign_handle, None, None, None).unwrap();
+    /// ```
+    pub fn commit(
+        &mut self,
+        sign_handle: KeyHandle,
+        p1: impl Into<Option<EccPoint>>,
+        s2: impl Into<Option<SensitiveData>>,
+        y2: impl Into<Option<EccParameter>>,
+    ) -> Result<(EccPoint, EccPoint, EccPoint, u16)> {
+        let mut k_ptr = null_mut();
+        let mut l_ptr = null_mut();
+        let mut e_ptr = null_mut();
+        let mut counter: u16 = 0;
+
+        let potential_p1 = p1.into().map(|v| v.into());
+        let p1_ptr = potential_p1.as_ref().map_or_else(null, std::ptr::from_ref);
+
+        let potential_s2 = s2.into().map(|v| v.into());
+        let s2_ptr = potential_s2.as_ref().map_or_else(null, std::ptr::from_ref);
+
+        let potential_y2 = y2.into().map(|v| v.into());
+        let y2_ptr = potential_y2.as_ref().map_or_else(null, std::ptr::from_ref);
+
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_Commit(
+                    self.mut_context(),
+                    sign_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    p1_ptr,
+                    s2_ptr,
+                    y2_ptr,
+                    &mut k_ptr,
+                    &mut l_ptr,
+                    &mut e_ptr,
+                    &mut counter,
+                )
+            },
+            |ret| {
+                error!("Error when performing ECC commit: {:#010X}", ret);
+            },
+        )?;
+
+        let k_point = Context::ffi_data_to_owned(k_ptr)?;
+        let l_point = Context::ffi_data_to_owned(l_ptr)?;
+        let e_point = Context::ffi_data_to_owned(e_ptr)?;
+        Ok((
+            EccPoint::try_from(k_point.point)?,
+            EccPoint::try_from(l_point.point)?,
+            EccPoint::try_from(e_point.point)?,
+            counter,
+        ))
+    }
+
+    /// Create an ephemeral ECC key.
+    ///
+    /// # Arguments
+    ///
+    /// * `curve` - An [EccCurve] specifying the curve for the ephemeral key.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > TPM2_EC_Ephemeral() creates an ephemeral key for use in a two-phase key exchange protocol.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(Q, counter)` where Q is an [EccPoint] representing
+    /// the public ephemeral key and counter is a `u16` to be used
+    /// in a subsequent TPM2_Commit().
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// use tss_esapi::interface_types::ecc::EccCurve;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let (q_point, counter) = context.ec_ephemeral(EccCurve::NistP256).unwrap();
+    /// ```
+    pub fn ec_ephemeral(&mut self, curve: EccCurve) -> Result<(EccPoint, u16)> {
+        let mut q_ptr = null_mut();
+        let mut counter: u16 = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_EC_Ephemeral(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    curve.into(),
+                    &mut q_ptr,
+                    &mut counter,
+                )
+            },
+            |ret| {
+                error!("Error when creating EC ephemeral key: {:#010X}", ret);
+            },
+        )?;
+
+        let q_point = Context::ffi_data_to_owned(q_ptr)?;
+        Ok((EccPoint::try_from(q_point.point)?, counter))
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/field_upgrade.rs
+++ b/tss-esapi/src/context/tpm_commands/field_upgrade.rs
@@ -1,9 +1,168 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode,
+    handles::{AuthHandle, KeyHandle},
+    structures::{Digest, HashAgile, MaxBuffer, Signature},
+    tss2_esys::{Esys_FieldUpgradeData, Esys_FieldUpgradeStart, Esys_FirmwareRead},
+};
+use log::error;
+use std::convert::TryFrom;
+use std::ptr::null_mut;
 
 impl Context {
-    // Missing function: FieldUpgradeStart
-    // Missing function: FieldUpgradeData
-    // Missing function: FirmwareRead
+    /// Start a field upgrade sequence.
+    ///
+    /// # Arguments
+    ///
+    /// * `authorization` - An [AuthHandle] for the platform hierarchy.
+    /// * `key_handle` - A [KeyHandle] used to validate the manifest signature.
+    /// * `fu_digest` - A [Digest] of the firmware upgrade data.
+    /// * `manifest_signature` - A [Signature] over the fu_digest.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command uses platformPolicy and target key to authorize
+    /// > a field upgrade.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes authorization, key_handle, fu_digest, and manifest_signature
+    /// # // are properly set up for a field upgrade operation.
+    /// # // context.field_upgrade_start(authorization, key_handle, fu_digest, manifest_signature).unwrap();
+    /// ```
+    pub fn field_upgrade_start(
+        &mut self,
+        authorization: AuthHandle,
+        key_handle: KeyHandle,
+        fu_digest: Digest,
+        manifest_signature: Signature,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_FieldUpgradeStart(
+                    self.mut_context(),
+                    authorization.into(),
+                    key_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &fu_digest.into(),
+                    &manifest_signature.try_into()?,
+                )
+            },
+            |ret| {
+                error!("Error starting field upgrade: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Send field upgrade data to the TPM.
+    ///
+    /// # Arguments
+    ///
+    /// * `fu_data` - A [MaxBuffer] containing the field upgrade data.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command will take the actual field upgrade image to be
+    /// > installed on the TPM. The data is processed in a manner
+    /// > that is determined by the TPM manufacturer.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(HashAgile, HashAgile)` containing the next digest and first digest.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::structures::MaxBuffer;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes a field upgrade sequence has been started
+    /// # // let data = MaxBuffer::from_bytes(&[0x01, 0x02]).unwrap();
+    /// # // let (next_digest, first_digest) = context.field_upgrade_data(data).unwrap();
+    /// ```
+    pub fn field_upgrade_data(&mut self, fu_data: MaxBuffer) -> Result<(HashAgile, HashAgile)> {
+        let mut next_digest_ptr = null_mut();
+        let mut first_digest_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_FieldUpgradeData(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &fu_data.into(),
+                    &mut next_digest_ptr,
+                    &mut first_digest_ptr,
+                )
+            },
+            |ret| {
+                error!("Error sending field upgrade data: {:#010X}", ret);
+            },
+        )?;
+
+        Ok((
+            HashAgile::try_from(Context::ffi_data_to_owned(next_digest_ptr)?)?,
+            HashAgile::try_from(Context::ffi_data_to_owned(first_digest_ptr)?)?,
+        ))
+    }
+
+    /// Read the firmware data from the TPM.
+    ///
+    /// # Arguments
+    ///
+    /// * `sequence_number` - A `u32` sequence number for the firmware read.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to read a copy of the current firmware installed
+    /// > in the TPM.
+    ///
+    /// # Returns
+    ///
+    /// A [MaxBuffer] containing the firmware data.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // context.firmware_read(0).unwrap();
+    /// ```
+    pub fn firmware_read(&mut self, sequence_number: u32) -> Result<MaxBuffer> {
+        let mut fu_data_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_FirmwareRead(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    sequence_number,
+                    &mut fu_data_ptr,
+                )
+            },
+            |ret| {
+                error!("Error reading firmware: {:#010X}", ret);
+            },
+        )?;
+        MaxBuffer::try_from(Context::ffi_data_to_owned(fu_data_ptr)?)
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/hash_hmac_event_sequences.rs
+++ b/tss-esapi/src/context/tpm_commands/hash_hmac_event_sequences.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     Context, Result, ReturnCode,
-    handles::{ObjectHandle, TpmHandle},
-    interface_types::{algorithm::HashingAlgorithm, reserved_handles::Hierarchy},
-    structures::{Auth, Digest, HashcheckTicket, MaxBuffer},
+    handles::{ObjectHandle, PcrHandle, TpmHandle},
+    interface_types::algorithm::HashingAlgorithm,
+    interface_types::reserved_handles::Hierarchy,
+    structures::{Auth, Digest, DigestValues, HashcheckTicket, MaxBuffer},
     tss2_esys::{
-        Esys_HMAC_Start, Esys_HashSequenceStart, Esys_SequenceComplete, Esys_SequenceUpdate,
+        Esys_EventSequenceComplete, Esys_HMAC_Start, Esys_HashSequenceStart, Esys_SequenceComplete,
+        Esys_SequenceUpdate,
     },
 };
 use log::error;
@@ -142,7 +144,8 @@ impl Context {
         Ok(ObjectHandle::from(sequence_handle))
     }
 
-    // Missing function: MAC_Start
+    // Missing function: MAC (requires TPMI_ALG_MAC_SCHEME wrapper)
+    // Missing function: MAC_Start (requires TPMI_ALG_MAC_SCHEME wrapper)
 
     /// Starts hash sequence of large data (larger than [`MaxBuffer::MAX_SIZE`]) using the specified algorithm.
     ///
@@ -322,5 +325,82 @@ impl Context {
         ))
     }
 
-    // Missing function: EventSequenceComplete
+    /// Complete an event sequence and extend a PCR.
+    ///
+    /// # Arguments
+    ///
+    /// * `pcr_handle` - A [PcrHandle] of the PCR to extend.
+    /// * `sequence_handle` - An [ObjectHandle] of the sequence to complete.
+    /// * `buffer` - A [MaxBuffer] containing the last data to include.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command adds the last part of data, if any, to a hash/HMAC sequence
+    /// > and returns the result. It also extends a PCR with the hash result.
+    ///
+    /// # Returns
+    ///
+    /// A [DigestValues] containing the digests computed over the event data.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::PcrHandle;
+    /// # use tss_esapi::interface_types::algorithm::HashingAlgorithm;
+    /// # use tss_esapi::structures::MaxBuffer;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # let handle = context.hash_sequence_start(HashingAlgorithm::Null, None).unwrap();
+    /// let data = MaxBuffer::from_bytes(&[1, 2, 3]).unwrap();
+    /// let digests = context.event_sequence_complete(PcrHandle::Pcr16, handle, data).unwrap();
+    /// ```
+    pub fn event_sequence_complete(
+        &mut self,
+        pcr_handle: PcrHandle,
+        sequence_handle: ObjectHandle,
+        buffer: MaxBuffer,
+    ) -> Result<DigestValues> {
+        let mut results_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_EventSequenceComplete(
+                    self.mut_context(),
+                    pcr_handle.into(),
+                    sequence_handle.into(),
+                    self.required_session_1()?,
+                    self.required_session_2()?,
+                    self.optional_session_3(),
+                    &buffer.into(),
+                    &mut results_ptr,
+                )
+            },
+            |ret| {
+                error!("Error completing event sequence: {:#010X}", ret);
+            },
+        )?;
+        let results = Context::ffi_data_to_owned(results_ptr)?;
+        let mut digest_values = DigestValues::new();
+        for i in 0..results.count as usize {
+            let tpmt_ha = results.digests[i];
+            let algorithm = HashingAlgorithm::try_from(tpmt_ha.hashAlg)?;
+            let digest = match algorithm {
+                HashingAlgorithm::Sha1 => Digest::from(unsafe { tpmt_ha.digest.sha1 }),
+                HashingAlgorithm::Sha256 => Digest::from(unsafe { tpmt_ha.digest.sha256 }),
+                HashingAlgorithm::Sha384 => Digest::from(unsafe { tpmt_ha.digest.sha384 }),
+                HashingAlgorithm::Sha512 => Digest::from(unsafe { tpmt_ha.digest.sha512 }),
+                HashingAlgorithm::Sm3_256 => Digest::from(unsafe { tpmt_ha.digest.sm3_256 }),
+                _ => {
+                    return Err(crate::Error::local_error(
+                        crate::WrapperErrorKind::WrongValueFromTpm,
+                    ));
+                }
+            };
+            digest_values.set(algorithm, digest);
+        }
+        Ok(digest_values)
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/hierarchy_commands.rs
@@ -4,12 +4,15 @@ use crate::{
     Context, Result, ReturnCode,
     context::handle_manager::HandleDropAction,
     handles::{AuthHandle, KeyHandle, ObjectHandle},
-    interface_types::{YesNo, reserved_handles::Hierarchy},
+    interface_types::{YesNo, algorithm::HashingAlgorithm, reserved_handles::Hierarchy},
     structures::{
         Auth, CreatePrimaryKeyResult, CreationData, CreationTicket, Data, Digest, PcrSelectionList,
         Public, SensitiveCreate, SensitiveData,
     },
-    tss2_esys::{Esys_Clear, Esys_ClearControl, Esys_CreatePrimary, Esys_HierarchyChangeAuth},
+    tss2_esys::{
+        Esys_ChangeEPS, Esys_ChangePPS, Esys_Clear, Esys_ClearControl, Esys_CreatePrimary,
+        Esys_HierarchyChangeAuth, Esys_HierarchyControl, Esys_SetPrimaryPolicy,
+    },
 };
 use log::error;
 use std::convert::{TryFrom, TryInto};
@@ -87,10 +90,194 @@ impl Context {
         })
     }
 
-    // Missing function: HierarchyControl
-    // Missing function: SetPrimaryPolicy
-    // Missing function: ChangePPS
-    // Missing function: ChangeEPS
+    /// Enable or disable use of a hierarchy and its associated NV storage.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the authorization.
+    /// * `enable` - An [ObjectHandle] of the hierarchy to be enabled or disabled.
+    /// * `state` - `true` to enable, `false` to disable.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command allows a platform specific hierarchy to be disabled or
+    /// > to enable use of a hierarchy and its associated NV storage.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # use tss_esapi::interface_types::reserved_handles::Hierarchy;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// // Disable the null hierarchy
+    /// context.hierarchy_control(AuthHandle::Platform, Hierarchy::Null.into(), false).unwrap();
+    /// // Re-enable it
+    /// context.hierarchy_control(AuthHandle::Platform, Hierarchy::Null.into(), true).unwrap();
+    /// ```
+    pub fn hierarchy_control(
+        &mut self,
+        auth_handle: AuthHandle,
+        enable: ObjectHandle,
+        state: bool,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_HierarchyControl(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    enable.into(),
+                    YesNo::from(state).into(),
+                )
+            },
+            |ret| {
+                error!("Error in hierarchy control: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Set the authorization policy for a hierarchy.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the authorization.
+    /// * `auth_policy` - A [Digest] representing the authorization policy.
+    /// * `hash_algorithm` - The [HashingAlgorithm] used to compute the policy digest.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command allows the authorization secret for a hierarchy or lockout
+    /// > to be changed using the current policy.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # use tss_esapi::interface_types::algorithm::HashingAlgorithm;
+    /// # use tss_esapi::structures::Digest;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context.set_primary_policy(
+    ///     AuthHandle::Platform,
+    ///     Digest::default(),
+    ///     HashingAlgorithm::Sha256,
+    /// ).unwrap();
+    /// ```
+    pub fn set_primary_policy(
+        &mut self,
+        auth_handle: AuthHandle,
+        auth_policy: Digest,
+        hash_algorithm: HashingAlgorithm,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_SetPrimaryPolicy(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &auth_policy.into(),
+                    hash_algorithm.into(),
+                )
+            },
+            |ret| {
+                error!("Error setting primary policy: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Change the platform primary seed.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the platform hierarchy authorization.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This replaces the current PPS with a value from the RNG and sets
+    /// > platformPolicy to the default initialization value (the Empty Buffer).
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context.change_pps(AuthHandle::Platform).unwrap();
+    /// ```
+    pub fn change_pps(&mut self, auth_handle: AuthHandle) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ChangePPS(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                )
+            },
+            |ret| {
+                error!("Error changing PPS: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Change the endorsement primary seed.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the platform hierarchy authorization.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This replaces the current EPS with a value from the RNG and sets
+    /// > the attributes of the Endorsement hierarchy to their default
+    /// > initialization values.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context.change_eps(AuthHandle::Platform).unwrap();
+    /// ```
+    pub fn change_eps(&mut self, auth_handle: AuthHandle) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ChangeEPS(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                )
+            },
+            |ret| {
+                error!("Error changing EPS: {:#010X}", ret);
+            },
+        )
+    }
 
     /// Clear all TPM context associated with a specific Owner
     pub fn clear(&mut self, auth_handle: AuthHandle) -> Result<()> {

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     Context, Result, ReturnCode,
-    handles::PcrHandle,
-    structures::{DigestList, DigestValues, PcrSelectionList},
-    tss2_esys::{Esys_PCR_Extend, Esys_PCR_Read, Esys_PCR_Reset},
+    handles::{AuthHandle, PcrHandle},
+    interface_types::algorithm::HashingAlgorithm,
+    structures::{Auth, Digest, DigestList, DigestValues, MaxBuffer, PcrSelectionList},
+    tss2_esys::{
+        Esys_PCR_Allocate, Esys_PCR_Event, Esys_PCR_Extend, Esys_PCR_Read, Esys_PCR_Reset,
+        Esys_PCR_SetAuthPolicy, Esys_PCR_SetAuthValue, TPM2B_EVENT,
+    },
 };
 use log::error;
 use std::convert::{TryFrom, TryInto};
@@ -105,7 +109,87 @@ impl Context {
         )
     }
 
-    // Missing function: PCR_Event
+    /// Cause an event to be recorded in a PCR.
+    ///
+    /// # Arguments
+    ///
+    /// * `pcr_handle` - A [PcrHandle] of the PCR slot to extend.
+    /// * `event_data` - A [MaxBuffer] containing the event data.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to cause an update to the indicated PCR.
+    /// > The data in eventData is hashed using each of the implemented hash algorithms.
+    /// > For each PCR bank, pcrHandle is extended with the hash of eventData
+    /// > for that bank's algorithm.
+    ///
+    /// # Returns
+    ///
+    /// A [DigestValues] containing the digest of the event data for each implemented algorithm.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::PcrHandle;
+    /// # use tss_esapi::structures::MaxBuffer;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let data = MaxBuffer::from_bytes(&[1, 2, 3, 4]).unwrap();
+    /// let digests = context.pcr_event(PcrHandle::Pcr16, data).unwrap();
+    /// ```
+    pub fn pcr_event(
+        &mut self,
+        pcr_handle: PcrHandle,
+        event_data: MaxBuffer,
+    ) -> Result<DigestValues> {
+        let mut digests_ptr = null_mut();
+        let event_data_bytes = event_data.as_bytes();
+        let mut event = TPM2B_EVENT {
+            size: event_data_bytes.len() as u16,
+            ..Default::default()
+        };
+        event.buffer[..event_data_bytes.len()].copy_from_slice(event_data_bytes);
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PCR_Event(
+                    self.mut_context(),
+                    pcr_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &event,
+                    &mut digests_ptr,
+                )
+            },
+            |ret| {
+                error!("Error when performing PCR event: {:#010X}", ret);
+            },
+        )?;
+        let digests = Context::ffi_data_to_owned(digests_ptr)?;
+        let mut digest_values = DigestValues::new();
+        for i in 0..digests.count as usize {
+            let tpmt_ha = digests.digests[i];
+            let algorithm = HashingAlgorithm::try_from(tpmt_ha.hashAlg)?;
+            let digest = match algorithm {
+                HashingAlgorithm::Sha1 => Digest::from(unsafe { tpmt_ha.digest.sha1 }),
+                HashingAlgorithm::Sha256 => Digest::from(unsafe { tpmt_ha.digest.sha256 }),
+                HashingAlgorithm::Sha384 => Digest::from(unsafe { tpmt_ha.digest.sha384 }),
+                HashingAlgorithm::Sha512 => Digest::from(unsafe { tpmt_ha.digest.sha512 }),
+                HashingAlgorithm::Sm3_256 => Digest::from(unsafe { tpmt_ha.digest.sm3_256 }),
+                _ => {
+                    return Err(crate::Error::local_error(
+                        crate::WrapperErrorKind::WrongValueFromTpm,
+                    ));
+                }
+            };
+            digest_values.set(algorithm, digest);
+        }
+        Ok(digest_values)
+    }
 
     /// Reads the values of a PCR.
     ///
@@ -180,9 +264,181 @@ impl Context {
         ))
     }
 
-    // Missing function: PCR_Allocate
-    // Missing function: PCR_SetAuthPolicy
-    // Missing function: PCR_SetAuthValue
+    /// Allocate PCR banks.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the platform hierarchy.
+    /// * `pcr_allocation` - A [PcrSelectionList] specifying the requested PCR allocation.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to set the desired PCR allocation of PCR and algorithms.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(bool, u32, u32, u32)` representing:
+    /// * `allocation_success` - Whether the allocation was successful.
+    /// * `max_pcr` - Maximum number of PCR that may be in a bank.
+    /// * `size_needed` - Number of octets required to satisfy the request.
+    /// * `size_available` - Number of octets available (maximum size of NV).
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # use tss_esapi::interface_types::algorithm::HashingAlgorithm;
+    /// # use tss_esapi::structures::{PcrSelectionListBuilder, PcrSlot};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let pcr_allocation = PcrSelectionListBuilder::new()
+    ///     .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0])
+    ///     .build()
+    ///     .unwrap();
+    /// let (success, max_pcr, size_needed, size_available) = context
+    ///     .pcr_allocate(AuthHandle::Platform, pcr_allocation)
+    ///     .unwrap();
+    /// ```
+    pub fn pcr_allocate(
+        &mut self,
+        auth_handle: AuthHandle,
+        pcr_allocation: PcrSelectionList,
+    ) -> Result<(bool, u32, u32, u32)> {
+        let mut allocation_success: u8 = 0;
+        let mut max_pcr: u32 = 0;
+        let mut size_needed: u32 = 0;
+        let mut size_available: u32 = 0;
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PCR_Allocate(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &pcr_allocation.into(),
+                    &mut allocation_success,
+                    &mut max_pcr,
+                    &mut size_needed,
+                    &mut size_available,
+                )
+            },
+            |ret| {
+                error!("Error when allocating PCR: {:#010X}", ret);
+            },
+        )?;
+        Ok((
+            allocation_success != 0,
+            max_pcr,
+            size_needed,
+            size_available,
+        ))
+    }
+
+    /// Set the authorization policy for a PCR.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the platform hierarchy.
+    /// * `auth_policy` - A [Digest] representing the authorization policy.
+    /// * `hash_algorithm` - The [HashingAlgorithm] of the policy.
+    /// * `pcr_handle` - A [PcrHandle] of the PCR to set the policy for.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to associate a policy with a PCR or group of PCR.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::{AuthHandle, PcrHandle};
+    /// # use tss_esapi::interface_types::algorithm::HashingAlgorithm;
+    /// # use tss_esapi::structures::Digest;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context.pcr_set_auth_policy(
+    ///     AuthHandle::Platform,
+    ///     Digest::default(),
+    ///     HashingAlgorithm::Sha256,
+    ///     PcrHandle::Pcr16,
+    /// ).unwrap();
+    /// ```
+    pub fn pcr_set_auth_policy(
+        &mut self,
+        auth_handle: AuthHandle,
+        auth_policy: Digest,
+        hash_algorithm: HashingAlgorithm,
+        pcr_handle: PcrHandle,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PCR_SetAuthPolicy(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &auth_policy.into(),
+                    hash_algorithm.into(),
+                    pcr_handle.into(),
+                )
+            },
+            |ret| {
+                error!("Error when setting PCR auth policy: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Set the authorization value for a PCR.
+    ///
+    /// # Arguments
+    ///
+    /// * `pcr_handle` - A [PcrHandle] of the PCR to set the auth value for.
+    /// * `auth` - An [Auth] value for the PCR.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command changes the authValue of a PCR or group of PCR.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::PcrHandle;
+    /// # use tss_esapi::structures::Auth;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let auth = Auth::from_bytes(&[1, 2, 3, 4]).unwrap();
+    /// context.pcr_set_auth_value(PcrHandle::Pcr16, auth).unwrap();
+    /// ```
+    pub fn pcr_set_auth_value(&mut self, pcr_handle: PcrHandle, auth: Auth) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PCR_SetAuthValue(
+                    self.mut_context(),
+                    pcr_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &auth.into(),
+                )
+            },
+            |ret| {
+                error!("Error when setting PCR auth value: {:#010X}", ret);
+            },
+        )
+    }
 
     /// Resets the value in a PCR.
     ///
@@ -254,7 +510,7 @@ impl Context {
         )
     }
 
-    // Missing function: _TPM_Hash_Start
-    // Missing function: _TPM_Hash_Data
-    // Missing function: _TPM_Hash_End
+    // Missing function: _TPM_Hash_Start (platform-level indication, not an ESAPI command)
+    // Missing function: _TPM_Hash_Data (platform-level indication, not an ESAPI command)
+    // Missing function: _TPM_Hash_End (platform-level indication, not an ESAPI command)
 }

--- a/tss-esapi/src/context/tpm_commands/miscellaneous_management_functions.rs
+++ b/tss-esapi/src/context/tpm_commands/miscellaneous_management_functions.rs
@@ -1,8 +1,108 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode,
+    handles::AuthHandle,
+    structures::CommandCodeList,
+    tss2_esys::{Esys_PP_Commands, Esys_SetAlgorithmSet},
+};
+use log::error;
 
 impl Context {
-    // Missing function: PP_Commands
-    // Missing function: SetAlgorithmSet
+    /// Set the list of commands that require Physical Presence for confirmation.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the platform hierarchy.
+    /// * `set_list` - A [CommandCodeList] of command codes to add to the PP list.
+    /// * `clear_list` - A [CommandCodeList] of command codes to remove from the PP list.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to determine which commands require assertion
+    /// > of Physical Presence (PP) in addition to platformAuth/platformPolicy.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # use tss_esapi::structures::CommandCodeList;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context.pp_commands(
+    ///     AuthHandle::Platform,
+    ///     CommandCodeList::new(),
+    ///     CommandCodeList::new(),
+    /// ).unwrap();
+    /// ```
+    pub fn pp_commands(
+        &mut self,
+        auth_handle: AuthHandle,
+        set_list: CommandCodeList,
+        clear_list: CommandCodeList,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PP_Commands(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &set_list.into(),
+                    &clear_list.into(),
+                )
+            },
+            |ret| {
+                error!("Error setting PP commands: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Set the algorithm set of the TPM.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the platform hierarchy.
+    /// * `algorithm_set` - A `u32` identifying the algorithm set.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command allows the platform to change the set of algorithms
+    /// > that are used by the TPM. The algorithmSet changes the
+    /// > group of algorithms that are used in TPM-dependent operations.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // context.set_algorithm_set(AuthHandle::Platform, 0).unwrap();
+    /// ```
+    pub fn set_algorithm_set(&mut self, auth_handle: AuthHandle, algorithm_set: u32) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_SetAlgorithmSet(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    algorithm_set,
+                )
+            },
+            |ret| {
+                error!("Error setting algorithm set: {:#010X}", ret);
+            },
+        )
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
+++ b/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
@@ -3,12 +3,16 @@
 use crate::{
     Context, Result, ReturnCode,
     context::handle_manager::HandleDropAction,
-    handles::{AuthHandle, NvIndexHandle, ObjectHandle},
+    handles::{AuthHandle, KeyHandle, NvIndexHandle, ObjectHandle},
     interface_types::reserved_handles::{NvAuth, Provision},
-    structures::{Auth, MaxNvBuffer, Name, NvPublic},
+    structures::{
+        Attest, AttestBuffer, Auth, Data, MaxNvBuffer, Name, NvPublic, Signature, SignatureScheme,
+    },
     tss2_esys::{
-        Esys_NV_DefineSpace, Esys_NV_Extend, Esys_NV_Increment, Esys_NV_Read, Esys_NV_ReadPublic,
-        Esys_NV_UndefineSpace, Esys_NV_UndefineSpaceSpecial, Esys_NV_Write,
+        Esys_NV_Certify, Esys_NV_ChangeAuth, Esys_NV_DefineSpace, Esys_NV_Extend,
+        Esys_NV_GlobalWriteLock, Esys_NV_Increment, Esys_NV_Read, Esys_NV_ReadLock,
+        Esys_NV_ReadPublic, Esys_NV_SetBits, Esys_NV_UndefineSpace, Esys_NV_UndefineSpaceSpecial,
+        Esys_NV_Write, Esys_NV_WriteLock,
     },
 };
 use log::error;
@@ -808,9 +812,145 @@ impl Context {
         )
     }
 
-    // Missing function: NV_SetBits
-    // Missing function: NV_WriteLock
-    // Missing function: NV_GlobalWriteLock
+    /// Set bits in an NV index.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - The handle indicating the source of authorization value.
+    /// * `nv_index_handle` - The [NvIndexHandle] of the NV index.
+    /// * `bits` - The data to OR with the current contents.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to SET bits in an NV Index that was
+    /// > created as a bit field. Any number of bits from 0 to 64 may
+    /// > be SET. The contents of bits are ORed with the current contents
+    /// > of the NV Index.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::interface_types::reserved_handles::NvAuth;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes nv_index_handle is a defined NV index of type Bits
+    /// # // context.nv_set_bits(NvAuth::Owner, nv_index_handle, 0x01).unwrap();
+    /// ```
+    pub fn nv_set_bits(
+        &mut self,
+        auth_handle: NvAuth,
+        nv_index_handle: NvIndexHandle,
+        bits: u64,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_NV_SetBits(
+                    self.mut_context(),
+                    AuthHandle::from(auth_handle).into(),
+                    nv_index_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    bits,
+                )
+            },
+            |ret| {
+                error!("Error when setting NV bits: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Write-lock an NV index.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - The handle indicating the source of authorization value.
+    /// * `nv_index_handle` - The [NvIndexHandle] of the NV index.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > If the TPMA_NV_WRITEDEFINE or TPMA_NV_WRITE_STCLEAR attribute of
+    /// > the NV Index is SET, then this command may be used to inhibit
+    /// > further writes of the NV Index.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::interface_types::reserved_handles::NvAuth;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes nv_index_handle is a defined NV index with TPMA_NV_WRITE_STCLEAR
+    /// # // context.nv_write_lock(NvAuth::Owner, nv_index_handle).unwrap();
+    /// ```
+    pub fn nv_write_lock(
+        &mut self,
+        auth_handle: NvAuth,
+        nv_index_handle: NvIndexHandle,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_NV_WriteLock(
+                    self.mut_context(),
+                    AuthHandle::from(auth_handle).into(),
+                    nv_index_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                )
+            },
+            |ret| {
+                error!("Error when write-locking NV index: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Apply a global lock on NV write.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the authorization (Platform hierarchy).
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command will SET TPMA_NV_WRITELOCKED for all indexes that have
+    /// > their TPMA_NV_GLOBALLOCK attribute SET.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context.nv_global_write_lock(AuthHandle::Owner).unwrap();
+    /// ```
+    pub fn nv_global_write_lock(&mut self, auth_handle: AuthHandle) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_NV_GlobalWriteLock(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                )
+            },
+            |ret| {
+                error!("Error when globally write-locking NV: {:#010X}", ret);
+            },
+        )
+    }
 
     /// Reads data from the nv index.
     ///
@@ -937,7 +1077,174 @@ impl Context {
         MaxNvBuffer::try_from(Context::ffi_data_to_owned(data_ptr)?)
     }
 
-    // Missing function: NV_ReadLock
-    // Missing function: NV_ChangeAuth
-    // Missing function: NV_Certify
+    /// Read-lock an NV index.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - The handle indicating the source of authorization value.
+    /// * `nv_index_handle` - The [NvIndexHandle] of the NV index.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > If TPMA_NV_READ_STCLEAR is SET in an Index, then this command
+    /// > may be used to prevent further reads of the NV Index until
+    /// > the next TPM2_Startup (TPM_SU_CLEAR).
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::interface_types::reserved_handles::NvAuth;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes nv_index_handle is a defined NV index with TPMA_NV_READ_STCLEAR
+    /// # // context.nv_read_lock(NvAuth::Owner, nv_index_handle).unwrap();
+    /// ```
+    pub fn nv_read_lock(
+        &mut self,
+        auth_handle: NvAuth,
+        nv_index_handle: NvIndexHandle,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_NV_ReadLock(
+                    self.mut_context(),
+                    AuthHandle::from(auth_handle).into(),
+                    nv_index_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                )
+            },
+            |ret| {
+                error!("Error when read-locking NV index: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Change the authorization value for an NV index.
+    ///
+    /// # Arguments
+    ///
+    /// * `nv_index_handle` - The [NvIndexHandle] of the NV index.
+    /// * `new_auth` - The new authorization [Auth] value.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command allows the authorization secret for an NV Index
+    /// > to be changed.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::structures::Auth;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes nv_index_handle is a defined NV index
+    /// # // let new_auth = Auth::from_bytes(&[1, 2, 3, 4]).unwrap();
+    /// # // context.nv_change_auth(nv_index_handle, new_auth).unwrap();
+    /// ```
+    pub fn nv_change_auth(&mut self, nv_index_handle: NvIndexHandle, new_auth: Auth) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_NV_ChangeAuth(
+                    self.mut_context(),
+                    nv_index_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &new_auth.into(),
+                )
+            },
+            |ret| {
+                error!("Error when changing NV auth: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Certify the contents of an NV index.
+    ///
+    /// # Arguments
+    ///
+    /// * `sign_handle` - A [KeyHandle] of the key used to sign the attestation structure.
+    /// * `auth_handle` - The handle indicating the source of authorization value for the NV index.
+    /// * `nv_index_handle` - The [NvIndexHandle] of the NV index to be certified.
+    /// * `qualifying_data` - [Data] to qualify the signing.
+    /// * `signing_scheme` - The [SignatureScheme] to use for signing.
+    /// * `size` - Number of octets to certify.
+    /// * `offset` - Octet offset into the NV area.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > The purpose of this command is to certify the contents of an
+    /// > NV Index or portion of an NV Index.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(Attest, Signature)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::structures::{Data, SignatureScheme};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// # // Assumes sign_handle and nv_index_handle are properly set up
+    /// # // let (attest, sig) = context.nv_certify(
+    /// # //     sign_handle, NvAuth::Owner, nv_index_handle,
+    /// # //     Data::default(), SignatureScheme::Null, 32, 0,
+    /// # // ).unwrap();
+    /// ```
+    // TODO: Fix when compacting the arguments into a struct
+    #[allow(clippy::too_many_arguments)]
+    pub fn nv_certify(
+        &mut self,
+        sign_handle: KeyHandle,
+        auth_handle: NvAuth,
+        nv_index_handle: NvIndexHandle,
+        qualifying_data: Data,
+        signing_scheme: SignatureScheme,
+        size: u16,
+        offset: u16,
+    ) -> Result<(Attest, Signature)> {
+        let mut certify_info_ptr = null_mut();
+        let mut signature_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_NV_Certify(
+                    self.mut_context(),
+                    sign_handle.into(),
+                    AuthHandle::from(auth_handle).into(),
+                    nv_index_handle.into(),
+                    self.required_session_1()?,
+                    self.required_session_2()?,
+                    self.optional_session_3(),
+                    &qualifying_data.into(),
+                    &signing_scheme.into(),
+                    size,
+                    offset,
+                    &mut certify_info_ptr,
+                    &mut signature_ptr,
+                )
+            },
+            |ret| {
+                error!("Error when certifying NV: {:#010X}", ret);
+            },
+        )?;
+
+        let certify_info = AttestBuffer::try_from(Context::ffi_data_to_owned(certify_info_ptr)?)?;
+        let signature = Signature::try_from(Context::ffi_data_to_owned(signature_ptr)?)?;
+        Ok((certify_info.try_into()?, signature))
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -413,5 +413,5 @@ impl Context {
         Private::try_from(Context::ffi_data_to_owned(out_private_ptr)?)
     }
 
-    // Missing function: CreateLoaded
+    // Missing function: CreateLoaded (requires TPM2B_TEMPLATE wrapper and marshalling support)
 }

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -372,5 +372,5 @@ impl Context {
         Digest::try_from(Context::ffi_data_to_owned(out_hmac_ptr)?)
     }
 
-    // Missing function: MAC
+    // Missing function: MAC (requires TPMI_ALG_MAC_SCHEME wrapper)
 }

--- a/tss-esapi/src/context/tpm_commands/testing.rs
+++ b/tss-esapi/src/context/tpm_commands/testing.rs
@@ -1,10 +1,10 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    Context, Result, ReturnCode,
+    Context, Error, Result, ReturnCode, WrapperErrorKind,
     interface_types::YesNo,
     structures::MaxBuffer,
-    tss2_esys::{Esys_GetTestResult, Esys_SelfTest},
+    tss2_esys::{Esys_GetTestResult, Esys_IncrementalSelfTest, Esys_SelfTest, TPML_ALG},
 };
 use log::error;
 use std::convert::TryFrom;
@@ -29,7 +29,65 @@ impl Context {
         )
     }
 
-    // Missing function: incremental_self_test
+    /// Run an incremental self test on the selected algorithms.
+    ///
+    /// # Arguments
+    ///
+    /// * `to_test` - A list of algorithm IDs to test.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command causes the TPM to perform a test of the selected algorithms.
+    ///
+    /// # Returns
+    ///
+    /// A list of algorithm IDs that still need to be tested.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let to_do_list = context.incremental_self_test(&[]).unwrap();
+    /// ```
+    pub fn incremental_self_test(&mut self, to_test: &[u16]) -> Result<Vec<u16>> {
+        let mut tpml_alg = TPML_ALG {
+            count: to_test.len() as u32,
+            ..Default::default()
+        };
+        if to_test.len() > tpml_alg.algorithms.len() {
+            error!(
+                "Too many algorithms to test ({}), maximum is {}",
+                to_test.len(),
+                tpml_alg.algorithms.len()
+            );
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        tpml_alg.algorithms[..to_test.len()].copy_from_slice(to_test);
+
+        let mut to_do_list_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_IncrementalSelfTest(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &tpml_alg,
+                    &mut to_do_list_ptr,
+                )
+            },
+            |ret| {
+                error!("Error in incremental self test: {:#010X}", ret);
+            },
+        )?;
+        let to_do_list = Context::ffi_data_to_owned(to_do_list_ptr)?;
+        Ok(to_do_list.algorithms[..to_do_list.count as usize].to_vec())
+    }
 
     /// Get the TPM self test result
     ///

--- a/tss-esapi/src/interface_types/algorithm.rs
+++ b/tss-esapi/src/interface_types/algorithm.rs
@@ -6,7 +6,7 @@ use crate::{
     tss2_esys::{
         TPMI_ALG_ASYM, TPMI_ALG_ECC_SCHEME, TPMI_ALG_HASH, TPMI_ALG_KDF, TPMI_ALG_KEYEDHASH_SCHEME,
         TPMI_ALG_PUBLIC, TPMI_ALG_RSA_DECRYPT, TPMI_ALG_RSA_SCHEME, TPMI_ALG_SIG_SCHEME,
-        TPMI_ALG_SYM, TPMI_ALG_SYM_MODE, TPMI_ALG_SYM_OBJECT,
+        TPMI_ALG_SYM, TPMI_ALG_SYM_MODE, TPMI_ALG_SYM_OBJECT, TPMI_ECC_KEY_EXCHANGE,
     },
 };
 use std::convert::TryFrom;
@@ -682,5 +682,56 @@ impl TryFrom<TPMI_ALG_RSA_DECRYPT> for RsaDecryptAlgorithm {
 
     fn try_from(tpmi_alg_rsa_decrypt: TPMI_ALG_RSA_DECRYPT) -> Result<Self> {
         RsaDecryptAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_alg_rsa_decrypt)?)
+    }
+}
+
+/// Enum representing the ECC key exchange interface type.
+///
+/// # Details
+/// This corresponds to `TPMI_ECC_KEY_EXCHANGE`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum EccKeyExchangeAlgorithm {
+    EcDh,
+    EcMqv,
+    Sm2,
+    Null,
+}
+
+impl From<EccKeyExchangeAlgorithm> for AlgorithmIdentifier {
+    fn from(ecc_key_exchange_algorithm: EccKeyExchangeAlgorithm) -> Self {
+        match ecc_key_exchange_algorithm {
+            EccKeyExchangeAlgorithm::EcDh => AlgorithmIdentifier::EcDh,
+            EccKeyExchangeAlgorithm::EcMqv => AlgorithmIdentifier::EcMqv,
+            EccKeyExchangeAlgorithm::Sm2 => AlgorithmIdentifier::Sm2,
+            EccKeyExchangeAlgorithm::Null => AlgorithmIdentifier::Null,
+        }
+    }
+}
+
+impl TryFrom<AlgorithmIdentifier> for EccKeyExchangeAlgorithm {
+    type Error = Error;
+
+    fn try_from(algorithm_identifier: AlgorithmIdentifier) -> Result<Self> {
+        match algorithm_identifier {
+            AlgorithmIdentifier::EcDh => Ok(EccKeyExchangeAlgorithm::EcDh),
+            AlgorithmIdentifier::EcMqv => Ok(EccKeyExchangeAlgorithm::EcMqv),
+            AlgorithmIdentifier::Sm2 => Ok(EccKeyExchangeAlgorithm::Sm2),
+            AlgorithmIdentifier::Null => Ok(EccKeyExchangeAlgorithm::Null),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+impl From<EccKeyExchangeAlgorithm> for TPMI_ECC_KEY_EXCHANGE {
+    fn from(ecc_key_exchange_algorithm: EccKeyExchangeAlgorithm) -> Self {
+        AlgorithmIdentifier::from(ecc_key_exchange_algorithm).into()
+    }
+}
+
+impl TryFrom<TPMI_ECC_KEY_EXCHANGE> for EccKeyExchangeAlgorithm {
+    type Error = Error;
+
+    fn try_from(tpmi_ecc_key_exchange: TPMI_ECC_KEY_EXCHANGE) -> Result<Self> {
+        EccKeyExchangeAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_ecc_key_exchange)?)
     }
 }

--- a/tss-esapi/src/interface_types/arithmetic_comparison.rs
+++ b/tss-esapi/src/interface_types/arithmetic_comparison.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    Error, Result, WrapperErrorKind,
+    constants::tss::{
+        TPM2_EO_BITCLEAR, TPM2_EO_BITSET, TPM2_EO_EQ, TPM2_EO_NEQ, TPM2_EO_SIGNED_GE,
+        TPM2_EO_SIGNED_GT, TPM2_EO_SIGNED_LE, TPM2_EO_SIGNED_LT, TPM2_EO_UNSIGNED_GE,
+        TPM2_EO_UNSIGNED_GT, TPM2_EO_UNSIGNED_LE, TPM2_EO_UNSIGNED_LT,
+    },
+    tss2_esys::TPM2_EO,
+};
+use log::error;
+use std::convert::TryFrom;
+
+/// Arithmetic comparison operation for policy evaluation.
+///
+/// # Details
+/// This corresponds to the `TPM2_EO` type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ArithmeticComparison {
+    /// A == B
+    Eq,
+    /// A != B
+    Neq,
+    /// A > B (signed)
+    SignedGt,
+    /// A > B (unsigned)
+    UnsignedGt,
+    /// A < B (signed)
+    SignedLt,
+    /// A < B (unsigned)
+    UnsignedLt,
+    /// A >= B (signed)
+    SignedGe,
+    /// A >= B (unsigned)
+    UnsignedGe,
+    /// A <= B (signed)
+    SignedLe,
+    /// A <= B (unsigned)
+    UnsignedLe,
+    /// All bits SET in B are SET in A
+    BitSet,
+    /// All bits SET in B are CLEAR in A
+    BitClear,
+}
+
+impl From<ArithmeticComparison> for TPM2_EO {
+    fn from(arithmetic_comparison: ArithmeticComparison) -> Self {
+        match arithmetic_comparison {
+            ArithmeticComparison::Eq => TPM2_EO_EQ,
+            ArithmeticComparison::Neq => TPM2_EO_NEQ,
+            ArithmeticComparison::SignedGt => TPM2_EO_SIGNED_GT,
+            ArithmeticComparison::UnsignedGt => TPM2_EO_UNSIGNED_GT,
+            ArithmeticComparison::SignedLt => TPM2_EO_SIGNED_LT,
+            ArithmeticComparison::UnsignedLt => TPM2_EO_UNSIGNED_LT,
+            ArithmeticComparison::SignedGe => TPM2_EO_SIGNED_GE,
+            ArithmeticComparison::UnsignedGe => TPM2_EO_UNSIGNED_GE,
+            ArithmeticComparison::SignedLe => TPM2_EO_SIGNED_LE,
+            ArithmeticComparison::UnsignedLe => TPM2_EO_UNSIGNED_LE,
+            ArithmeticComparison::BitSet => TPM2_EO_BITSET,
+            ArithmeticComparison::BitClear => TPM2_EO_BITCLEAR,
+        }
+    }
+}
+
+impl TryFrom<TPM2_EO> for ArithmeticComparison {
+    type Error = Error;
+
+    fn try_from(tpm2_eo: TPM2_EO) -> Result<Self> {
+        match tpm2_eo {
+            TPM2_EO_EQ => Ok(ArithmeticComparison::Eq),
+            TPM2_EO_NEQ => Ok(ArithmeticComparison::Neq),
+            TPM2_EO_SIGNED_GT => Ok(ArithmeticComparison::SignedGt),
+            TPM2_EO_UNSIGNED_GT => Ok(ArithmeticComparison::UnsignedGt),
+            TPM2_EO_SIGNED_LT => Ok(ArithmeticComparison::SignedLt),
+            TPM2_EO_UNSIGNED_LT => Ok(ArithmeticComparison::UnsignedLt),
+            TPM2_EO_SIGNED_GE => Ok(ArithmeticComparison::SignedGe),
+            TPM2_EO_UNSIGNED_GE => Ok(ArithmeticComparison::UnsignedGe),
+            TPM2_EO_SIGNED_LE => Ok(ArithmeticComparison::SignedLe),
+            TPM2_EO_UNSIGNED_LE => Ok(ArithmeticComparison::UnsignedLe),
+            TPM2_EO_BITSET => Ok(ArithmeticComparison::BitSet),
+            TPM2_EO_BITCLEAR => Ok(ArithmeticComparison::BitClear),
+            _ => {
+                error!("Invalid TPM2_EO value: {}", tpm2_eo);
+                Err(Error::local_error(WrapperErrorKind::InvalidParam))
+            }
+        }
+    }
+}

--- a/tss-esapi/src/interface_types/mod.rs
+++ b/tss-esapi/src/interface_types/mod.rs
@@ -3,6 +3,7 @@
 
 //! This module contains the different interface types defined in
 //! the TPM 2.0 specification.
+mod arithmetic_comparison;
 mod yes_no;
 
 pub mod algorithm;
@@ -13,4 +14,5 @@ pub mod reserved_handles;
 pub mod session_handles;
 pub mod structure_tags;
 
+pub use arithmetic_comparison::ArithmeticComparison;
 pub use yes_no::YesNo;

--- a/tss-esapi/src/structures/attestation/attest.rs
+++ b/tss-esapi/src/structures/attestation/attest.rs
@@ -9,7 +9,6 @@ use crate::{
     traits::impl_mu_standard,
     tss2_esys::TPMS_ATTEST,
 };
-use log::error;
 use std::convert::{TryFrom, TryInto};
 
 /// Type for holding attestation data
@@ -110,8 +109,17 @@ impl TryFrom<TPMS_ATTEST> for Attest {
                     info: unsafe { tpms_attest.attested.nv }.try_into()?,
                 },
                 AttestationType::NvDigest => {
-                    error!("NvDigest attestation type is currently not supported");
-                    return Err(Error::local_error(WrapperErrorKind::UnsupportedParam));
+                    // TPMU_ATTEST does not have a nvDigest field in the current
+                    // tpm2-tss bindings. TPMS_NV_DIGEST_CERTIFY_INFO occupies the
+                    // same union offset and is smaller, so reinterpreting is safe.
+                    let nv_digest_info = unsafe {
+                        let ptr: *const crate::tss2_esys::TPMS_NV_DIGEST_CERTIFY_INFO =
+                            std::ptr::from_ref(&tpms_attest.attested).cast();
+                        *ptr
+                    };
+                    AttestInfo::NvDigest {
+                        info: nv_digest_info.try_into()?,
+                    }
                 }
             },
         })

--- a/tss-esapi/src/structures/attestation/attest_info.rs
+++ b/tss-esapi/src/structures/attestation/attest_info.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     structures::{
-        CertifyInfo, CommandAuditInfo, CreationInfo, NvCertifyInfo, QuoteInfo, SessionAuditInfo,
-        TimeAttestInfo,
+        CertifyInfo, CommandAuditInfo, CreationInfo, NvCertifyInfo, NvDigestCertifyInfo, QuoteInfo,
+        SessionAuditInfo, TimeAttestInfo,
     },
     tss2_esys::TPMU_ATTEST,
 };
@@ -25,8 +25,7 @@ pub enum AttestInfo {
     Time { info: TimeAttestInfo },
     Creation { info: CreationInfo },
     Nv { info: NvCertifyInfo },
-    // NvDigest, the TPMS_NV_DIGEST_CERTIFY_INFO,
-    // was first added in the 3.1.0 version of the tpm2-tss
+    NvDigest { info: NvDigestCertifyInfo },
 }
 
 impl From<AttestInfo> for TPMU_ATTEST {
@@ -47,6 +46,23 @@ impl From<AttestInfo> for TPMU_ATTEST {
                 creation: info.into(),
             },
             AttestInfo::Nv { info } => TPMU_ATTEST { nv: info.into() },
+            // TPMU_ATTEST does not have a nvDigest field in the current
+            // tpm2-tss bindings (4.1.3). TPMS_NV_DIGEST_CERTIFY_INFO is
+            // smaller than TPMS_NV_CERTIFY_INFO, so reinterpreting via
+            // the `nv` field is safe for marshalling purposes.
+            AttestInfo::NvDigest { info } => {
+                let mut attest = TPMU_ATTEST {
+                    nv: Default::default(),
+                };
+                // Safety: nv is larger than nvDigest, and we are writing
+                // the smaller struct into the beginning of the union.
+                unsafe {
+                    let ptr: *mut crate::tss2_esys::TPMS_NV_DIGEST_CERTIFY_INFO =
+                        std::ptr::from_mut(&mut attest).cast();
+                    *ptr = info.into();
+                }
+                attest
+            }
         }
     }
 }

--- a/tss-esapi/src/structures/attestation/nv_digest_certify_info.rs
+++ b/tss-esapi/src/structures/attestation/nv_digest_certify_info.rs
@@ -1,7 +1,12 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::structures::{Digest, Name};
+use crate::{
+    Error, Result,
+    structures::{Digest, Name},
+    tss2_esys::TPMS_NV_DIGEST_CERTIFY_INFO,
+};
+use std::convert::{TryFrom, TryInto};
 
 /// This structure contains the Name and hash of the
 /// contents of the selected NV Index that is certified by
@@ -24,5 +29,25 @@ impl NvDigestCertifyInfo {
     /// Returns the NV digest.
     pub const fn nv_digest(&self) -> &Digest {
         &self.nv_digest
+    }
+}
+
+impl From<NvDigestCertifyInfo> for TPMS_NV_DIGEST_CERTIFY_INFO {
+    fn from(nv_digest_certify_info: NvDigestCertifyInfo) -> Self {
+        TPMS_NV_DIGEST_CERTIFY_INFO {
+            indexName: nv_digest_certify_info.index_name.into(),
+            nvDigest: nv_digest_certify_info.nv_digest.into(),
+        }
+    }
+}
+
+impl TryFrom<TPMS_NV_DIGEST_CERTIFY_INFO> for NvDigestCertifyInfo {
+    type Error = Error;
+
+    fn try_from(tpms_nv_digest_certify_info: TPMS_NV_DIGEST_CERTIFY_INFO) -> Result<Self> {
+        Ok(NvDigestCertifyInfo {
+            index_name: tpms_nv_digest_certify_info.indexName.try_into()?,
+            nv_digest: tpms_nv_digest_certify_info.nvDigest.try_into()?,
+        })
     }
 }

--- a/tss-esapi/src/structures/ecc/mod.rs
+++ b/tss-esapi/src/structures/ecc/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+pub mod parameter_details;
 pub mod point;

--- a/tss-esapi/src/structures/ecc/parameter_details.rs
+++ b/tss-esapi/src/structures/ecc/parameter_details.rs
@@ -1,0 +1,106 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    Error, Result,
+    interface_types::ecc::EccCurve,
+    structures::{EccParameter, EccScheme, KeyDerivationFunctionScheme},
+    tss2_esys::TPMS_ALGORITHM_DETAIL_ECC,
+};
+use std::convert::{TryFrom, TryInto};
+
+/// Detailed information about an ECC curve.
+///
+/// # Details
+/// This corresponds to `TPMS_ALGORITHM_DETAIL_ECC`.
+#[derive(Debug, Clone)]
+pub struct EccParameterDetails {
+    curve_id: EccCurve,
+    key_size: u16,
+    kdf: KeyDerivationFunctionScheme,
+    sign: EccScheme,
+    p: EccParameter,
+    a: EccParameter,
+    b: EccParameter,
+    g_x: EccParameter,
+    g_y: EccParameter,
+    n: EccParameter,
+    h: EccParameter,
+}
+
+impl EccParameterDetails {
+    /// Returns the curve ID.
+    pub const fn curve_id(&self) -> EccCurve {
+        self.curve_id
+    }
+
+    /// Returns the key size in bits.
+    pub const fn key_size(&self) -> u16 {
+        self.key_size
+    }
+
+    /// Returns the key derivation function scheme.
+    pub const fn kdf(&self) -> &KeyDerivationFunctionScheme {
+        &self.kdf
+    }
+
+    /// Returns the signing scheme.
+    pub const fn sign(&self) -> &EccScheme {
+        &self.sign
+    }
+
+    /// Returns the prime modulus p.
+    pub const fn p(&self) -> &EccParameter {
+        &self.p
+    }
+
+    /// Returns the curve coefficient a.
+    pub const fn a(&self) -> &EccParameter {
+        &self.a
+    }
+
+    /// Returns the curve coefficient b.
+    pub const fn b(&self) -> &EccParameter {
+        &self.b
+    }
+
+    /// Returns the x-coordinate of the base point G.
+    pub const fn g_x(&self) -> &EccParameter {
+        &self.g_x
+    }
+
+    /// Returns the y-coordinate of the base point G.
+    pub const fn g_y(&self) -> &EccParameter {
+        &self.g_y
+    }
+
+    /// Returns the order of the base point n.
+    pub const fn n(&self) -> &EccParameter {
+        &self.n
+    }
+
+    /// Returns the cofactor h.
+    pub const fn h(&self) -> &EccParameter {
+        &self.h
+    }
+}
+
+impl TryFrom<TPMS_ALGORITHM_DETAIL_ECC> for EccParameterDetails {
+    type Error = Error;
+
+    fn try_from(details: TPMS_ALGORITHM_DETAIL_ECC) -> Result<Self> {
+        Ok(EccParameterDetails {
+            curve_id: EccCurve::try_from(details.curveID)?,
+            key_size: details.keySize,
+            kdf: details.kdf.try_into()?,
+            sign: details.sign.try_into()?,
+            p: details.p.try_into()?,
+            a: details.a.try_into()?,
+            b: details.b.try_into()?,
+            g_x: details.gX.try_into()?,
+            g_y: details.gY.try_into()?,
+            n: details.n.try_into()?,
+            h: details.h.try_into()?,
+        })
+    }
+}

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -171,6 +171,7 @@ pub use tagged::{
 // ECC structures
 // //////////////////////////////////////////////////////
 mod ecc;
+pub use ecc::parameter_details::EccParameterDetails;
 pub use ecc::point::EccPoint;
 // //////////////////////////////////////////////////////
 // Signatures structures

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
@@ -106,3 +106,92 @@ mod test_rsa_encrypt_decrypt {
         assert_eq!(z_point.x().as_bytes(), param.x().as_bytes());
     }
 }
+
+mod test_zgen_2phase {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        attributes::ObjectAttributesBuilder,
+        interface_types::{
+            algorithm::{EccKeyExchangeAlgorithm, HashingAlgorithm, PublicAlgorithm},
+            ecc::EccCurve,
+            reserved_handles::Hierarchy,
+        },
+        structures::{
+            Auth, EccPoint, EccScheme, HashScheme, KeyDerivationFunctionScheme, PublicBuilder,
+            PublicEccParametersBuilder,
+        },
+    };
+
+    #[test]
+    fn test_zgen_2phase() {
+        let mut context = create_ctx_with_session();
+        let mut random_digest = vec![0u8; 16];
+        getrandom::getrandom(&mut random_digest).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
+
+        let ecc_parms = PublicEccParametersBuilder::new()
+            .with_ecc_scheme(EccScheme::EcDh(HashScheme::new(HashingAlgorithm::Sha256)))
+            .with_curve(EccCurve::NistP256)
+            .with_is_signing_key(false)
+            .with_is_decryption_key(true)
+            .with_restricted(false)
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .build()
+            .unwrap();
+
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .with_decrypt(true)
+            .with_sign_encrypt(false)
+            .with_restricted(false)
+            .build()
+            .unwrap();
+
+        let public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_ecc_parameters(ecc_parms)
+            .with_ecc_unique_identifier(EccPoint::default())
+            .build()
+            .unwrap();
+
+        let key_handle = context
+            .create_primary(Hierarchy::Owner, public, Some(key_auth), None, None, None)
+            .unwrap()
+            .key_handle;
+
+        // Get ephemeral key and counter
+        let (q_point, counter) = context.ec_ephemeral(EccCurve::NistP256).unwrap();
+
+        // Generate another ephemeral via ecdh_key_gen
+        let (_z_point, pub_point) = context.ecdh_key_gen(key_handle).unwrap();
+
+        // Perform two-phase key exchange
+        let (_out_z1, _out_z2) = context
+            .zgen_2phase(
+                key_handle,
+                pub_point,
+                q_point,
+                EccKeyExchangeAlgorithm::EcDh,
+                counter,
+            )
+            .unwrap();
+    }
+}
+
+mod test_ecc_parameters {
+    use crate::common::create_ctx_without_session;
+    use tss_esapi::interface_types::ecc::EccCurve;
+
+    #[test]
+    fn test_ecc_parameters() {
+        let mut context = create_ctx_without_session();
+        let details = context.ecc_parameters(EccCurve::NistP256).unwrap();
+        assert_eq!(details.curve_id(), EccCurve::NistP256);
+        assert!(details.key_size() > 0);
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/attestation_commands_tests.rs
@@ -265,3 +265,140 @@ mod test_quote {
         assert!(matches!(attest.attested(), AttestInfo::Creation { .. }));
     }
 }
+
+mod test_get_session_audit_digest {
+    use crate::common::create_ctx_with_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        attributes::SessionAttributesBuilder,
+        constants::SessionType,
+        handles::{ObjectHandle, SessionHandle},
+        interface_types::{
+            algorithm::{HashingAlgorithm, RsaSchemeAlgorithm},
+            key_bits::RsaKeyBits,
+            reserved_handles::Hierarchy,
+            session_handles::AuthSession,
+        },
+        structures::{Data, RsaExponent, RsaScheme, SignatureScheme, SymmetricDefinition},
+        utils::create_unrestricted_signing_rsa_public,
+    };
+
+    #[test]
+    fn test_get_session_audit_digest() {
+        let mut context = create_ctx_with_session();
+        let signing_key_pub = create_unrestricted_signing_rsa_public(
+            RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
+                .expect("Failed to create RSA scheme"),
+            RsaKeyBits::Rsa2048,
+            RsaExponent::default(),
+        )
+        .expect("Failed to create signing rsa public structure");
+        let sign_key_handle = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.create_primary(Hierarchy::Owner, signing_key_pub, None, None, None, None)
+            })
+            .unwrap()
+            .key_handle;
+
+        // Create an audit session with the audit attribute set
+        let audit_session = context
+            .execute_without_session(|ctx| {
+                ctx.start_auth_session(
+                    None,
+                    None,
+                    None,
+                    SessionType::Hmac,
+                    SymmetricDefinition::AES_256_CFB,
+                    HashingAlgorithm::Sha256,
+                )
+            })
+            .expect("Failed to create audit session")
+            .expect("Received invalid handle");
+
+        let (session_attributes, session_attributes_mask) =
+            SessionAttributesBuilder::new().with_audit(true).build();
+        context
+            .tr_sess_set_attributes(audit_session, session_attributes, session_attributes_mask)
+            .expect("Failed to set audit attribute on session");
+
+        let session_handle = SessionHandle::from(audit_session);
+
+        let (_attest, _signature) = context
+            .execute_with_sessions(
+                (
+                    Some(AuthSession::Password),
+                    Some(AuthSession::Password),
+                    None,
+                ),
+                |ctx| {
+                    ctx.get_session_audit_digest(
+                        ObjectHandle::Endorsement,
+                        sign_key_handle,
+                        session_handle,
+                        Data::try_from(vec![0xff; 16]).unwrap(),
+                        SignatureScheme::Null,
+                    )
+                },
+            )
+            .expect("Failed to get session audit digest");
+    }
+}
+
+mod test_certify_x509 {
+    #[test]
+    #[ignore]
+    fn test_certify_x509() {
+        // CertifyX509 requires specific X.509 partial certificate input
+        // and may not be supported by all TPM simulators.
+    }
+}
+
+mod test_get_command_audit_digest {
+    use crate::common::create_ctx_with_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        interface_types::{
+            algorithm::{HashingAlgorithm, RsaSchemeAlgorithm},
+            key_bits::RsaKeyBits,
+            reserved_handles::Hierarchy,
+            session_handles::AuthSession,
+        },
+        structures::{Data, RsaExponent, RsaScheme, SignatureScheme},
+        utils::create_unrestricted_signing_rsa_public,
+    };
+
+    #[test]
+    fn test_get_command_audit_digest() {
+        let mut context = create_ctx_with_session();
+        let signing_key_pub = create_unrestricted_signing_rsa_public(
+            RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
+                .expect("Failed to create RSA scheme"),
+            RsaKeyBits::Rsa2048,
+            RsaExponent::default(),
+        )
+        .expect("Failed to create an unrestricted signing rsa public structure");
+        let sign_key_handle = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.create_primary(Hierarchy::Owner, signing_key_pub, None, None, None, None)
+            })
+            .unwrap()
+            .key_handle;
+        let (_attest, _signature) = context
+            .execute_with_sessions(
+                (
+                    Some(AuthSession::Password),
+                    Some(AuthSession::Password),
+                    None,
+                ),
+                |ctx| {
+                    ctx.get_command_audit_digest(
+                        tss_esapi::handles::ObjectHandle::Endorsement,
+                        sign_key_handle,
+                        Data::try_from(vec![0xff; 16]).unwrap(),
+                        SignatureScheme::Null,
+                    )
+                },
+            )
+            .expect("Failed to get command audit digest");
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/authenticated_countdown_timer_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/authenticated_countdown_timer_tests.rs
@@ -1,2 +1,12 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_act_set_timeout {
+    // ACT (Authenticated Countdown Timer) is not universally supported.
+    // This test is marked as ignored since it requires TPM ACT support.
+    #[test]
+    #[ignore]
+    fn test_act_set_timeout() {
+        // ACT handles are vendor-specific and may not be available on all TPMs.
+        // This test is intentionally ignored as it requires specific hardware support.
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/clocks_and_timers_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/clocks_and_timers_tests.rs
@@ -1,2 +1,30 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_read_clock {
+    use crate::common::create_ctx_without_session;
+
+    #[test]
+    fn test_read_clock() {
+        let mut context = create_ctx_without_session();
+        let time_info = context.read_clock().unwrap();
+        assert!(time_info.time() > 0);
+    }
+}
+
+mod test_clock_set {
+    use crate::common::create_ctx_without_session;
+    use tss_esapi::{handles::AuthHandle, interface_types::session_handles::AuthSession};
+
+    #[test]
+    fn test_clock_set() {
+        let mut context = create_ctx_without_session();
+        let time_info = context.read_clock().unwrap();
+        // Advance the clock forward
+        let new_time = time_info.clock_info().clock() + 100_000;
+        context
+            .execute_with_session(Some(AuthSession::Password), |ctx| {
+                ctx.clock_set(AuthHandle::Owner, new_time)
+            })
+            .unwrap();
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/command_audit_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/command_audit_tests.rs
@@ -1,2 +1,22 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_set_command_code_audit_status {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        handles::AuthHandle, interface_types::algorithm::HashingAlgorithm,
+        structures::CommandCodeList,
+    };
+
+    #[test]
+    fn test_set_command_code_audit_status() {
+        let mut context = create_ctx_with_session();
+        context
+            .set_command_code_audit_status(
+                AuthHandle::Owner,
+                HashingAlgorithm::Sha256,
+                CommandCodeList::new(),
+                CommandCodeList::new(),
+            )
+            .unwrap();
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/dictionary_attack_functions_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/dictionary_attack_functions_tests.rs
@@ -1,2 +1,31 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_dictionary_attack_lock_reset {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::handles::AuthHandle;
+
+    #[test]
+    fn test_dictionary_attack_lock_reset() {
+        let mut context = create_ctx_with_session();
+        context
+            .dictionary_attack_lock_reset(AuthHandle::Lockout)
+            .unwrap();
+    }
+}
+
+mod test_dictionary_attack_parameters {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::handles::AuthHandle;
+
+    #[test]
+    fn test_dictionary_attack_parameters() {
+        let mut context = create_ctx_with_session();
+        context
+            .dictionary_attack_parameters(AuthHandle::Lockout, 10, 300, 300)
+            .unwrap();
+        // Restore defaults
+        context
+            .dictionary_attack_parameters(AuthHandle::Lockout, 0, 0, 0)
+            .unwrap();
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/duplication_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/duplication_commands_tests.rs
@@ -303,3 +303,280 @@ mod test_duplicate {
         eprintln!("P: {private:?}");
     }
 }
+
+mod test_rewrap {
+    use crate::common::{create_ctx_with_session, create_ctx_without_session};
+    use std::convert::TryFrom;
+    use std::convert::TryInto;
+    use tss_esapi::attributes::{ObjectAttributesBuilder, SessionAttributesBuilder};
+    use tss_esapi::constants::SessionType;
+    use tss_esapi::handles::ObjectHandle;
+    use tss_esapi::interface_types::{
+        algorithm::{HashingAlgorithm, PublicAlgorithm},
+        ecc::EccCurve,
+        reserved_handles::Hierarchy,
+        session_handles::PolicySession,
+    };
+    use tss_esapi::structures::SymmetricDefinition;
+    use tss_esapi::structures::{
+        EccPoint, EccScheme, KeyDerivationFunctionScheme, PublicBuilder,
+        PublicEccParametersBuilder, SymmetricDefinitionObject,
+    };
+
+    #[test]
+    fn test_rewrap() {
+        let mut context = create_ctx_with_session();
+
+        // Create parent key spec (storage key)
+        let parent_object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .with_decrypt(true)
+            .with_sign_encrypt(false)
+            .with_restricted(true)
+            .build()
+            .expect("Attributes to be valid");
+
+        let public_parent = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(parent_object_attributes)
+            .with_ecc_parameters(
+                PublicEccParametersBuilder::new()
+                    .with_ecc_scheme(EccScheme::Null)
+                    .with_curve(EccCurve::NistP256)
+                    .with_is_signing_key(false)
+                    .with_is_decryption_key(true)
+                    .with_restricted(true)
+                    .with_symmetric(SymmetricDefinitionObject::AES_128_CFB)
+                    .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+                    .build()
+                    .expect("Params to be valid"),
+            )
+            .with_ecc_unique_identifier(EccPoint::default())
+            .build()
+            .expect("public to be valid");
+
+        // Create old parent and new parent
+        let old_parent_handle: ObjectHandle = context
+            .create_primary(
+                Hierarchy::Owner,
+                public_parent.clone(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+            .key_handle
+            .into();
+
+        let new_parent_handle: ObjectHandle = context
+            .create_primary(
+                Hierarchy::Owner,
+                public_parent.clone(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+            .key_handle
+            .into();
+
+        let old_parent_name = context.read_public(old_parent_handle.into()).unwrap().1;
+
+        drop(context);
+
+        // Create trial session to get policy digest for duplication
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Trial,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .expect("Start auth session failed")
+            .expect("Start auth session returned a NONE handle");
+
+        let (attrs, mask) = SessionAttributesBuilder::new()
+            .with_decrypt(true)
+            .with_encrypt(true)
+            .build();
+        context
+            .tr_sess_set_attributes(trial_session, attrs, mask)
+            .expect("tr_sess_set_attributes call failed");
+
+        let policy_session = PolicySession::try_from(trial_session)
+            .expect("Failed to convert auth session into policy session");
+
+        // Allow duplication to old parent (we don't restrict the new parent for rewrap)
+        context
+            .policy_duplication_select(
+                policy_session,
+                Vec::<u8>::new().try_into().unwrap(),
+                old_parent_name,
+                false,
+            )
+            .expect("Policy duplication select");
+
+        let digest = context
+            .policy_get_digest(policy_session)
+            .expect("Could retrieve digest");
+
+        drop(context);
+        let mut context = create_ctx_with_session();
+
+        // Create child key eligible for duplication
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(false)
+            .with_fixed_parent(false)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .with_decrypt(true)
+            .with_sign_encrypt(true)
+            .with_restricted(false)
+            .build()
+            .expect("Attributes to be valid");
+
+        let public_child = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_auth_policy(digest)
+            .with_ecc_parameters(
+                PublicEccParametersBuilder::new()
+                    .with_ecc_scheme(EccScheme::Null)
+                    .with_curve(EccCurve::NistP256)
+                    .with_is_signing_key(false)
+                    .with_is_decryption_key(true)
+                    .with_restricted(false)
+                    .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+                    .build()
+                    .expect("Params to be valid"),
+            )
+            .with_ecc_unique_identifier(EccPoint::default())
+            .build()
+            .expect("public to be valid");
+
+        // Re-create old and new parents (same specs → same keys)
+        let old_parent_handle: ObjectHandle = context
+            .create_primary(
+                Hierarchy::Owner,
+                public_parent.clone(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+            .key_handle
+            .into();
+
+        let new_parent_handle: ObjectHandle = context
+            .create_primary(Hierarchy::Owner, public_parent, None, None, None, None)
+            .unwrap()
+            .key_handle
+            .into();
+
+        let result = context
+            .create(
+                old_parent_handle.into(),
+                public_child,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let object_to_duplicate: ObjectHandle = context
+            .load(
+                old_parent_handle.into(),
+                result.out_private,
+                result.out_public,
+            )
+            .unwrap()
+            .into();
+
+        let object_name = context.read_public(object_to_duplicate.into()).unwrap().1;
+        let old_parent_name = context.read_public(old_parent_handle.into()).unwrap().1;
+
+        context.set_sessions((None, None, None));
+
+        // Create real policy session for duplication
+        let policy_auth_session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Policy,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .expect("Start auth session failed")
+            .expect("Start auth session returned a NONE handle");
+        let (attrs, mask) = SessionAttributesBuilder::new()
+            .with_decrypt(true)
+            .with_encrypt(true)
+            .build();
+        context
+            .tr_sess_set_attributes(policy_auth_session, attrs, mask)
+            .expect("tr_sess_set_attributes call failed");
+
+        let policy_session = PolicySession::try_from(policy_auth_session)
+            .expect("Failed to convert auth session into policy session");
+        context
+            .policy_duplication_select(policy_session, object_name, old_parent_name, false)
+            .unwrap();
+        context.set_sessions((Some(policy_auth_session), None, None));
+
+        // Duplicate from old parent (NULL encryption)
+        let (_data, duplicate, secret) = context
+            .duplicate(
+                object_to_duplicate,
+                old_parent_handle,
+                None,
+                SymmetricDefinitionObject::Null,
+            )
+            .unwrap();
+
+        let name = context.read_public(object_to_duplicate.into()).unwrap().1;
+
+        // Set up HMAC session for rewrap
+        let session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Hmac,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .unwrap();
+        let (attrs, mask) = SessionAttributesBuilder::new()
+            .with_decrypt(true)
+            .with_encrypt(true)
+            .build();
+        context
+            .tr_sess_set_attributes(session.unwrap(), attrs, mask)
+            .unwrap();
+        context.set_sessions((session, None, None));
+
+        // Rewrap: move the duplicated object from old parent to new parent
+        let (_out_duplicate, _out_sym_seed) = context
+            .rewrap(
+                old_parent_handle,
+                new_parent_handle,
+                duplicate,
+                name,
+                secret,
+            )
+            .unwrap();
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -911,3 +911,226 @@ mod test_policy_authorize_nv {
         policy_result.unwrap();
     }
 }
+
+mod test_policy_counter_timer {
+    use crate::common::create_ctx_without_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        constants::SessionType,
+        interface_types::{
+            ArithmeticComparison, algorithm::HashingAlgorithm, session_handles::PolicySession,
+        },
+        structures::{Digest, SymmetricDefinition},
+    };
+
+    #[test]
+    fn test_policy_counter_timer() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Trial,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .expect("Failed to create trial session")
+            .expect("Received invalid handle");
+        let policy_session =
+            PolicySession::try_from(trial_session).expect("Failed to convert to policy session");
+
+        // Compare a zero operand at offset 0 (time field) with unsigned GE
+        let operand_b = Digest::try_from(vec![0u8; 8]).unwrap();
+        context
+            .policy_counter_timer(
+                policy_session,
+                operand_b,
+                0,
+                ArithmeticComparison::UnsignedGe,
+            )
+            .unwrap();
+    }
+}
+
+mod test_policy_nv {
+    use crate::common::create_ctx_with_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        attributes::NvIndexAttributesBuilder,
+        constants::SessionType,
+        handles::NvIndexTpmHandle,
+        interface_types::{
+            ArithmeticComparison,
+            algorithm::HashingAlgorithm,
+            reserved_handles::{NvAuth, Provision},
+            session_handles::PolicySession,
+        },
+        structures::{Digest, MaxNvBuffer, NvPublicBuilder, SymmetricDefinition},
+    };
+
+    #[test]
+    fn test_policy_nv() {
+        let mut context = create_ctx_with_session();
+
+        // Define an NV index
+        let nv_index =
+            NvIndexTpmHandle::new(0x01500040).expect("Failed to create NV index tpm handle");
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create nv index attributes");
+        let nv_public = NvPublicBuilder::new()
+            .with_nv_index(nv_index)
+            .with_index_name_algorithm(HashingAlgorithm::Sha256)
+            .with_index_attributes(nv_index_attributes)
+            .with_data_area_size(8)
+            .build()
+            .expect("Failed to build NvPublic");
+        let nv_index_handle = context
+            .nv_define_space(Provision::Owner, None, nv_public)
+            .expect("Failed to define NV space");
+
+        // Write some data to the NV index
+        let data = MaxNvBuffer::try_from(vec![0u8; 8]).unwrap();
+        context
+            .nv_write(NvAuth::Owner, nv_index_handle, data, 0)
+            .expect("Failed to write NV");
+
+        // Create a trial policy session
+        let trial_session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Trial,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .expect("Failed to create trial session")
+            .expect("Received invalid handle");
+        let policy_session =
+            PolicySession::try_from(trial_session).expect("Failed to convert to policy session");
+
+        // Call policy_nv with an EQ comparison against zeros
+        let operand = Digest::try_from(vec![0u8; 8]).unwrap();
+        context
+            .policy_nv(
+                policy_session,
+                NvAuth::Owner,
+                nv_index_handle,
+                operand,
+                0,
+                ArithmeticComparison::Eq,
+            )
+            .expect("Failed to call policy_nv");
+
+        // Cleanup
+        context
+            .nv_undefine_space(Provision::Owner, nv_index_handle)
+            .expect("Failed to undefine NV space");
+    }
+}
+
+mod test_policy_ticket {
+    use crate::common::create_ctx_with_session;
+    use std::{convert::TryFrom, time::Duration};
+    use tss_esapi::{
+        attributes::SessionAttributesBuilder,
+        constants::SessionType,
+        handles::AuthHandle,
+        interface_types::{algorithm::HashingAlgorithm, session_handles::PolicySession},
+        structures::{Digest, Nonce, SymmetricDefinition},
+    };
+
+    #[test]
+    fn test_policy_ticket() {
+        let mut context = create_ctx_with_session();
+
+        // Create a policy session with a nonce
+        let nonce = Nonce::try_from(vec![1u8; 16]).expect("Failed to create nonce");
+        let policy_auth_session = context
+            .execute_without_session(|ctx| {
+                ctx.start_auth_session(
+                    None,
+                    None,
+                    Some(nonce),
+                    SessionType::Policy,
+                    SymmetricDefinition::AES_256_CFB,
+                    HashingAlgorithm::Sha256,
+                )
+            })
+            .expect("Start auth session failed")
+            .expect("Start auth session returned a NONE handle");
+        let (attrs, mask) = SessionAttributesBuilder::new()
+            .with_decrypt(true)
+            .with_encrypt(true)
+            .build();
+        context
+            .tr_sess_set_attributes(policy_auth_session, attrs, mask)
+            .expect("tr_sess_set_attributes call failed");
+
+        let policy_session = PolicySession::try_from(policy_auth_session)
+            .expect("Failed to convert auth session into policy session");
+
+        // Get the session's nonceTPM to include in the policy_secret call
+        let nonce_tpm = context
+            .tr_sess_get_nonce_tpm(policy_auth_session)
+            .expect("Failed to get nonceTPM");
+        let cp_hash_a = Digest::default();
+        let policy_ref = Nonce::default();
+
+        // Use policy_secret with an expiration and the session nonce to get a ticket
+        let (timeout, ticket) = context
+            .policy_secret(
+                policy_session,
+                AuthHandle::Endorsement,
+                nonce_tpm,
+                cp_hash_a.clone(),
+                policy_ref.clone(),
+                Some(Duration::from_secs(3600)),
+            )
+            .expect("Failed to call policy_secret");
+
+        let auth_name = context
+            .tr_get_name(AuthHandle::Endorsement.into())
+            .expect("Failed to get endorsement name");
+
+        // Create a new policy session and use policy_ticket with the ticket
+        let policy_auth_session_2 = context
+            .execute_without_session(|ctx| {
+                ctx.start_auth_session(
+                    None,
+                    None,
+                    None,
+                    SessionType::Policy,
+                    SymmetricDefinition::AES_256_CFB,
+                    HashingAlgorithm::Sha256,
+                )
+            })
+            .expect("Start auth session failed")
+            .expect("Start auth session returned a NONE handle");
+        let (attrs, mask) = SessionAttributesBuilder::new()
+            .with_decrypt(true)
+            .with_encrypt(true)
+            .build();
+        context
+            .tr_sess_set_attributes(policy_auth_session_2, attrs, mask)
+            .expect("tr_sess_set_attributes call failed");
+
+        let policy_session_2 = PolicySession::try_from(policy_auth_session_2)
+            .expect("Failed to convert auth session into policy session");
+
+        context
+            .policy_ticket(
+                policy_session_2,
+                timeout,
+                cp_hash_a,
+                policy_ref,
+                auth_name,
+                ticket,
+            )
+            .expect("Failed to call policy_ticket");
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/ephemeral_ec_keys_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/ephemeral_ec_keys_tests.rs
@@ -1,2 +1,79 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_ec_ephemeral {
+    use crate::common::create_ctx_without_session;
+    use tss_esapi::interface_types::ecc::EccCurve;
+
+    #[test]
+    fn test_ec_ephemeral() {
+        let mut context = create_ctx_without_session();
+        let (q_point, counter) = context.ec_ephemeral(EccCurve::NistP256).unwrap();
+        assert!(q_point.x().len() > 0);
+        assert!(counter > 0);
+    }
+}
+
+mod test_commit {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        attributes::ObjectAttributesBuilder,
+        interface_types::{
+            algorithm::{HashingAlgorithm, PublicAlgorithm},
+            ecc::EccCurve,
+            reserved_handles::Hierarchy,
+        },
+        structures::{
+            Auth, EccPoint, EccScheme, KeyDerivationFunctionScheme, PublicBuilder,
+            PublicEccParametersBuilder,
+        },
+    };
+
+    #[test]
+    fn test_commit() {
+        let mut context = create_ctx_with_session();
+        let mut random_digest = vec![0u8; 16];
+        getrandom::getrandom(&mut random_digest).unwrap();
+        let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
+
+        let ecc_parms = PublicEccParametersBuilder::new()
+            .with_ecc_scheme(EccScheme::EcDaa(tss_esapi::structures::EcDaaScheme::new(
+                HashingAlgorithm::Sha256,
+                0,
+            )))
+            .with_curve(EccCurve::BnP256)
+            .with_is_signing_key(true)
+            .with_is_decryption_key(false)
+            .with_restricted(false)
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .build()
+            .unwrap();
+
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .with_decrypt(false)
+            .with_sign_encrypt(true)
+            .with_restricted(false)
+            .build()
+            .unwrap();
+
+        let public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_ecc_parameters(ecc_parms)
+            .with_ecc_unique_identifier(EccPoint::default())
+            .build()
+            .unwrap();
+
+        let key_handle = context
+            .create_primary(Hierarchy::Owner, public, Some(key_auth), None, None, None)
+            .unwrap()
+            .key_handle;
+
+        let (_k, _l, _e, counter) = context.commit(key_handle, None, None, None).unwrap();
+        assert!(counter > 0);
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/field_upgrade_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/field_upgrade_tests.rs
@@ -1,2 +1,28 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_field_upgrade_start {
+    #[test]
+    #[ignore]
+    fn test_field_upgrade_start() {
+        // FieldUpgradeStart requires vendor-specific firmware upgrade data
+        // and is not supported by standard TPM simulators.
+    }
+}
+
+mod test_field_upgrade_data {
+    #[test]
+    #[ignore]
+    fn test_field_upgrade_data() {
+        // FieldUpgradeData requires an active field upgrade sequence
+        // which is vendor-specific.
+    }
+}
+
+mod test_firmware_read {
+    #[test]
+    #[ignore]
+    fn test_firmware_read() {
+        // FirmwareRead is vendor-specific and may not be supported
+        // by standard TPM simulators.
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hash_hmac_event_sequences_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hash_hmac_event_sequences_tests.rs
@@ -155,3 +155,36 @@ mod test_hmac_sequence {
         let _ticket = ticket.expect("HashcheckTicket should be returned");
     }
 }
+
+mod test_event_sequence_complete {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        handles::PcrHandle,
+        interface_types::{algorithm::HashingAlgorithm, session_handles::AuthSession},
+        structures::MaxBuffer,
+    };
+
+    #[test]
+    fn test_event_sequence_complete() {
+        let mut context = create_ctx_with_session();
+
+        let handle = context
+            .hash_sequence_start(HashingAlgorithm::Null, None)
+            .unwrap();
+
+        let data = MaxBuffer::from_bytes(&[0x01, 0x02, 0x03, 0x04]).unwrap();
+        context.sequence_update(handle, data).unwrap();
+
+        let last_data = MaxBuffer::from_bytes(&[0x05, 0x06]).unwrap();
+        let _digest_values = context
+            .execute_with_sessions(
+                (
+                    Some(AuthSession::Password),
+                    Some(AuthSession::Password),
+                    None,
+                ),
+                |ctx| ctx.event_sequence_complete(PcrHandle::Pcr16, handle, last_data),
+            )
+            .unwrap();
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hierarchy_commands_tests.rs
@@ -126,3 +126,59 @@ mod test_change_auth {
             .unwrap();
     }
 }
+
+mod test_hierarchy_control {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{handles::AuthHandle, interface_types::reserved_handles::Hierarchy};
+
+    #[test]
+    fn test_hierarchy_control() {
+        let mut context = create_ctx_with_session();
+        // Enable endorsement hierarchy (no-op if already enabled, but tests the API)
+        context
+            .hierarchy_control(AuthHandle::Platform, Hierarchy::Endorsement.into(), true)
+            .unwrap();
+    }
+}
+
+mod test_change_pps {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::handles::AuthHandle;
+
+    #[test]
+    fn test_change_pps() {
+        let mut context = create_ctx_with_session();
+        context.change_pps(AuthHandle::Platform).unwrap();
+    }
+}
+
+mod test_change_eps {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::handles::AuthHandle;
+
+    #[test]
+    fn test_change_eps() {
+        let mut context = create_ctx_with_session();
+        context.change_eps(AuthHandle::Platform).unwrap();
+    }
+}
+
+mod test_set_primary_policy {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        handles::AuthHandle, interface_types::algorithm::HashingAlgorithm, structures::Digest,
+    };
+
+    #[test]
+    fn test_set_primary_policy() {
+        let mut context = create_ctx_with_session();
+        // Clear policy on platform hierarchy (empty digest with Null algorithm)
+        context
+            .set_primary_policy(
+                AuthHandle::Platform,
+                Digest::default(),
+                HashingAlgorithm::Null,
+            )
+            .unwrap();
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/integrity_collection_pcr_tests.rs
@@ -265,3 +265,78 @@ mod test_pcr_read {
         assert_ne!(pcr_selection_list_in, pcr_selection_list_out);
     }
 }
+
+mod test_pcr_event {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{handles::PcrHandle, structures::MaxBuffer};
+
+    #[test]
+    fn test_pcr_event() {
+        let mut context = create_ctx_with_session();
+        let data = MaxBuffer::from_bytes(&[0x01, 0x02, 0x03, 0x04]).unwrap();
+        context.pcr_event(PcrHandle::Pcr16, data).unwrap();
+    }
+}
+
+mod test_pcr_allocate {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        handles::AuthHandle,
+        interface_types::algorithm::HashingAlgorithm,
+        structures::{PcrSelectionListBuilder, PcrSlot},
+    };
+
+    #[test]
+    fn test_pcr_allocate() {
+        let mut context = create_ctx_with_session();
+        let pcr_allocation = PcrSelectionListBuilder::new()
+            .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot0, PcrSlot::Slot1])
+            .build()
+            .unwrap();
+        let (success, _max_pcr, _size_needed, _size_available) = context
+            .pcr_allocate(AuthHandle::Platform, pcr_allocation)
+            .unwrap();
+        assert!(success);
+    }
+}
+
+mod test_pcr_set_auth_policy {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        handles::{AuthHandle, PcrHandle},
+        interface_types::algorithm::HashingAlgorithm,
+        structures::Digest,
+    };
+
+    #[test]
+    fn test_pcr_set_auth_policy() {
+        let mut context = create_ctx_with_session();
+        // Clear policy on PCR 16 (empty digest with Null algorithm)
+        context
+            .pcr_set_auth_policy(
+                AuthHandle::Platform,
+                Digest::default(),
+                HashingAlgorithm::Null,
+                PcrHandle::Pcr16,
+            )
+            .unwrap();
+    }
+}
+
+mod test_pcr_set_auth_value {
+    use crate::common::create_ctx_without_session;
+    use tss_esapi::{
+        handles::PcrHandle, interface_types::session_handles::AuthSession, structures::Auth,
+    };
+
+    #[test]
+    fn test_pcr_set_auth_value() {
+        let mut context = create_ctx_without_session();
+        let auth = Auth::default();
+        context
+            .execute_with_session(Some(AuthSession::Password), |ctx| {
+                ctx.pcr_set_auth_value(PcrHandle::Pcr16, auth)
+            })
+            .unwrap();
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/miscellaneous_management_functions_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/miscellaneous_management_functions_tests.rs
@@ -1,2 +1,33 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_pp_commands {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{handles::AuthHandle, structures::CommandCodeList};
+
+    #[test]
+    #[ignore = "Platform-specific command"]
+    fn test_pp_commands() {
+        let mut context = create_ctx_with_session();
+        context
+            .pp_commands(
+                AuthHandle::Platform,
+                CommandCodeList::new(),
+                CommandCodeList::new(),
+            )
+            .unwrap();
+    }
+}
+
+mod test_set_algorithm_set {
+    // SetAlgorithmSet is a platform-specific command that may not be
+    // supported on all TPMs or simulators.
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::handles::AuthHandle;
+
+    #[test]
+    #[ignore = "Platform-specific command"]
+    fn test_set_algorithm_set() {
+        let mut context = create_ctx_with_session();
+        context.set_algorithm_set(AuthHandle::Platform, 0).unwrap();
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/non_volatile_storage_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/non_volatile_storage_tests.rs
@@ -543,3 +543,272 @@ mod test_nv_extend {
             .expect("Call to nv_undefine_space failed");
     }
 }
+
+mod test_nv_set_bits {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        attributes::NvIndexAttributesBuilder,
+        constants::nv_index_type::NvIndexType,
+        handles::NvIndexTpmHandle,
+        interface_types::{
+            algorithm::HashingAlgorithm,
+            reserved_handles::{NvAuth, Provision},
+        },
+        structures::NvPublicBuilder,
+    };
+
+    #[test]
+    fn test_nv_set_bits() {
+        let mut context = create_ctx_with_session();
+        let nv_index =
+            NvIndexTpmHandle::new(0x01500030).expect("Failed to create NV index tpm handle");
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .with_nv_index_type(NvIndexType::Bits)
+            .build()
+            .expect("Failed to create nv index attributes");
+        let nv_public = NvPublicBuilder::new()
+            .with_nv_index(nv_index)
+            .with_index_name_algorithm(HashingAlgorithm::Sha256)
+            .with_index_attributes(nv_index_attributes)
+            .with_data_area_size(8)
+            .build()
+            .expect("Failed to build NvPublic");
+        let nv_index_handle = context
+            .nv_define_space(Provision::Owner, None, nv_public)
+            .expect("Failed to define NV space");
+        context
+            .nv_set_bits(NvAuth::Owner, nv_index_handle, 0x01)
+            .expect("Failed to set NV bits");
+        context
+            .nv_undefine_space(Provision::Owner, nv_index_handle)
+            .expect("Failed to undefine NV space");
+    }
+}
+
+mod test_nv_write_lock {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        attributes::NvIndexAttributesBuilder,
+        handles::NvIndexTpmHandle,
+        interface_types::{
+            algorithm::HashingAlgorithm,
+            reserved_handles::{NvAuth, Provision},
+        },
+        structures::NvPublicBuilder,
+    };
+
+    #[test]
+    fn test_nv_write_lock() {
+        let mut context = create_ctx_with_session();
+        let nv_index =
+            NvIndexTpmHandle::new(0x01500031).expect("Failed to create NV index tpm handle");
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .with_write_stclear(true)
+            .build()
+            .expect("Failed to create nv index attributes");
+        let nv_public = NvPublicBuilder::new()
+            .with_nv_index(nv_index)
+            .with_index_name_algorithm(HashingAlgorithm::Sha256)
+            .with_index_attributes(nv_index_attributes)
+            .with_data_area_size(32)
+            .build()
+            .expect("Failed to build NvPublic");
+        let nv_index_handle = context
+            .nv_define_space(Provision::Owner, None, nv_public)
+            .expect("Failed to define NV space");
+        context
+            .nv_write_lock(NvAuth::Owner, nv_index_handle)
+            .expect("Failed to write-lock NV index");
+        context
+            .nv_undefine_space(Provision::Owner, nv_index_handle)
+            .expect("Failed to undefine NV space");
+    }
+}
+
+mod test_nv_read_lock {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        attributes::NvIndexAttributesBuilder,
+        handles::NvIndexTpmHandle,
+        interface_types::{
+            algorithm::HashingAlgorithm,
+            reserved_handles::{NvAuth, Provision},
+        },
+        structures::NvPublicBuilder,
+    };
+
+    #[test]
+    fn test_nv_read_lock() {
+        let mut context = create_ctx_with_session();
+        let nv_index =
+            NvIndexTpmHandle::new(0x01500032).expect("Failed to create NV index tpm handle");
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .with_read_stclear(true)
+            .build()
+            .expect("Failed to create nv index attributes");
+        let nv_public = NvPublicBuilder::new()
+            .with_nv_index(nv_index)
+            .with_index_name_algorithm(HashingAlgorithm::Sha256)
+            .with_index_attributes(nv_index_attributes)
+            .with_data_area_size(32)
+            .build()
+            .expect("Failed to build NvPublic");
+        let nv_index_handle = context
+            .nv_define_space(Provision::Owner, None, nv_public)
+            .expect("Failed to define NV space");
+        context
+            .nv_read_lock(NvAuth::Owner, nv_index_handle)
+            .expect("Failed to read-lock NV index");
+        context
+            .nv_undefine_space(Provision::Owner, nv_index_handle)
+            .expect("Failed to undefine NV space");
+    }
+}
+
+mod test_nv_change_auth {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        attributes::NvIndexAttributesBuilder,
+        handles::NvIndexTpmHandle,
+        interface_types::{algorithm::HashingAlgorithm, reserved_handles::Provision},
+        structures::{Auth, NvPublicBuilder},
+    };
+
+    #[test]
+    fn test_nv_change_auth() {
+        let mut context = create_ctx_with_session();
+        let nv_index =
+            NvIndexTpmHandle::new(0x01500033).expect("Failed to create NV index tpm handle");
+        // NV_ChangeAuth requires auth_write and auth_read on the NV index
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_auth_write(true)
+            .with_auth_read(true)
+            .build()
+            .expect("Failed to create nv index attributes");
+        let initial_auth = Auth::from_bytes(&[5, 6, 7, 8]).unwrap();
+        let nv_public = NvPublicBuilder::new()
+            .with_nv_index(nv_index)
+            .with_index_name_algorithm(HashingAlgorithm::Sha256)
+            .with_index_attributes(nv_index_attributes)
+            .with_data_area_size(32)
+            .build()
+            .expect("Failed to build NvPublic");
+        let nv_index_handle = context
+            .nv_define_space(Provision::Owner, Some(initial_auth), nv_public)
+            .expect("Failed to define NV space");
+        let new_auth = Auth::from_bytes(&[1, 2, 3, 4]).unwrap();
+        context
+            .nv_change_auth(nv_index_handle, new_auth)
+            .expect("Failed to change NV auth");
+        context
+            .nv_undefine_space(Provision::Owner, nv_index_handle)
+            .expect("Failed to undefine NV space");
+    }
+}
+
+mod test_nv_global_write_lock {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::handles::AuthHandle;
+
+    #[test]
+    fn test_nv_global_write_lock() {
+        let mut context = create_ctx_with_session();
+        context
+            .nv_global_write_lock(AuthHandle::Owner)
+            .expect("Failed to global write-lock NV");
+    }
+}
+
+mod test_nv_certify {
+    use crate::common::create_ctx_with_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        attributes::NvIndexAttributesBuilder,
+        handles::NvIndexTpmHandle,
+        interface_types::{
+            algorithm::{HashingAlgorithm, RsaSchemeAlgorithm},
+            key_bits::RsaKeyBits,
+            reserved_handles::{Hierarchy, NvAuth, Provision},
+            session_handles::AuthSession,
+        },
+        structures::{Data, MaxNvBuffer, NvPublicBuilder, RsaExponent, RsaScheme, SignatureScheme},
+        utils::create_unrestricted_signing_rsa_public,
+    };
+
+    #[test]
+    fn test_nv_certify() {
+        let mut context = create_ctx_with_session();
+
+        // Create a signing key
+        let signing_key_pub = create_unrestricted_signing_rsa_public(
+            RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
+                .expect("Failed to create RSA scheme"),
+            RsaKeyBits::Rsa2048,
+            RsaExponent::default(),
+        )
+        .expect("Failed to create signing rsa public structure");
+        let sign_key_handle = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.create_primary(Hierarchy::Owner, signing_key_pub, None, None, None, None)
+            })
+            .unwrap()
+            .key_handle;
+
+        // Define an NV index and write data
+        let nv_index =
+            NvIndexTpmHandle::new(0x01500050).expect("Failed to create NV index tpm handle");
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create nv index attributes");
+        let nv_public = NvPublicBuilder::new()
+            .with_nv_index(nv_index)
+            .with_index_name_algorithm(HashingAlgorithm::Sha256)
+            .with_index_attributes(nv_index_attributes)
+            .with_data_area_size(32)
+            .build()
+            .expect("Failed to build NvPublic");
+        let nv_index_handle = context
+            .nv_define_space(Provision::Owner, None, nv_public)
+            .expect("Failed to define NV space");
+
+        let data = MaxNvBuffer::try_from(vec![1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+        context
+            .nv_write(NvAuth::Owner, nv_index_handle, data, 0)
+            .expect("Failed to write NV");
+
+        // Certify the NV index
+        let (_attest, _signature) = context
+            .execute_with_sessions(
+                (
+                    Some(AuthSession::Password),
+                    Some(AuthSession::Password),
+                    None,
+                ),
+                |ctx| {
+                    ctx.nv_certify(
+                        sign_key_handle,
+                        NvAuth::Owner,
+                        nv_index_handle,
+                        Data::try_from(vec![0xff; 16]).unwrap(),
+                        SignatureScheme::Null,
+                        8,
+                        0,
+                    )
+                },
+            )
+            .expect("Failed to certify NV");
+
+        // Cleanup
+        context
+            .nv_undefine_space(Provision::Owner, nv_index_handle)
+            .expect("Failed to undefine NV space");
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/testing_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/testing_tests.rs
@@ -20,3 +20,13 @@ mod test_get_test_result {
         rc.unwrap();
     }
 }
+
+mod test_incremental_self_test {
+    use crate::common::create_ctx_without_session;
+
+    #[test]
+    fn test_incremental_self_test() {
+        let mut context = create_ctx_without_session();
+        let _to_do_list = context.incremental_self_test(&[]).unwrap();
+    }
+}


### PR DESCRIPTION
This PR adds Rust wrappers for missing `Esys_*` functions across `tpm_commands`, and also adds `NvDigest` attestation support.

### Implemented wrappers (38 functions)

**Reference:** [TCG TSS 2.0 ESAPI Specification (Ver. 1.00, Rev.14)](https://trustedcomputinggroup.org/wp-content/uploads/TSS_ESAPI_v1p0_r14_pub10012021.pdf)

| Module | Functions | ESAPI Spec Section |
| ------ | --------- | ------------------ |
| `ephemeral_ec_keys` | `commit`, `ec_ephemeral` | 11.3.46, 11.3.47 |
| `asymmetric_primitives` | `ecc_parameters`, `zgen_2phase` | 11.3.24, 11.3.25 |
| `attestation_commands` | `get_session_audit_digest`, `get_command_audit_digest`, `certify_x509` | 11.3.43, 11.3.44, 11.3.41 |
| `authenticated_countdown_timer` | `act_set_timeout` | 11.3.116 |
| `clocks_and_timers` | `read_clock`, `clock_set` | 11.3.97, 11.3.98 |
| `command_audit` | `set_command_code_audit_status` | 11.3.50 |
| `dictionary_attack_functions` | `dictionary_attack_lock_reset`, `dictionary_attack_parameters` | 11.3.86, 11.3.87 |
| `duplication_commands` | `rewrap` | 11.3.18 |
| `enhanced_authorization_ea_commands` | `policy_ticket`, `policy_nv`, `policy_counter_timer` | 11.3.60, 11.3.64, 11.3.65 |
| `field_upgrade` | `field_upgrade_start`, `field_upgrade_data`, `firmware_read` | 11.3.90, 11.3.91, 11.3.92 |
| `hash_hmac_event_sequences` | `event_sequence_complete` | 11.3.38 |
| `hierarchy_commands` | `hierarchy_control`, `set_primary_policy`, `change_pps`, `change_eps` | 11.3.79, 11.3.80, 11.3.81, 11.3.82 |
| `integrity_collection_pcr` | `pcr_event`, `pcr_allocate`, `pcr_set_auth_policy`, `pcr_set_auth_value` | 11.3.52, 11.3.54, 11.3.55, 11.3.56 |
| `miscellaneous_management_functions` | `pp_commands`, `set_algorithm_set` | 11.3.88, 11.3.89 |
| `non_volatile_storage` | `nv_set_bits`, `nv_write_lock`, `nv_global_write_lock`, `nv_read_lock`, `nv_change_auth`, `nv_certify` | 11.3.109, 11.3.110, 11.3.111, 11.3.113, 11.3.114, 11.3.115 |
| `testing` | `incremental_self_test` | 11.3.4 |

### `NvDigest` attestation support

- Added `TryFrom<TPMS_NV_DIGEST_CERTIFY_INFO>` and `From<NvDigestCertifyInfo>` conversions in `nv_digest_certify_info.rs`
- Added `AttestInfo::NvDigest` variant in `attest_info.rs`
- `Attest::try_from` now deserializes `NvDigest` instead of returning `UnsupportedParam`

Since `TPMU_ATTEST` in the upstream `tpm2-tss` does not include a `nvDigest` union field, the current implementation uses a pointer cast to reinterpret the union memory. This is safe because `TPMS_NV_DIGEST_CERTIFY_INFO` is smaller than `TPMS_NV_CERTIFY_INFO` and shares the same union offset.

**Note:** The upstream C library does not handle `TPM2_ST_ATTEST_NV_DIGEST` (`0x801c`) in `Tss2_MU_TPMU_ATTEST_Unmarshal`, so `Esys_NV_Certify` will fail at the marshalling layer when a TPM returns this attestation type. A fix has been submitted upstream (tpm2-software/tpm2-tss#3071). Once merged and the bindings regenerated, the pointer casts can be replaced with direct union field access.

**Reference:** [TPM 2.0 Library Part 2: Structures (Ver. 184)](https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-2-Version-184_pub.pdf)

### Not yet implemented (missing Rust wrapper types)

The following functions remain unimplemented because they require FFI types that do not yet have Rust wrappers in this crate:

- `ClockRateAdjust` — needs `TPM2_CLOCK_ADJUST`
- `MAC`, `MAC_Start` — need `TPMI_ALG_MAC_SCHEME`
- `CreateLoaded` — needs `TPM2B_TEMPLATE` + marshalling
- `AC_GetCapability`, `AC_Send`, `Policy_AC_SendSelect` — need `TPM_AT`, `TPML_AC_CAPABILITIES`, `TPMS_AC_OUTPUT`

## TODO

- [x] Add missing interface types / structures
- [x] Fix return types
- [x] Add integration tests
- [x] Add code examples
- [ ] Separate PR
  - [x] `ephemeral_ec_keys`
  - [x] `asymmetric_primitives`
  - [x] `attestation_commands`
  - [x] `authenticated_countdown_timer`
  - [x] `clocks_and_timers`
  - [x] `command_audit`
  - [x] `dictionary_attack_functions`
  - [x] `duplication_commands`
  - [x] `enhanced_authorization_ea_commands`
  - [x] `field_upgrade`
  - [x] `hash_hmac_event_sequences`
  - [x] `hierarchy_commands`
  - [x] `integrity_collection_pcr`
  - [x] `miscellaneous_management_functions`
  - [x] `non_volatile_storage`
  - [x] `testing`
  - [x] `NVDigest` attestation support