### PR TITLE
test: upgrade Ubuntu CI base image from 20.04 to 22.04

### DIFF
--- a/tss-esapi/tests/Dockerfile-ubuntu
+++ b/tss-esapi/tests/Dockerfile-ubuntu
@@ -1,4 +1,4 @@
-FROM ghcr.io/tpm2-software/ubuntu-20.04:latest AS base
+FROM ghcr.io/tpm2-software/ubuntu-22.04:latest AS base
 
 FROM base AS rust-toolchain
 # Install Rust toolchain


### PR DESCRIPTION
This PR upgrades to 22.04 LTS, supported until April 2027. Note that the standard support for Ubuntu 20.04 ended in April 2025.

Note: Starting with Ubuntu 22.04, swtpm has become available in the apt repository. As a result, swtpm is now available on both Ubuntu and Fedora.

Additional Note: Fedora 40 also [reached its end of life (EOL) on May 13, 2025](https://docs.fedoraproject.org/en-US/releases/eol/). (The same applies to Fedora 41.) We may have to upgrade Fedora to version 42 or 43.