### PR TITLE
test: upgrade Fedora CI base image from 40 to 42

### DIFF
--- a/tss-esapi/tests/Dockerfile-fedora
+++ b/tss-esapi/tests/Dockerfile-fedora
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:42
 
 RUN dnf install -y \
 	tpm2-tss-devel tpm2-abrmd tpm2-tools \


### PR DESCRIPTION
This PR upgrades Fedora from 40 to 42, the lowest version that is not EOL (based on the discussions in #631).

### Notes (EOL date)

- Fedora 40: 2025-05-13
- Fedora 41: 2025-12-15
- Fedora 42: 2026-05-13 ([scheduled](https://fedorapeople.org/groups/schedule/f-42/f-42-key-tasks.html))
- Fedora 43: 2026-12-09 ([scheduled](https://fedorapeople.org/groups/schedule/f-43/f-43-key-tasks.html))