### PR TITLE
Bump sys crate version on main after 0.6.0 release.

### DIFF
--- a/tss-esapi-sys/Cargo.toml
+++ b/tss-esapi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tss-esapi-sys"
-version = "0.6.0-alpha.2"
+version = "0.7.0-alpha.1"
 authors = ["Parsec Project Contributors"]
 edition = "2024"
 description = "FFI wrapper around TSS 2.0 Enhanced System API"

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -33,7 +33,7 @@ num-traits = "0.2.12"
 hostname-validator = "1.1.0"
 regex = "1.3.9"
 zeroize = { version = "1.5.7", features = ["zeroize_derive"] }
-tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.6.0-alpha.2" }
+tss-esapi-sys = { path = "../tss-esapi-sys", version = "0.7.0-alpha.1" }
 x509-cert = { version = "0.2.0", optional = true }
 ecdsa = { version = "0.16.9", features = [
     "der",


### PR DESCRIPTION
After the release of tss-esapi-sys 0.6.0 it is
no longer a good idea to continue to release
0.6.0-alpha releases. So this commit bumps the
version of the tss-espi-sys crate to enable further development.