### PR TITLE
ESAPI: Add missing interface types and structures: EccKeyExchangeAlgorithm, EccParameterDetails, ArithmeticComparison

### DIFF
--- a/tss-esapi/src/interface_types/algorithm.rs
+++ b/tss-esapi/src/interface_types/algorithm.rs
@@ -6,9 +6,10 @@ use crate::{
     tss2_esys::{
         TPMI_ALG_ASYM, TPMI_ALG_ECC_SCHEME, TPMI_ALG_HASH, TPMI_ALG_KDF, TPMI_ALG_KEYEDHASH_SCHEME,
         TPMI_ALG_PUBLIC, TPMI_ALG_RSA_DECRYPT, TPMI_ALG_RSA_SCHEME, TPMI_ALG_SIG_SCHEME,
-        TPMI_ALG_SYM, TPMI_ALG_SYM_MODE, TPMI_ALG_SYM_OBJECT,
+        TPMI_ALG_SYM, TPMI_ALG_SYM_MODE, TPMI_ALG_SYM_OBJECT, TPMI_ECC_KEY_EXCHANGE,
     },
 };
+use log::error;
 use std::convert::TryFrom;
 /// Enum containing the supported hash algorithms
 ///
@@ -682,5 +683,62 @@ impl TryFrom<TPMI_ALG_RSA_DECRYPT> for RsaDecryptAlgorithm {
 
     fn try_from(tpmi_alg_rsa_decrypt: TPMI_ALG_RSA_DECRYPT) -> Result<Self> {
         RsaDecryptAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_alg_rsa_decrypt)?)
+    }
+}
+
+/// Enum representing the ECC key exchange interface type.
+///
+/// # Details
+/// This corresponds to `TPMI_ECC_KEY_EXCHANGE`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum EccKeyExchangeAlgorithm {
+    EcDh,
+    EcMqv,
+    Sm2,
+    Null,
+}
+
+impl From<EccKeyExchangeAlgorithm> for AlgorithmIdentifier {
+    fn from(ecc_key_exchange_algorithm: EccKeyExchangeAlgorithm) -> Self {
+        match ecc_key_exchange_algorithm {
+            EccKeyExchangeAlgorithm::EcDh => AlgorithmIdentifier::EcDh,
+            EccKeyExchangeAlgorithm::EcMqv => AlgorithmIdentifier::EcMqv,
+            EccKeyExchangeAlgorithm::Sm2 => AlgorithmIdentifier::Sm2,
+            EccKeyExchangeAlgorithm::Null => AlgorithmIdentifier::Null,
+        }
+    }
+}
+
+impl TryFrom<AlgorithmIdentifier> for EccKeyExchangeAlgorithm {
+    type Error = Error;
+
+    fn try_from(algorithm_identifier: AlgorithmIdentifier) -> Result<Self> {
+        match algorithm_identifier {
+            AlgorithmIdentifier::EcDh => Ok(EccKeyExchangeAlgorithm::EcDh),
+            AlgorithmIdentifier::EcMqv => Ok(EccKeyExchangeAlgorithm::EcMqv),
+            AlgorithmIdentifier::Sm2 => Ok(EccKeyExchangeAlgorithm::Sm2),
+            AlgorithmIdentifier::Null => Ok(EccKeyExchangeAlgorithm::Null),
+            _ => {
+                error!(
+                    "Invalid AlgorithmIdentifier value: {:?}",
+                    algorithm_identifier
+                );
+                Err(Error::local_error(WrapperErrorKind::InvalidParam))
+            }
+        }
+    }
+}
+
+impl From<EccKeyExchangeAlgorithm> for TPMI_ECC_KEY_EXCHANGE {
+    fn from(ecc_key_exchange_algorithm: EccKeyExchangeAlgorithm) -> Self {
+        AlgorithmIdentifier::from(ecc_key_exchange_algorithm).into()
+    }
+}
+
+impl TryFrom<TPMI_ECC_KEY_EXCHANGE> for EccKeyExchangeAlgorithm {
+    type Error = Error;
+
+    fn try_from(tpmi_ecc_key_exchange: TPMI_ECC_KEY_EXCHANGE) -> Result<Self> {
+        EccKeyExchangeAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_ecc_key_exchange)?)
     }
 }

--- a/tss-esapi/src/interface_types/arithmetic_comparison.rs
+++ b/tss-esapi/src/interface_types/arithmetic_comparison.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    Error, Result, WrapperErrorKind,
+    constants::tss::{
+        TPM2_EO_BITCLEAR, TPM2_EO_BITSET, TPM2_EO_EQ, TPM2_EO_NEQ, TPM2_EO_SIGNED_GE,
+        TPM2_EO_SIGNED_GT, TPM2_EO_SIGNED_LE, TPM2_EO_SIGNED_LT, TPM2_EO_UNSIGNED_GE,
+        TPM2_EO_UNSIGNED_GT, TPM2_EO_UNSIGNED_LE, TPM2_EO_UNSIGNED_LT,
+    },
+    tss2_esys::TPM2_EO,
+};
+use log::error;
+use std::convert::TryFrom;
+
+/// Arithmetic comparison operation for policy evaluation.
+///
+/// # Details
+/// This corresponds to the `TPM2_EO` type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ArithmeticComparison {
+    /// A == B
+    Eq,
+    /// A != B
+    Neq,
+    /// A > B (signed)
+    SignedGt,
+    /// A > B (unsigned)
+    UnsignedGt,
+    /// A < B (signed)
+    SignedLt,
+    /// A < B (unsigned)
+    UnsignedLt,
+    /// A >= B (signed)
+    SignedGe,
+    /// A >= B (unsigned)
+    UnsignedGe,
+    /// A <= B (signed)
+    SignedLe,
+    /// A <= B (unsigned)
+    UnsignedLe,
+    /// All bits SET in B are SET in A
+    BitSet,
+    /// All bits SET in B are CLEAR in A
+    BitClear,
+}
+
+impl From<ArithmeticComparison> for TPM2_EO {
+    fn from(arithmetic_comparison: ArithmeticComparison) -> Self {
+        match arithmetic_comparison {
+            ArithmeticComparison::Eq => TPM2_EO_EQ,
+            ArithmeticComparison::Neq => TPM2_EO_NEQ,
+            ArithmeticComparison::SignedGt => TPM2_EO_SIGNED_GT,
+            ArithmeticComparison::UnsignedGt => TPM2_EO_UNSIGNED_GT,
+            ArithmeticComparison::SignedLt => TPM2_EO_SIGNED_LT,
+            ArithmeticComparison::UnsignedLt => TPM2_EO_UNSIGNED_LT,
+            ArithmeticComparison::SignedGe => TPM2_EO_SIGNED_GE,
+            ArithmeticComparison::UnsignedGe => TPM2_EO_UNSIGNED_GE,
+            ArithmeticComparison::SignedLe => TPM2_EO_SIGNED_LE,
+            ArithmeticComparison::UnsignedLe => TPM2_EO_UNSIGNED_LE,
+            ArithmeticComparison::BitSet => TPM2_EO_BITSET,
+            ArithmeticComparison::BitClear => TPM2_EO_BITCLEAR,
+        }
+    }
+}
+
+impl TryFrom<TPM2_EO> for ArithmeticComparison {
+    type Error = Error;
+
+    fn try_from(tpm2_eo: TPM2_EO) -> Result<Self> {
+        match tpm2_eo {
+            TPM2_EO_EQ => Ok(ArithmeticComparison::Eq),
+            TPM2_EO_NEQ => Ok(ArithmeticComparison::Neq),
+            TPM2_EO_SIGNED_GT => Ok(ArithmeticComparison::SignedGt),
+            TPM2_EO_UNSIGNED_GT => Ok(ArithmeticComparison::UnsignedGt),
+            TPM2_EO_SIGNED_LT => Ok(ArithmeticComparison::SignedLt),
+            TPM2_EO_UNSIGNED_LT => Ok(ArithmeticComparison::UnsignedLt),
+            TPM2_EO_SIGNED_GE => Ok(ArithmeticComparison::SignedGe),
+            TPM2_EO_UNSIGNED_GE => Ok(ArithmeticComparison::UnsignedGe),
+            TPM2_EO_SIGNED_LE => Ok(ArithmeticComparison::SignedLe),
+            TPM2_EO_UNSIGNED_LE => Ok(ArithmeticComparison::UnsignedLe),
+            TPM2_EO_BITSET => Ok(ArithmeticComparison::BitSet),
+            TPM2_EO_BITCLEAR => Ok(ArithmeticComparison::BitClear),
+            _ => {
+                error!("Invalid TPM2_EO value: {}", tpm2_eo);
+                Err(Error::local_error(WrapperErrorKind::InvalidParam))
+            }
+        }
+    }
+}

--- a/tss-esapi/src/interface_types/mod.rs
+++ b/tss-esapi/src/interface_types/mod.rs
@@ -3,6 +3,7 @@
 
 //! This module contains the different interface types defined in
 //! the TPM 2.0 specification.
+mod arithmetic_comparison;
 mod yes_no;
 
 pub mod algorithm;
@@ -13,4 +14,5 @@ pub mod reserved_handles;
 pub mod session_handles;
 pub mod structure_tags;
 
+pub use arithmetic_comparison::ArithmeticComparison;
 pub use yes_no::YesNo;

--- a/tss-esapi/src/structures/ecc/mod.rs
+++ b/tss-esapi/src/structures/ecc/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+pub mod parameter_details;
 pub mod point;

--- a/tss-esapi/src/structures/ecc/parameter_details.rs
+++ b/tss-esapi/src/structures/ecc/parameter_details.rs
@@ -1,0 +1,106 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    Error, Result,
+    interface_types::ecc::EccCurve,
+    structures::{EccParameter, EccScheme, KeyDerivationFunctionScheme},
+    tss2_esys::TPMS_ALGORITHM_DETAIL_ECC,
+};
+use std::convert::{TryFrom, TryInto};
+
+/// Detailed information about an ECC curve.
+///
+/// # Details
+/// This corresponds to `TPMS_ALGORITHM_DETAIL_ECC`.
+#[derive(Debug, Clone)]
+pub struct EccParameterDetails {
+    curve_id: EccCurve,
+    key_size: u16,
+    kdf: KeyDerivationFunctionScheme,
+    sign: EccScheme,
+    p: EccParameter,
+    a: EccParameter,
+    b: EccParameter,
+    g_x: EccParameter,
+    g_y: EccParameter,
+    n: EccParameter,
+    h: EccParameter,
+}
+
+impl EccParameterDetails {
+    /// Returns the curve ID.
+    pub const fn curve_id(&self) -> EccCurve {
+        self.curve_id
+    }
+
+    /// Returns the key size in bits.
+    pub const fn key_size(&self) -> u16 {
+        self.key_size
+    }
+
+    /// Returns the key derivation function scheme.
+    pub const fn kdf(&self) -> &KeyDerivationFunctionScheme {
+        &self.kdf
+    }
+
+    /// Returns the signing scheme.
+    pub const fn sign(&self) -> &EccScheme {
+        &self.sign
+    }
+
+    /// Returns the prime modulus p.
+    pub const fn p(&self) -> &EccParameter {
+        &self.p
+    }
+
+    /// Returns the curve coefficient a.
+    pub const fn a(&self) -> &EccParameter {
+        &self.a
+    }
+
+    /// Returns the curve coefficient b.
+    pub const fn b(&self) -> &EccParameter {
+        &self.b
+    }
+
+    /// Returns the x-coordinate of the base point G.
+    pub const fn g_x(&self) -> &EccParameter {
+        &self.g_x
+    }
+
+    /// Returns the y-coordinate of the base point G.
+    pub const fn g_y(&self) -> &EccParameter {
+        &self.g_y
+    }
+
+    /// Returns the order of the base point n.
+    pub const fn n(&self) -> &EccParameter {
+        &self.n
+    }
+
+    /// Returns the cofactor h.
+    pub const fn h(&self) -> &EccParameter {
+        &self.h
+    }
+}
+
+impl TryFrom<TPMS_ALGORITHM_DETAIL_ECC> for EccParameterDetails {
+    type Error = Error;
+
+    fn try_from(details: TPMS_ALGORITHM_DETAIL_ECC) -> Result<Self> {
+        Ok(EccParameterDetails {
+            curve_id: EccCurve::try_from(details.curveID)?,
+            key_size: details.keySize,
+            kdf: details.kdf.try_into()?,
+            sign: details.sign.try_into()?,
+            p: details.p.try_into()?,
+            a: details.a.try_into()?,
+            b: details.b.try_into()?,
+            g_x: details.gX.try_into()?,
+            g_y: details.gY.try_into()?,
+            n: details.n.try_into()?,
+            h: details.h.try_into()?,
+        })
+    }
+}

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -171,6 +171,7 @@ pub use tagged::{
 // ECC structures
 // //////////////////////////////////////////////////////
 mod ecc;
+pub use ecc::parameter_details::EccParameterDetails;
 pub use ecc::point::EccPoint;
 // //////////////////////////////////////////////////////
 // Signatures structures


### PR DESCRIPTION
This pull request introduces the following interface types and structures:

- `EccKeyExchangeAlgorithm` == `TPMI_ECC_KEY_EXCHANGE`
- `EccParameterDetails` == `TPMS_ALGORITHM_DETAIL_ECC`
- `ArithmeticComparison` == `TPM2_EO_*`

This was extracted from PR #625 as a preliminary step toward implementing the missing wrapper functions in `tpm_commands`.