### PR TITLE
feat(esapi): add missing TPM commands related to ECC

### DIFF
--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -3,9 +3,13 @@
 use crate::{
     Context, Result, ReturnCode,
     handles::KeyHandle,
+    interface_types::{algorithm::EccKeyExchangeAlgorithm, ecc::EccCurve},
     structures::Data,
-    structures::{EccPoint, PublicKeyRsa, RsaDecryptionScheme},
-    tss2_esys::{Esys_ECDH_KeyGen, Esys_ECDH_ZGen, Esys_RSA_Decrypt, Esys_RSA_Encrypt},
+    structures::{EccParameterDetails, EccPoint, PublicKeyRsa, RsaDecryptionScheme},
+    tss2_esys::{
+        Esys_ECC_Parameters, Esys_ECDH_KeyGen, Esys_ECDH_ZGen, Esys_RSA_Decrypt, Esys_RSA_Encrypt,
+        Esys_ZGen_2Phase,
+    },
 };
 use log::error;
 use std::ptr::null_mut;
@@ -603,6 +607,210 @@ impl Context {
         EccPoint::try_from(out_point.point)
     }
 
-    // Missing function: ECC_Parameters
-    // Missing function: ZGen_2Phase
+    /// Get the parameters of an ECC curve.
+    ///
+    /// # Arguments
+    ///
+    /// * `curve` - The [EccCurve] to query.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command returns the parameters of an ECC curve identified
+    /// > by its TCG-assigned curveID.
+    ///
+    /// # Returns
+    ///
+    /// An [EccParameterDetails] containing the curve parameters.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// use tss_esapi::interface_types::ecc::EccCurve;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// // Get the parameters of the elliptic curve
+    /// let details = context.ecc_parameters(EccCurve::NistP256).expect("Failed to get ECC parameters");
+    /// ```
+    pub fn ecc_parameters(&mut self, curve: EccCurve) -> Result<EccParameterDetails> {
+        let mut parameters_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ECC_Parameters(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    curve.into(),
+                    &mut parameters_ptr,
+                )
+            },
+            |ret| {
+                error!("Error when getting ECC parameters: {:#010X}", ret);
+            },
+        )?;
+        EccParameterDetails::try_from(Context::ffi_data_to_owned(parameters_ptr)?)
+    }
+
+    /// Perform a two-phase ECC key exchange.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_handle` - A [KeyHandle] of the ECC key (Party A).
+    /// * `in_qs_b` - The static public key of Party B as an [EccPoint].
+    /// * `in_qe_b` - The ephemeral public key of Party B as an [EccPoint].
+    /// * `in_scheme` - The key exchange protocol as an [EccKeyExchangeAlgorithm].
+    /// * `counter` - The commit counter from the TPM.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command supports two-phase key exchange protocols. The
+    /// > command is used in combination with TPM2_EC_Ephemeral().
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(EccPoint, EccPoint)` representing `(outZ1, outZ2)`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{
+    /// #    Context, TctiNameConf,
+    /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},
+    /// #    constants::SessionType,
+    /// #    interface_types::{
+    /// #        algorithm::{EccKeyExchangeAlgorithm, HashingAlgorithm, PublicAlgorithm},
+    /// #        ecc::EccCurve,
+    /// #        reserved_handles::Hierarchy,
+    /// #   },
+    /// #   structures::{
+    /// #       Auth, EccPoint, EccScheme, HashScheme, KeyDerivationFunctionScheme,
+    /// #       PublicBuilder, PublicEccParametersBuilder, SymmetricDefinition,
+    /// #    },
+    /// # };
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// #
+    /// # let session = context
+    /// #     .start_auth_session(
+    /// #         None,
+    /// #         None,
+    /// #         None,
+    /// #         SessionType::Hmac,
+    /// #         SymmetricDefinition::AES_256_CFB,
+    /// #         HashingAlgorithm::Sha256,
+    /// #     )
+    /// #     .expect("Failed to create session")
+    /// #     .expect("Received invalid handle");
+    /// # let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new()
+    /// #     .with_decrypt(true)
+    /// #     .with_encrypt(true)
+    /// #     .build();
+    /// # context.tr_sess_set_attributes(session, session_attributes, session_attributes_mask)
+    /// #     .expect("Failed to set attributes on session");
+    /// # context.set_sessions((Some(session), None, None));
+    /// # let mut random_digest = vec![0u8; 16];
+    /// # getrandom::getrandom(&mut random_digest).expect("Failed to get random bytes");
+    /// # let key_auth = Auth::from_bytes(random_digest.as_slice()).expect("Failed to create key auth");
+    /// #
+    /// # let ecc_parms = PublicEccParametersBuilder::new()
+    /// #     .with_ecc_scheme(EccScheme::EcDh(HashScheme::new(HashingAlgorithm::Sha256)))
+    /// #     .with_curve(EccCurve::NistP256)
+    /// #     .with_is_signing_key(false)
+    /// #     .with_is_decryption_key(true)
+    /// #     .with_restricted(false)
+    /// #     .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+    /// #     .build()
+    /// #     .expect("Failed to build ECC parameters");
+    /// #
+    /// # let object_attributes = ObjectAttributesBuilder::new()
+    /// #     .with_fixed_tpm(true)
+    /// #     .with_fixed_parent(true)
+    /// #     .with_sensitive_data_origin(true)
+    /// #     .with_user_with_auth(true)
+    /// #     .with_decrypt(true)
+    /// #     .with_sign_encrypt(false)
+    /// #     .with_restricted(false)
+    /// #     .build()
+    /// #     .expect("Failed to build object attributes");
+    /// #
+    /// # let public = PublicBuilder::new()
+    /// #     .with_public_algorithm(PublicAlgorithm::Ecc)
+    /// #     .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+    /// #     .with_object_attributes(object_attributes)
+    /// #     .with_ecc_parameters(ecc_parms)
+    /// #     .with_ecc_unique_identifier(EccPoint::default())
+    /// #     .build()
+    /// #     .expect("Failed to build public key");
+    /// #
+    /// # let key_handle = context
+    /// #     .create_primary(Hierarchy::Owner, public, Some(key_auth), None, None, None)
+    /// #     .expect("Failed to create primary key")
+    /// #     .key_handle;
+    /// #
+    /// // Get ephemeral key and counter
+    /// let (q_point, counter) = context
+    ///     .ec_ephemeral(EccCurve::NistP256)
+    ///     .expect("Failed to create EC ephemeral key");
+    ///
+    /// // Generate another ephemeral via ecdh_key_gen
+    /// let (_z_point, pub_point) = context
+    ///     .ecdh_key_gen(key_handle)
+    ///     .expect("Failed to generate ECDH key");
+    ///
+    /// // Perform two-phase key exchange
+    /// let (_out_z1, _out_z2) = context
+    ///     .zgen_2phase(
+    ///         key_handle,
+    ///         pub_point,
+    ///         q_point,
+    ///         EccKeyExchangeAlgorithm::EcDh,
+    ///         counter,
+    ///     )
+    ///     .expect("Failed to perform ZGen_2Phase");
+    /// ```
+    pub fn zgen_2phase(
+        &mut self,
+        key_handle: KeyHandle,
+        in_qs_b: EccPoint,
+        in_qe_b: EccPoint,
+        in_scheme: EccKeyExchangeAlgorithm,
+        counter: u16,
+    ) -> Result<(EccPoint, EccPoint)> {
+        let mut out_z1_ptr = null_mut();
+        let mut out_z2_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ZGen_2Phase(
+                    self.mut_context(),
+                    key_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &in_qs_b.into(),
+                    &in_qe_b.into(),
+                    in_scheme.into(),
+                    counter,
+                    &mut out_z1_ptr,
+                    &mut out_z2_ptr,
+                )
+            },
+            |ret| {
+                error!("Error in ZGen_2Phase: {:#010X}", ret);
+            },
+        )?;
+
+        let out_z1 = Context::ffi_data_to_owned(out_z1_ptr)?;
+        let out_z2 = Context::ffi_data_to_owned(out_z2_ptr)?;
+        Ok((
+            EccPoint::try_from(out_z1.point)?,
+            EccPoint::try_from(out_z2.point)?,
+        ))
+    }
 }

--- a/tss-esapi/src/context/tpm_commands/ephemeral_ec_keys.rs
+++ b/tss-esapi/src/context/tpm_commands/ephemeral_ec_keys.rs
@@ -1,8 +1,233 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode,
+    handles::KeyHandle,
+    interface_types::ecc::EccCurve,
+    structures::{EccParameter, EccPoint, SensitiveData},
+    tss2_esys::{Esys_Commit, Esys_EC_Ephemeral},
+};
+use log::error;
+use std::convert::TryFrom;
+use std::ptr::null;
+use std::ptr::null_mut;
 
 impl Context {
-    // Missing function: Commit
-    // Missing function: EC_Ephemeral
+    /// Perform an ECC commit to generate ephemeral key pair (K, L) and counter.
+    ///
+    /// # Arguments
+    ///
+    /// * `sign_handle` - A [KeyHandle] of the ECC key for which the commit is being generated.
+    /// * `p1` - An optional point on the curve used by `sign_handle`.
+    /// * `s2` - An optional octet array used in the commit computation.
+    /// * `y2` - An optional ECC parameter used in the commit computation.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > TPM2_Commit() performs the first part of an ECC anonymous signing operation. The TPM will
+    /// > perform the point multiplications on the provided points and return intermediate signing
+    /// > values.
+    ///
+    /// > The TPM shall return TPM_RC_ATTRIBUTES if the sign attribute is not SET in the key
+    /// > referenced by signHandle.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(K, L, E, counter)` where K, L, E are [EccPoint] values
+    /// and counter is a `u16` value to be used in the signing operation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{
+    /// #    Context, TctiNameConf,
+    /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},
+    /// #    constants::SessionType,
+    /// #    interface_types::{
+    /// #        algorithm::{HashingAlgorithm, PublicAlgorithm},
+    /// #        ecc::EccCurve,
+    /// #        reserved_handles::Hierarchy,
+    /// #   },
+    /// #   structures::{
+    /// #       Auth, EccPoint, EccScheme, KeyDerivationFunctionScheme,
+    /// #       PublicBuilder, PublicEccParametersBuilder, SymmetricDefinition,
+    /// #    },
+    /// # };
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// #
+    /// # let session = context
+    /// #     .start_auth_session(
+    /// #         None,
+    /// #         None,
+    /// #         None,
+    /// #         SessionType::Hmac,
+    /// #         SymmetricDefinition::AES_256_CFB,
+    /// #         HashingAlgorithm::Sha256,
+    /// #     )
+    /// #     .expect("Failed to create session")
+    /// #     .expect("Received invalid handle");
+    /// # let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new()
+    /// #     .with_decrypt(true)
+    /// #     .with_encrypt(true)
+    /// #     .build();
+    /// # context.tr_sess_set_attributes(session, session_attributes, session_attributes_mask)
+    /// #     .expect("Failed to set attributes on session");
+    /// # context.set_sessions((Some(session), None, None));
+    /// # let mut random_digest = vec![0u8; 16];
+    /// # getrandom::getrandom(&mut random_digest).expect("Failed to get random bytes");
+    /// # let key_auth
+    /// #     = Auth::from_bytes(random_digest.as_slice()).expect("Failed to create key auth");
+    /// #
+    /// # let ecc_parms = PublicEccParametersBuilder::new()
+    /// #     .with_ecc_scheme(EccScheme::EcDaa(
+    /// #         tss_esapi::structures::EcDaaScheme::new(HashingAlgorithm::Sha256, 0),
+    /// #     ))
+    /// #     .with_curve(EccCurve::BnP256)
+    /// #     .with_is_signing_key(true)
+    /// #     .with_is_decryption_key(false)
+    /// #     .with_restricted(false)
+    /// #     .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+    /// #     .build()
+    /// #     .expect("Failed to build ECC parameters");
+    /// #
+    /// # let object_attributes = ObjectAttributesBuilder::new()
+    /// #     .with_fixed_tpm(true)
+    /// #     .with_fixed_parent(true)
+    /// #     .with_sensitive_data_origin(true)
+    /// #     .with_user_with_auth(true)
+    /// #     .with_decrypt(false)
+    /// #     .with_sign_encrypt(true)
+    /// #     .with_restricted(false)
+    /// #     .build()
+    /// #     .expect("Failed to build object attributes");
+    /// #
+    /// # let public = PublicBuilder::new()
+    /// #     .with_public_algorithm(PublicAlgorithm::Ecc)
+    /// #     .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+    /// #     .with_object_attributes(object_attributes)
+    /// #     .with_ecc_parameters(ecc_parms)
+    /// #     .with_ecc_unique_identifier(EccPoint::default())
+    /// #     .build()
+    /// #     .expect("Failed to build public key");
+    /// #
+    /// # let key_handle = context
+    /// #     .create_primary(Hierarchy::Owner, public, Some(key_auth), None, None, None)
+    /// #     .expect("Failed to create primary key")
+    /// #     .key_handle;
+    /// let (_k, _l, _e, counter) = context
+    ///     .commit(key_handle, EccPoint::default(), None, None)
+    ///     .expect("Failed to perform ECC commit");
+    /// ```
+    pub fn commit(
+        &mut self,
+        sign_handle: KeyHandle,
+        p1: impl Into<Option<EccPoint>>,
+        s2: impl Into<Option<SensitiveData>>,
+        y2: impl Into<Option<EccParameter>>,
+    ) -> Result<(EccPoint, EccPoint, EccPoint, u16)> {
+        let mut k_ptr = null_mut();
+        let mut l_ptr = null_mut();
+        let mut e_ptr = null_mut();
+        let mut counter: u16 = 0;
+
+        let potential_p1 = p1.into().map(|v| v.into());
+        let p1_ptr = potential_p1.as_ref().map_or_else(null, std::ptr::from_ref);
+
+        let potential_s2 = s2.into().map(|v| v.into());
+        let s2_ptr = potential_s2.as_ref().map_or_else(null, std::ptr::from_ref);
+
+        let potential_y2 = y2.into().map(|v| v.into());
+        let y2_ptr = potential_y2.as_ref().map_or_else(null, std::ptr::from_ref);
+
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_Commit(
+                    self.mut_context(),
+                    sign_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    p1_ptr,
+                    s2_ptr,
+                    y2_ptr,
+                    &mut k_ptr,
+                    &mut l_ptr,
+                    &mut e_ptr,
+                    &mut counter,
+                )
+            },
+            |ret| {
+                error!("Error when performing ECC commit: {:#010X}", ret);
+            },
+        )?;
+
+        let k_point = Context::ffi_data_to_owned(k_ptr)?;
+        let l_point = Context::ffi_data_to_owned(l_ptr)?;
+        let e_point = Context::ffi_data_to_owned(e_ptr)?;
+        Ok((
+            EccPoint::try_from(k_point.point)?,
+            EccPoint::try_from(l_point.point)?,
+            EccPoint::try_from(e_point.point)?,
+            counter,
+        ))
+    }
+
+    /// Create an ephemeral ECC key.
+    ///
+    /// # Arguments
+    ///
+    /// * `curve` - An [EccCurve] specifying the curve for the ephemeral key.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > TPM2_EC_Ephemeral() creates an ephemeral key for use in a two-phase key exchange protocol.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of `(Q, counter)` where Q is an [EccPoint] representing
+    /// the public ephemeral key and counter is a `u16` to be used
+    /// in a subsequent TPM2_Commit().
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// use tss_esapi::interface_types::ecc::EccCurve;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let (q_point, counter) = context
+    ///     .ec_ephemeral(EccCurve::NistP256)
+    ///     .expect("Failed to create EC ephemeral key");
+    /// ```
+    pub fn ec_ephemeral(&mut self, curve: EccCurve) -> Result<(EccPoint, u16)> {
+        let mut q_ptr = null_mut();
+        let mut counter: u16 = 0;
+
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_EC_Ephemeral(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    curve.into(),
+                    &mut q_ptr,
+                    &mut counter,
+                )
+            },
+            |ret| {
+                error!("Error when creating EC ephemeral key: {:#010X}", ret);
+            },
+        )?;
+
+        let q_point = Context::ffi_data_to_owned(q_ptr)?;
+        Ok((EccPoint::try_from(q_point.point)?, counter))
+    }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/asymmetric_primitives_tests.rs
@@ -106,3 +106,96 @@ mod test_rsa_encrypt_decrypt {
         assert_eq!(z_point.x().as_bytes(), param.x().as_bytes());
     }
 }
+
+mod test_zgen_2phase {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        attributes::ObjectAttributesBuilder,
+        interface_types::{
+            algorithm::{EccKeyExchangeAlgorithm, HashingAlgorithm, PublicAlgorithm},
+            ecc::EccCurve,
+            reserved_handles::Hierarchy,
+        },
+        structures::{
+            Auth, EccPoint, EccScheme, HashScheme, KeyDerivationFunctionScheme, PublicBuilder,
+            PublicEccParametersBuilder,
+        },
+    };
+
+    #[test]
+    fn test_zgen_2phase() {
+        let mut context = create_ctx_with_session();
+        let mut random_digest = vec![0u8; 16];
+        getrandom::getrandom(&mut random_digest).expect("Failed to get random bytes");
+        let key_auth =
+            Auth::from_bytes(random_digest.as_slice()).expect("Failed to create key auth");
+
+        let ecc_parms = PublicEccParametersBuilder::new()
+            .with_ecc_scheme(EccScheme::EcDh(HashScheme::new(HashingAlgorithm::Sha256)))
+            .with_curve(EccCurve::NistP256)
+            .with_is_signing_key(false)
+            .with_is_decryption_key(true)
+            .with_restricted(false)
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .build()
+            .expect("Failed to build ECC parameters");
+
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .with_decrypt(true)
+            .with_sign_encrypt(false)
+            .with_restricted(false)
+            .build()
+            .expect("Failed to build object attributes");
+
+        let public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_ecc_parameters(ecc_parms)
+            .with_ecc_unique_identifier(EccPoint::default())
+            .build()
+            .expect("Failed to build public key");
+
+        let key_handle = context
+            .create_primary(Hierarchy::Owner, public, Some(key_auth), None, None, None)
+            .expect("Failed to create primary key")
+            .key_handle;
+
+        let (q_point, counter) = context
+            .ec_ephemeral(EccCurve::NistP256)
+            .expect("Failed to create EC ephemeral key");
+
+        let (_z_point, pub_point) = context
+            .ecdh_key_gen(key_handle)
+            .expect("Failed to generate ECDH key");
+
+        let (_out_z1, _out_z2) = context
+            .zgen_2phase(
+                key_handle,
+                pub_point,
+                q_point,
+                EccKeyExchangeAlgorithm::EcDh,
+                counter,
+            )
+            .expect("Failed to perform ZGen_2Phase");
+    }
+}
+
+mod test_ecc_parameters {
+    use crate::common::create_ctx_without_session;
+    use tss_esapi::interface_types::ecc::EccCurve;
+
+    #[test]
+    fn test_ecc_parameters() {
+        let mut context = create_ctx_without_session();
+        let details = context
+            .ecc_parameters(EccCurve::NistP256)
+            .expect("Failed to get ECC parameters");
+        assert_eq!(details.curve_id(), EccCurve::NistP256);
+        assert!(details.key_size() > 0);
+    }
+}

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/ephemeral_ec_keys_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/ephemeral_ec_keys_tests.rs
@@ -1,2 +1,84 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_ec_ephemeral {
+    use crate::common::create_ctx_without_session;
+    use tss_esapi::interface_types::ecc::EccCurve;
+
+    #[test]
+    fn test_ec_ephemeral() {
+        let mut context = create_ctx_without_session();
+        let (q_point, counter) = context
+            .ec_ephemeral(EccCurve::NistP256)
+            .expect("Failed to create EC ephemeral key");
+        assert!(!q_point.x().is_empty());
+        assert!(counter > 0);
+    }
+}
+
+mod test_commit {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        attributes::ObjectAttributesBuilder,
+        interface_types::{
+            algorithm::{HashingAlgorithm, PublicAlgorithm},
+            ecc::EccCurve,
+            reserved_handles::Hierarchy,
+        },
+        structures::{
+            Auth, EccPoint, EccScheme, KeyDerivationFunctionScheme, PublicBuilder,
+            PublicEccParametersBuilder,
+        },
+    };
+
+    #[test]
+    fn test_commit() {
+        let mut context = create_ctx_with_session();
+        let mut random_digest = vec![0u8; 16];
+        getrandom::getrandom(&mut random_digest).expect("Failed to get random bytes");
+        let key_auth =
+            Auth::from_bytes(random_digest.as_slice()).expect("Failed to create key auth");
+
+        let ecc_parms = PublicEccParametersBuilder::new()
+            .with_ecc_scheme(EccScheme::EcDaa(tss_esapi::structures::EcDaaScheme::new(
+                HashingAlgorithm::Sha256,
+                0,
+            )))
+            .with_curve(EccCurve::BnP256)
+            .with_is_signing_key(true)
+            .with_is_decryption_key(false)
+            .with_restricted(false)
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .build()
+            .expect("Failed to build ECC parameters");
+
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .with_decrypt(false)
+            .with_sign_encrypt(true)
+            .with_restricted(false)
+            .build()
+            .expect("Failed to build object attributes");
+
+        let public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_ecc_parameters(ecc_parms)
+            .with_ecc_unique_identifier(EccPoint::default())
+            .build()
+            .expect("Failed to build public key");
+
+        let key_handle = context
+            .create_primary(Hierarchy::Owner, public, Some(key_auth), None, None, None)
+            .expect("Failed to create primary key")
+            .key_handle;
+
+        let (_k, _l, _e, counter) = context
+            .commit(key_handle, EccPoint::default(), None, None)
+            .expect("Failed to perform ECC commit");
+        assert!(counter > 0);
+    }
+}


### PR DESCRIPTION
This pull request adds support for several missing TPM 2.0 commands related to ECC along with integration tests for these new features. Originally extracted from #625.

| Module | Functions | ESAPI Spec Section |
| ------ | --------- | ------------------ |
| `asymmetric_primitives` | `ecc_parameters`, `zgen_2phase` | 11.3.24, 11.3.25 |
| `ephemeral_ec_keys` | `commit`, `ec_ephemeral` | 11.3.46, 11.3.47 |

This PR includes changes to both `asymmetric_primitives.rs` and `ephemeral_ec_keys.rs` because `test_zgen_2phase` depends on `ec_ephemeral` (from `ephemeral_ec_keys`) to obtain the counter value needed for the two-phase key exchange.

### Local Tests

```sh
# Lint
cargo fmt --all
podman run --rm -v "$(pwd):/workspaces/rust-tss-esapi" -w /workspaces/rust-tss-esapi ubuntucontainer bash -c "rustup component add clippy && ./tss-esapi/tests/lint-checks.sh"

# Test
podman run --rm -v "$(pwd):/workspaces/rust-tss-esapi" -w /workspaces/rust-tss-esapi ubuntucontainer bash -c "apt-get update -qq && apt-get install -y -qq swtpm && mkdir -p /tmp/tpm && swtpm socket --tpmstate dir=/tmp/tpm --tpm2 --server type=tcp,port=2321 --ctrl type=tcp,port=2322 --flags not-need-init,startup-clear & sleep 2 && TEST_TCTI=swtpm:host=localhost,port=2321 cargo test -p tss-esapi --features integration-tests -- --test-threads=1"

# Doc
podman run --rm -v "$(pwd):/workspaces/rust-tss-esapi" -w /workspaces/rust-tss-esapi ubuntucontainer bash -c "cargo doc --document-private-items --no-deps"
```
