### PR TITLE
chore(esapi): fix doc link in context/tpm_commands/testing.rs

### DIFF
--- a/tss-esapi/src/context/tpm_commands/testing.rs
+++ b/tss-esapi/src/context/tpm_commands/testing.rs
@@ -40,7 +40,7 @@ impl Context {
     /// test went in the form a [Result].
     ///
     /// If testing of all functions is complete without functional failures then Ok(())
-    /// or else a `TssError` (see [Error](crate::error::Error)) is returned.
+    /// or else a `TssError` (see [Error](crate::Error)) is returned.
     ///
     /// - A [TpmFormatZeroWarningResponseCode](crate::error::TpmFormatZeroWarningResponseCode) with a `Testing`
     ///   [TpmFormatZeroWarning](crate::constants::return_code::TpmFormatZeroWarning) indicates that the test


### PR DESCRIPTION
This PR fixes a `rustdoc::redundant-explicit-links` error in CI caused by `context/tpm_commands/testing.rs`.