### PR TITLE
docs(esapi): mark all TPM-dependent doc examples as no_run

### DIFF
--- a/tss-esapi/src/abstraction/no_tpm/quote.rs
+++ b/tss-esapi/src/abstraction/no_tpm/quote.rs
@@ -206,7 +206,7 @@ fn checkquote_pcr_digests(
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```no_run
 /// # use std::convert::TryFrom;
 /// # use tss_esapi::{
 /// #     attributes::SessionAttributes,

--- a/tss-esapi/src/abstraction/pcr.rs
+++ b/tss-esapi/src/abstraction/pcr.rs
@@ -13,7 +13,7 @@ pub use data::PcrData;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```no_run
 /// # use tss_esapi::{Context, TctiNameConf};
 /// # // Create context
 /// # let mut context =

--- a/tss-esapi/src/context.rs
+++ b/tss-esapi/src/context.rs
@@ -143,7 +143,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, tcti_ldr::TctiNameConf,
     /// #     constants::SessionType,
     /// #     interface_types::algorithm::HashingAlgorithm,
@@ -194,7 +194,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, tcti_ldr::TctiNameConf, interface_types::session_handles::AuthSession};
     /// # // Create context
     /// # let mut context =
@@ -219,7 +219,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, tcti_ldr::TctiNameConf, interface_types::session_handles::AuthSession};
     /// # // Create context
     /// # let mut context =
@@ -355,7 +355,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, tcti_ldr::TctiNameConf, constants::PropertyTag};
     /// # use std::str::FromStr;
     /// # // Create context

--- a/tss-esapi/src/context/general_esys_tr.rs
+++ b/tss-esapi/src/context/general_esys_tr.rs
@@ -26,7 +26,7 @@ impl Context {
     /// * `object_handle` - The [ObjectHandle] associated with an object for which the auth is to be set.
     /// * `auth` -  The [Auth] that is to be set.
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// use tss_esapi::{handles::ObjectHandle, structures::Auth};
     /// # // Create context
@@ -60,7 +60,7 @@ impl Context {
     /// The objects name.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::{SessionAttributes, NvIndexAttributes},
     /// #     constants::SessionType, handles::NvIndexTpmHandle,
@@ -152,7 +152,7 @@ impl Context {
     /// A handle to the ESYS object that was created from a TPM resource.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::{SessionAttributes, NvIndexAttributes},
     /// #     constants::SessionType,
@@ -280,7 +280,7 @@ impl Context {
     ///   resources is going to be released.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::{SessionAttributes, NvIndexAttributes},
     /// #     constants::SessionType, handles::NvIndexTpmHandle,
@@ -410,7 +410,7 @@ impl Context {
     /// * if the buffer length cannot be converted to a `usize`, an `InvalidParam`
     ///   wrapper error is returned.
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf,
     /// #     interface_types::reserved_handles::Hierarchy,
@@ -478,7 +478,7 @@ impl Context {
     /// * if the buffer length cannot be converted to a `usize`, an `InvalidParam`
     ///   wrapper error is returned.
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf,
     /// #     interface_types::reserved_handles::Hierarchy,

--- a/tss-esapi/src/context/session_administration.rs
+++ b/tss-esapi/src/context/session_administration.rs
@@ -70,7 +70,7 @@ impl Context {
     /// digest to satisfy the policy.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// # use tss_esapi::constants::SessionType;
     /// # use tss_esapi::interface_types::algorithm::HashingAlgorithm;

--- a/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/asymmetric_primitives.rs
@@ -44,7 +44,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #    Context, TctiNameConf,
     /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},
@@ -205,7 +205,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #    Context, TctiNameConf,
     /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},
@@ -353,7 +353,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #    Context, TctiNameConf,
     /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},
@@ -489,7 +489,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #    Context, TctiNameConf,
     /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},
@@ -625,7 +625,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// use tss_esapi::interface_types::ecc::EccCurve;
     /// # let mut context =
@@ -677,7 +677,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #    Context, TctiNameConf,
     /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},

--- a/tss-esapi/src/context/tpm_commands/attestation_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/attestation_commands.rs
@@ -40,7 +40,7 @@ impl Context {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// # use std::convert::TryFrom;
     /// # use tss_esapi::{
@@ -183,7 +183,7 @@ impl Context {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// # use std::convert::TryFrom;
     /// # use tss_esapi::{
@@ -293,7 +293,7 @@ impl Context {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// use std::convert::TryFrom;
     /// # use tss_esapi::{
@@ -445,7 +445,7 @@ impl Context {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// # use std::convert::TryFrom;
     /// # use tss_esapi::{

--- a/tss-esapi/src/context/tpm_commands/capability_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/capability_commands.rs
@@ -26,7 +26,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// # // Create context
     /// # let mut context =

--- a/tss-esapi/src/context/tpm_commands/context_management.rs
+++ b/tss-esapi/src/context/tpm_commands/context_management.rs
@@ -53,7 +53,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, tcti_ldr::TctiNameConf, structures::Auth,
     /// #     constants::{
@@ -165,7 +165,7 @@ impl Context {
     /// # Example
     ///
     /// Make transient object persistent:
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, tcti_ldr::TctiNameConf, Result,
     /// #     constants::{
@@ -284,7 +284,7 @@ impl Context {
     /// ```
     ///
     /// Make persistent object transient
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, tcti_ldr::TctiNameConf, Result,
     /// #     constants::{

--- a/tss-esapi/src/context/tpm_commands/duplication_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/duplication_commands.rs
@@ -38,7 +38,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use std::convert::{TryFrom, TryInto};
     /// # use tss_esapi::attributes::{ObjectAttributesBuilder, SessionAttributesBuilder};
     /// # use tss_esapi::constants::{CommandCode, SessionType};
@@ -360,7 +360,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use std::convert::{TryFrom, TryInto};
     /// # use tss_esapi::attributes::{ObjectAttributesBuilder, SessionAttributesBuilder};
     /// # use tss_esapi::constants::{CommandCode, SessionType};

--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -339,7 +339,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use std::convert::{TryFrom, TryInto};
     /// # use tss_esapi::attributes::{ObjectAttributesBuilder, SessionAttributesBuilder};
     /// # use tss_esapi::constants::{CommandCode, SessionType};
@@ -604,7 +604,7 @@ impl Context {
     ///   where the policy is stored.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use std::convert::TryFrom;
     /// # use tss_esapi::attributes::{NvIndexAttributes, SessionAttributes};
     /// # use tss_esapi::constants::SessionType;

--- a/tss-esapi/src/context/tpm_commands/ephemeral_ec_keys.rs
+++ b/tss-esapi/src/context/tpm_commands/ephemeral_ec_keys.rs
@@ -39,7 +39,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #    Context, TctiNameConf,
     /// #    attributes::{SessionAttributesBuilder, ObjectAttributesBuilder},
@@ -195,7 +195,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// use tss_esapi::interface_types::ecc::EccCurve;
     /// # let mut context =

--- a/tss-esapi/src/context/tpm_commands/hash_hmac_event_sequences.rs
+++ b/tss-esapi/src/context/tpm_commands/hash_hmac_event_sequences.rs
@@ -26,7 +26,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, tcti_ldr::TctiNameConf,
     /// #     attributes::{ObjectAttributesBuilder, SessionAttributesBuilder},
     /// #     structures::{
@@ -157,7 +157,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, tcti_ldr::TctiNameConf,
     /// #     attributes::SessionAttributesBuilder,
     /// #     structures::{Auth, MaxBuffer, Ticket, SymmetricDefinition, RsaExponent, RsaScheme},

--- a/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
+++ b/tss-esapi/src/context/tpm_commands/integrity_collection_pcr.rs
@@ -23,7 +23,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf,
     /// #     constants::SessionType,
@@ -126,7 +126,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf};
     /// # use std::{env, str::FromStr};
     /// # // Create context
@@ -197,7 +197,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf,
     /// #     constants::SessionType,

--- a/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
+++ b/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
@@ -35,7 +35,7 @@ impl Context {
     /// was defined.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::SessionAttributes, constants::SessionType,
     /// #     structures::SymmetricDefinition,
@@ -142,7 +142,7 @@ impl Context {
     ///   the nv area that is to be removed.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::SessionAttributes, constants::SessionType,
     /// #     structures::SymmetricDefinition,
@@ -241,7 +241,7 @@ impl Context {
     ///   the nv area that is to be removed.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::SessionAttributes, constants::SessionType,
     /// #     structures::SymmetricDefinition, constants::CommandCode,
@@ -383,7 +383,7 @@ impl Context {
     /// A tuple containing the public area and the name of an nv index.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::{SessionAttributes, NvIndexAttributes},
     /// #     handles::NvIndexTpmHandle, interface_types::algorithm::HashingAlgorithm,
@@ -498,7 +498,7 @@ impl Context {
     /// * `offset` - The octet offset into the NV area.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::{SessionAttributes, NvIndexAttributes},
     /// #     handles::NvIndexTpmHandle, interface_types::algorithm::HashingAlgorithm,
@@ -609,7 +609,7 @@ impl Context {
     /// * `auth_handle` - Handle indicating the source of authorization value.
     /// * `nv_index_handle` - The [NvIndexHandle] associated with NV memory
     ///   where data is to be written.
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::{SessionAttributes, NvIndexAttributes},
     /// #     handles::NvIndexTpmHandle, interface_types::algorithm::HashingAlgorithm,
@@ -718,7 +718,7 @@ impl Context {
     /// * `data` - The data, in the form of a [MaxNvBuffer], that is to be written.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::{SessionAttributes, NvIndexAttributes},
     /// #     handles::NvIndexTpmHandle, interface_types::algorithm::HashingAlgorithm,
@@ -829,7 +829,7 @@ impl Context {
     /// * `offset`- Octet offset into the NV area.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     Context, TctiNameConf, attributes::{SessionAttributes, NvIndexAttributes},
     /// #     handles::NvIndexTpmHandle, interface_types::algorithm::HashingAlgorithm,

--- a/tss-esapi/src/context/tpm_commands/object_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/object_commands.rs
@@ -138,7 +138,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #    Context, TctiNameConf,
     /// #    attributes::ObjectAttributesBuilder,

--- a/tss-esapi/src/context/tpm_commands/session_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/session_commands.rs
@@ -23,7 +23,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, Tcti,
     /// #     constants::SessionType,
     /// #     interface_types::algorithm::HashingAlgorithm,

--- a/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
+++ b/tss-esapi/src/context/tpm_commands/signing_and_signature_verification.rs
@@ -52,7 +52,7 @@ impl Context {
     ///                N.B. None will be treated as a "Null ticket".
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, TctiNameConf,
     /// #    interface_types::{
     /// #        algorithm::{HashingAlgorithm, RsaSchemeAlgorithm},

--- a/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
+++ b/tss-esapi/src/context/tpm_commands/symmetric_primitives.rs
@@ -29,7 +29,7 @@ impl Context {
     /// * `initial_value_in` - An initial value as required by the algorithm.
     ///
     /// # Example
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     constants::AlgorithmIdentifier,
     /// #     attributes::ObjectAttributesBuilder,
@@ -229,7 +229,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{Context, tcti_ldr::TctiNameConf,
     /// #     structures::{MaxBuffer, Ticket},
     /// #     interface_types::{algorithm::HashingAlgorithm, reserved_handles::Hierarchy},
@@ -299,7 +299,7 @@ impl Context {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # use tss_esapi::{
     /// #     attributes::ObjectAttributesBuilder,
     /// #     structures::{MaxBuffer, Ticket, PublicKeyedHashParameters, KeyedHashScheme, HmacScheme, PublicBuilder, Digest},

--- a/tss-esapi/src/tcti_ldr.rs
+++ b/tss-esapi/src/tcti_ldr.rs
@@ -162,7 +162,7 @@ impl TctiNameConf {
     /// - TEST_TCTI
     ///
     /// # Examples
-    /// ```
+    /// ```no_run
     /// # use tss_esapi::tcti_ldr::TctiNameConf;
     /// // Create context
     /// let tcti_name_conf = TctiNameConf::from_environment_variable().expect("Failed to get TCTI");


### PR DESCRIPTION
All 53 doc examples that connect to a TPM via `TctiNameConf::from_environment_variable()` and `Context::new()` are changed to `no_run` code blocks. They are still compiled (catching API breakage) *but no longer executed*.

### Why this change should be made

These executable doc examples are duplicating the integration test suite. Each contains complete setup-to-teardown TPM interaction code identical to what the integration tests already cover. This imposes a double maintenance burden: changes to the API require updating both the integration tests and the doc examples, with the latter being harder to maintain since linter/builder do not operate on code embedded in doc comments. Coverage is also inconsistent, with many functions lacking examples entirely.

Doc examples should serve as concise usage illustrations for API consumers, not as a parallel test suite. Marking them as `no_run` preserves their value as documentation while eliminating the runtime dependency on a TPM simulator.

### Note

For TPM-related APIs, requiring doc examples to be fully runnable is not always appropriate. Some operations involve stateful or effectively irreversible TPM changes (e.g. DA lockout), so executable doctests can make such APIs difficult or unsafe to document. The only practical workaround would be to expose TPM emulator setup helpers, but those are test-only utilities and do not belong in the public API.