### PR TITLE
test(esapi): use per-test swtpm instances over UDSs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,8 @@ RUN apt -y update && apt -y install \
     libltdl-dev \
     libusb-1.0-0-dev \
     libftdi-dev \
-    clang
+    clang \
+    swtpm
 
 WORKDIR /build
 ADD . /build

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,19 +8,8 @@ services:
       - ../..:/workspaces:cached
     command: sleep infinity
     network_mode: host
-    environment:
-      TPM2TOOLS_TCTI: mssim:host=localhost,port=2321
     deploy:
       resources:
         limits:
           cpus: '4.0'
           memory: 16G
-
-  tpm:
-    image: tpmdev/tpm2-runtime
-    network_mode: host
-    restart: unless-stopped
-    environment:
-      TPM2TOOLS_TCTI: mssim:host=localhost,port=2321
-    command: /bin/bash -c "tpm_server >/dev/null & sleep 1; tpm2_startup -c; sleep infinity"
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu --target tpm2-tools
       - name: Run the container
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
       - name: Run the cross-compilation script
         run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/cross-compile.sh
 
@@ -54,7 +54,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --build-arg TPM2_TSS_VERSION=4.1.3 --file tss-esapi/tests/Dockerfile-ubuntu --target tpm2-tools
       - name: Run the container
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
 
   test-ubuntu-v4-path:
     name: Ubuntu tests on v4.x.y of tpm2-tss libraries found using a path
@@ -64,7 +64,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --build-arg TPM2_TSS_VERSION=4.1.3 --file tss-esapi/tests/Dockerfile-ubuntu --target tpm2-tss-install-dir
       - name: Run the container
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
 
   tests-fedora:
     name: Fedora tests
@@ -96,7 +96,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu --target tpm2-tools
       - name: Run the tests
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi -e RUST_TOOLCHAIN_VERSION="1.87" ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/valgrind.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi -e RUST_TOOLCHAIN_VERSION="1.87" ubuntucontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/valgrind.sh
 
   # Check that the documentation builds as well.
   docs:
@@ -121,7 +121,7 @@ jobs:
         run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env RUST_TOOLCHAIN_VERSION=1.85.0 ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/lint-checks.sh
       - name: Check Clippy lints latest
         run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/lint-checks.sh
-        
+
   # Check that it is possible to build the documentation the same way as it is done in Docs.rs
   docs-rs:
     name: Check Docs.rs compatibility
@@ -134,7 +134,7 @@ jobs:
       - uses: dtolnay/install@cargo-docs-rs
       - run: cargo docs-rs -p tss-esapi
       - run: cargo docs-rs -p tss-esapi-sys
-        
+
   # Check that examples builds can be executed.
   tests-examples:
     name: Check examples

--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -66,9 +66,11 @@ paste = "1.0.14"
 getrandom = "0.2.11"
 
 [dev-dependencies]
+assert_fs = "1.1.3"
 env_logger = "0.11.5"
 serde_json = "^1.0.108"
 sha2 = { version = "0.10.8", features = ["oid"] }
+socket2 = "0.6.3"
 tss-esapi = { path = ".", features = [
     "integration-tests",
     "serde",

--- a/tss-esapi/tests/Dockerfile-fedora
+++ b/tss-esapi/tests/Dockerfile-fedora
@@ -1,7 +1,7 @@
 FROM fedora:42
 
 RUN dnf install -y \
-	tpm2-tss-devel tpm2-abrmd tpm2-tools \
+	tpm2-tss-devel tpm2-tools \
 	swtpm swtpm-tools \
 	rust clippy cargo \
 	llvm llvm-devel clang pkg-config \

--- a/tss-esapi/tests/Dockerfile-fedora-rawhide
+++ b/tss-esapi/tests/Dockerfile-fedora-rawhide
@@ -1,7 +1,7 @@
 FROM fedora:rawhide
 
 RUN dnf install -y \
-	tpm2-tss-devel tpm2-abrmd tpm2-tools \
+	tpm2-tss-devel tpm2-tools \
 	swtpm swtpm-tools swtpm-selinux\
 	rust clippy cargo \
 	llvm llvm-devel clang pkg-config \

--- a/tss-esapi/tests/Dockerfile-opensuse-tw
+++ b/tss-esapi/tests/Dockerfile-opensuse-tw
@@ -9,7 +9,7 @@
 FROM opensuse/tumbleweed:latest
 
 RUN zypper install -y \
-    tpm2-0-tss-devel tpm2.0-tools tpm2.0-abrmd \
+    tpm2-0-tss-devel tpm2.0-tools \
     swtpm \
     cargo \
     clang \

--- a/tss-esapi/tests/Dockerfile-ubuntu
+++ b/tss-esapi/tests/Dockerfile-ubuntu
@@ -21,6 +21,7 @@ RUN cd tpm2-tss \
 	&& ldconfig
 
 FROM tpm2-tss AS tpm2-tools
+
 # Download and install TPM2 tools
 RUN git clone https://github.com/tpm2-software/tpm2-tools.git --branch 5.7
 RUN cd tpm2-tools \

--- a/tss-esapi/tests/all-fedora.sh
+++ b/tss-esapi/tests/all-fedora.sh
@@ -17,28 +17,20 @@ if [[ ! -z ${USE_FROZEN_LOCKFILE:+x} ]]; then
 	cp tests/Cargo.lock.frozen ../Cargo.lock
 fi
 
-############################
-# Run the TPM SWTPM server #
-############################
+########################################
+# Run the TPM SWTPM server for doctest #
+########################################
 mkdir /tmp/tpmdir
 swtpm_setup --tpm2 \
     --tpmstate /tmp/tpmdir \
-    --createek --decryption --create-ek-cert \
-    --create-platform-cert \
     --pcr-banks sha1,sha256 \
     --display
 swtpm socket --tpm2 \
     --tpmstate dir=/tmp/tpmdir \
     --flags startup-clear \
-    --ctrl type=tcp,port=2322 \
-    --server type=tcp,port=2321 \
+    --ctrl type=unixio,path=/tmp/tpmdir/swtpm.sock.ctrl \
+    --server type=unixio,path=/tmp/tpmdir/swtpm.sock \
     --daemon
-tpm2-abrmd \
-    --logger=stdout \
-    --tcti=swtpm: \
-    --allow-root \
-    --session \
-    --flush-all &
 
 ###################
 # Build the crate #
@@ -48,4 +40,8 @@ RUST_BACKTRACE=1 cargo build --features "generate-bindings integration-tests ser
 #################
 # Run the tests #
 #################
-TEST_TCTI=tabrmd:bus_type=session RUST_BACKTRACE=1 RUST_LOG=info cargo test --features "generate-bindings integration-tests serde" --  --test-threads=1 --nocapture
+RUST_BACKTRACE=1 RUST_LOG=info \
+    cargo test --all-targets --features "generate-bindings integration-tests serde" -- --nocapture
+
+TEST_TCTI="swtpm:path=/tmp/tpmdir/swtpm.sock" RUST_BACKTRACE=1 RUST_LOG=info \
+    cargo test --doc --features "generate-bindings integration-tests serde" -- --test-threads=1 --nocapture

--- a/tss-esapi/tests/all-opensuse.sh
+++ b/tss-esapi/tests/all-opensuse.sh
@@ -10,21 +10,19 @@
 
 set -euf -o pipefail
 
-############################
-# Run the TPM SWTPM server #
-############################
+########################################
+# Run the TPM SWTPM server for doctest #
+########################################
 mkdir /tmp/tpmdir
 swtpm_setup --tpm2 \
     --tpmstate /tmp/tpmdir \
-    --createek --decryption --create-ek-cert \
-    --create-platform-cert \
     --pcr-banks sha1,sha256 \
     --display
 swtpm socket --tpm2 \
     --tpmstate dir=/tmp/tpmdir \
     --flags startup-clear \
-    --ctrl type=tcp,port=2322 \
-    --server type=tcp,port=2321 \
+    --ctrl type=unixio,path=/tmp/tpmdir/swtpm.sock.ctrl \
+    --server type=unixio,path=/tmp/tpmdir/swtpm.sock \
     --daemon
 
 ###################
@@ -35,5 +33,8 @@ RUST_BACKTRACE=1 cargo build --features "generate-bindings integration-tests ser
 #################
 # Run the tests #
 #################
-TEST_TCTI="swtpm:host=localhost,port=2321" RUST_BACKTRACE=1 RUST_LOG=info cargo test --features "generate-bindings integration-tests serde" --  --test-threads=1 --nocapture
+RUST_BACKTRACE=1 RUST_LOG=info \
+    cargo test --all-targets --features "generate-bindings integration-tests serde" -- --nocapture
 
+TEST_TCTI="swtpm:path=/tmp/tpmdir/swtpm.sock" RUST_BACKTRACE=1 RUST_LOG=info \
+    cargo test --doc --features "generate-bindings integration-tests serde" -- --test-threads=1 --nocapture

--- a/tss-esapi/tests/all-ubuntu.sh
+++ b/tss-esapi/tests/all-ubuntu.sh
@@ -32,12 +32,21 @@ fi
 if [[ ! -z ${TPM2_TSS_PATH:+x} ]]; then
 	export LD_LIBRARY_PATH="${TPM2_TSS_PATH}"
 fi
-#################################
-# Run the TPM simulation server #
-#################################
-tpm_server &
-sleep 5
-tpm2_startup -c -T mssim
+
+#############################################
+# Run the TPM simulation server for doctest #
+#############################################
+mkdir /tmp/tpmdir
+swtpm_setup --tpm2 \
+    --tpmstate /tmp/tpmdir \
+    --pcr-banks sha1,sha256 \
+    --display
+swtpm socket --tpm2 \
+    --tpmstate dir=/tmp/tpmdir \
+    --flags startup-clear \
+    --ctrl type=unixio,path=/tmp/tpmdir/swtpm.sock.ctrl \
+    --server type=unixio,path=/tmp/tpmdir/swtpm.sock \
+    --daemon
 
 ###################
 # Build the crate #
@@ -47,4 +56,8 @@ RUST_BACKTRACE=1 cargo build --features "$FEATURES"
 #################
 # Run the tests #
 #################
-TEST_TCTI=mssim: RUST_BACKTRACE=1 RUST_LOG=info cargo test --features "${FEATURES}" -- --test-threads=1 --nocapture
+RUST_BACKTRACE=1 RUST_LOG=info \
+    cargo test --all-targets --features "generate-bindings integration-tests serde" -- --nocapture
+
+TEST_TCTI="swtpm:path=/tmp/tpmdir/swtpm.sock" RUST_BACKTRACE=1 RUST_LOG=info \
+    cargo test --doc --features "generate-bindings integration-tests serde" -- --test-threads=1 --nocapture

--- a/tss-esapi/tests/coverage.sh
+++ b/tss-esapi/tests/coverage.sh
@@ -5,15 +5,8 @@
 
 set -euf -o pipefail
 
-#################################
-# Run the TPM simulation server #
-#################################
-tpm_server &
-sleep 5
-tpm2_startup -c -T mssim
-
 #############################
 # Install and run tarpaulin #
 #############################
 cargo install cargo-tarpaulin
-cargo tarpaulin --features "integration-tests serde" --tests --out xml --exclude-files="tests/*,../*" -- --test-threads=1 --nocapture
+cargo tarpaulin --features "integration-tests serde" --tests --out xml --exclude-files="tests/*,../*" -- --nocapture

--- a/tss-esapi/tests/examples.sh
+++ b/tss-esapi/tests/examples.sh
@@ -25,31 +25,14 @@ fi
 mkdir /tmp/tpmdir
 swtpm_setup --tpm2 \
     --tpmstate /tmp/tpmdir \
-    --createek --decryption --create-ek-cert \
-    --create-platform-cert \
     --pcr-banks sha1,sha256 \
     --display
 swtpm socket --tpm2 \
     --tpmstate dir=/tmp/tpmdir \
     --flags startup-clear \
-    --ctrl type=tcp,port=2322 \
-    --server type=tcp,port=2321 \
+    --ctrl type=unixio,path=/tmp/tpmdir/swtpm.sock.ctrl \
+    --server type=unixio,path=/tmp/tpmdir/swtpm.sock \
     --daemon
-
-####################
-# Start tpm2-abrmd #
-####################
-tpm2-abrmd \
-    --logger=stdout \
-    --tcti=swtpm: \
-    --allow-root \
-    --session \
-    --flush-all &
-
-#################
-# Clear the TPM #
-#################
-tpm2_startup -c -T tabrmd:bus_type=session
 
 ########################
 # Declare the examples #
@@ -72,5 +55,5 @@ export EXAMPLES_INITIAL_DATA_FILE="/tmp/rust-tss-esapi/tss-esapi/examples/symmet
 # Run the examples #
 ####################
 for e in ${examples[@]}; do
-    TEST_TCTI=tabrmd:bus_type=session RUST_BACKTRACE=1 RUST_LOG=info cargo run --example ${e}
+    TEST_TCTI="swtpm:path=/tmp/tpmdir/swtpm.sock" RUST_BACKTRACE=1 RUST_LOG=info cargo run --example ${e}
 done

--- a/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/abstraction_tests/transient_key_context_tests.rs
@@ -35,61 +35,51 @@ use x509_cert::{
     name::Name,
 };
 
-use crate::common::create_tcti;
+use crate::common::{SwtpmSession, create_tcti};
 
 const HASH: [u8; 32] = [
     0x69, 0x3E, 0xDB, 0x1B, 0x22, 0x79, 0x03, 0xF4, 0xC0, 0xBF, 0xD6, 0x91, 0x76, 0x37, 0x84, 0xA2,
     0x94, 0x8E, 0x92, 0x50, 0x35, 0xC2, 0x8C, 0x5C, 0x3C, 0xCA, 0xFE, 0x18, 0xE8, 0x81, 0x37, 0x78,
 ];
 
-fn create_ctx() -> TransientKeyContext {
+fn create_ctx() -> (SwtpmSession, TransientKeyContext) {
+    let (_swtpm, tcti) = create_tcti();
+    let ctx = TransientKeyContextBuilder::new()
+        .with_tcti(tcti)
+        .build()
+        .unwrap();
+    (_swtpm, ctx)
+}
+
+/// Create a TransientKeyContext on an existing swtpm instance.
+fn create_ctx_on(swtpm: &SwtpmSession) -> TransientKeyContext {
     TransientKeyContextBuilder::new()
-        .with_tcti(create_tcti())
+        .with_tcti(swtpm.tcti())
         .build()
         .unwrap()
 }
 
 #[test]
 fn wrong_key_sizes() {
-    assert_eq!(
-        TransientKeyContextBuilder::new()
-            .with_tcti(create_tcti())
-            .with_root_key_size(1023)
-            .build()
-            .unwrap_err(),
-        Error::WrapperError(ErrorKind::InvalidParam)
-    );
-    assert_eq!(
-        TransientKeyContextBuilder::new()
-            .with_tcti(create_tcti())
-            .with_root_key_size(1025)
-            .build()
-            .unwrap_err(),
-        Error::WrapperError(ErrorKind::InvalidParam)
-    );
-    assert_eq!(
-        TransientKeyContextBuilder::new()
-            .with_tcti(create_tcti())
-            .with_root_key_size(2047)
-            .build()
-            .unwrap_err(),
-        Error::WrapperError(ErrorKind::InvalidParam)
-    );
-    assert_eq!(
-        TransientKeyContextBuilder::new()
-            .with_tcti(create_tcti())
-            .with_root_key_size(2049)
-            .build()
-            .unwrap_err(),
-        Error::WrapperError(ErrorKind::InvalidParam)
-    );
+    for bad_size in [1023, 1025, 2047, 2049] {
+        let (_swtpm, tcti) = create_tcti();
+        assert_eq!(
+            TransientKeyContextBuilder::new()
+                .with_tcti(tcti)
+                .with_root_key_size(bad_size)
+                .build()
+                .unwrap_err(),
+            Error::WrapperError(ErrorKind::InvalidParam)
+        );
+    }
 }
 
 #[test]
 fn wrong_auth_size() {
+    let (_swtpm, tcti) = create_tcti();
     assert_eq!(
         TransientKeyContextBuilder::new()
-            .with_tcti(create_tcti())
+            .with_tcti(tcti)
             .with_root_key_auth_size(33)
             .build()
             .unwrap_err(),
@@ -99,7 +89,7 @@ fn wrong_auth_size() {
 
 #[test]
 fn load_bad_sized_key() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let key_params = KeyParams::Rsa {
         size: RsaKeyBits::Rsa1024,
         scheme: RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
@@ -134,7 +124,7 @@ fn load_with_invalid_params() {
         )
         .expect("Failed to create ecc scheme"),
     };
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let _ = ctx
         .load_external_public_key(PublicKey::Rsa(pub_key), key_params)
         .unwrap_err();
@@ -182,7 +172,7 @@ fn verify() {
         .expect("Failed to create RSA signature"),
     );
 
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let key_params = KeyParams::Rsa {
         size: RsaKeyBits::Rsa1024,
         scheme: RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
@@ -199,7 +189,7 @@ fn verify() {
 
 #[test]
 fn sign_with_bad_auth() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let key_params = KeyParams::Rsa {
         size: RsaKeyBits::Rsa2048,
         scheme: RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
@@ -221,7 +211,7 @@ fn sign_with_bad_auth() {
 
 #[test]
 fn sign_with_no_auth() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let key_params = KeyParams::Rsa {
         size: RsaKeyBits::Rsa2048,
         scheme: RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
@@ -240,7 +230,7 @@ fn sign_with_no_auth() {
 
 #[test]
 fn encrypt_decrypt() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let key_params = KeyParams::Rsa {
         size: RsaKeyBits::Rsa2048,
         scheme: RsaScheme::create(RsaSchemeAlgorithm::Oaep, Some(HashingAlgorithm::Sha256))
@@ -272,7 +262,7 @@ fn encrypt_decrypt() {
 
 #[test]
 fn two_signatures_different_digest() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let key_params1 = KeyParams::Rsa {
         size: RsaKeyBits::Rsa2048,
         scheme: RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
@@ -320,7 +310,7 @@ fn two_signatures_different_digest() {
 
 #[test]
 fn verify_wrong_key() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let key_params1 = KeyParams::Rsa {
         size: RsaKeyBits::Rsa2048,
         scheme: RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
@@ -367,7 +357,7 @@ fn verify_wrong_key() {
 }
 #[test]
 fn verify_wrong_digest() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let key_params = KeyParams::Rsa {
         size: RsaKeyBits::Rsa2048,
         scheme: RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
@@ -407,7 +397,7 @@ fn verify_wrong_digest() {
 
 #[test]
 fn full_test() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     for _ in 0..4 {
         let key_params = KeyParams::Rsa {
             size: RsaKeyBits::Rsa2048,
@@ -440,7 +430,7 @@ fn full_test() {
 
 #[test]
 fn create_ecc_key() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let _ = ctx
         .create_key(
             KeyParams::Ecc {
@@ -459,7 +449,7 @@ fn create_ecc_key() {
 
 #[test]
 fn create_ecc_key_decryption_scheme() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let _ = ctx
         .create_key(
             KeyParams::Ecc {
@@ -478,7 +468,7 @@ fn create_ecc_key_decryption_scheme() {
 
 #[test]
 fn full_ecc_test() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let key_params = KeyParams::Ecc {
         curve: EccCurve::NistP256,
         scheme: EccScheme::create(
@@ -514,9 +504,12 @@ fn full_ecc_test() {
 
 #[test]
 fn ctx_migration_test() {
+    // Use a shared swtpm so Context and TransientKeyContext share TPM state.
+    let swtpm = SwtpmSession::new();
+
     // Create two key contexts using `Context`, one for an RSA keypair,
     // one for just the public part of the key
-    let mut basic_ctx = crate::common::create_ctx_with_session();
+    let mut basic_ctx = swtpm.create_session_context();
     let mut random_digest = vec![0u8; 16];
     getrandom::getrandom(&mut random_digest).unwrap();
     let key_auth = Auth::from_bytes(random_digest.as_slice()).unwrap();
@@ -566,7 +559,7 @@ fn ctx_migration_test() {
     std::mem::drop(basic_ctx);
 
     // Migrate the keys and attempt to use them
-    let mut ctx = create_ctx();
+    let mut ctx = create_ctx_on(&swtpm);
     let key = ctx
         .migrate_key_from_ctx(key_context, Some(key_auth.clone()))
         .unwrap();
@@ -618,9 +611,12 @@ fn ctx_migration_test() {
 
 #[test]
 fn activate_credential() {
+    // Use a shared swtpm so all contexts share TPM state.
+    let swtpm = SwtpmSession::new();
+
     // create a Transient key context, generate a key and
     // obtain the Make Credential parameters
-    let mut ctx = create_ctx();
+    let mut ctx = create_ctx_on(&swtpm);
     let params = KeyParams::Ecc {
         curve: EccCurve::NistP256,
         scheme: EccScheme::create(
@@ -641,7 +637,7 @@ fn activate_credential() {
     drop(ctx);
 
     // create a normal Context and make the credential
-    let mut basic_ctx = crate::common::create_ctx_with_session();
+    let mut basic_ctx = swtpm.create_session_context();
 
     // the public part of the EK is used, so we retrieve the parameters
     let key_pub = ek::create_ek_public_from_default_template(
@@ -689,7 +685,7 @@ fn activate_credential() {
     drop(basic_ctx);
 
     // Create a new Transient key context and activate the credential
-    let mut ctx = create_ctx();
+    let mut ctx = create_ctx_on(&swtpm);
     let cred_back = ctx
         .activate_credential(
             obj,
@@ -706,7 +702,7 @@ fn activate_credential() {
 fn make_cred_params_name() {
     // create a Transient key context, generate a key and
     // obtain the Make Credential parameters
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let params = KeyParams::Ecc {
         curve: EccCurve::NistP256,
         scheme: EccScheme::create(
@@ -736,9 +732,12 @@ fn make_cred_params_name() {
 
 #[test]
 fn activate_credential_wrong_key() {
+    // Use a shared swtpm so all contexts share TPM state.
+    let swtpm = SwtpmSession::new();
+
     // create a Transient key context, generate two keys and
     // obtain the Make Credential parameters for the first one
-    let mut ctx = create_ctx();
+    let mut ctx = create_ctx_on(&swtpm);
     let params = KeyParams::Ecc {
         curve: EccCurve::NistP256,
         scheme: EccScheme::create(
@@ -768,7 +767,7 @@ fn activate_credential_wrong_key() {
     drop(ctx);
 
     // create a normal Context and make the credential
-    let mut basic_ctx = crate::common::create_ctx_with_session();
+    let mut basic_ctx = swtpm.create_session_context();
 
     // the public part of the EK is used, so we retrieve the parameters
     let key_pub = ek::create_ek_public_from_default_template(
@@ -818,7 +817,7 @@ fn activate_credential_wrong_key() {
     // Create a new Transient key context and activate the credential
     // Validation fails within the TPM because the credential HMAC is
     // associated with a different object (so the integrity check fails).
-    let mut ctx = create_ctx();
+    let mut ctx = create_ctx_on(&swtpm);
     let e = ctx
         .activate_credential(
             wrong_obj,
@@ -836,7 +835,7 @@ fn activate_credential_wrong_key() {
 
 #[test]
 fn activate_credential_wrong_data() {
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let params = KeyParams::Ecc {
         curve: EccCurve::NistP256,
         scheme: EccScheme::create(
@@ -884,7 +883,7 @@ fn activate_credential_wrong_data() {
 #[test]
 fn get_random_from_tkc() {
     // Check that we can convert a reference from TKC to Context
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
     let _rand_bytes = ctx
         .as_mut()
         .execute_without_session(|ctx| ctx.get_random(16))
@@ -894,7 +893,7 @@ fn get_random_from_tkc() {
 #[test]
 fn sign_csr() {
     // Check that we can convert a reference from TKC to Context
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
 
     let key_params = EcSigner::<NistP256, ()>::key_params_default();
     let (tpm_km, _tpm_auth) = ctx.create_key(key_params, 0).expect("create private key");
@@ -919,7 +918,7 @@ fn sign_csr() {
 #[test]
 fn sign_p256_sha2_256() {
     // Check that we can convert a reference from TKC to Context
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
 
     let key_params = EcSigner::<NistP256, ()>::key_params::<sha2::Sha256>();
     let (tpm_km, _tpm_auth) = ctx.create_key(key_params, 0).expect("create private key");
@@ -950,7 +949,7 @@ fn sign_p256_sha2_256() {
 #[test]
 fn sign_p256_sha3_256() {
     // Check that we can convert a reference from TKC to Context
-    let mut ctx = create_ctx();
+    let (_swtpm, mut ctx) = create_ctx();
 
     let key_params = EcSigner::<NistP256, ()>::key_params::<Sha3_256>();
     let (tpm_km, _tpm_auth) = ctx.create_key(key_params, 0).expect("create private key");

--- a/tss-esapi/tests/integration_tests/common/mod.rs
+++ b/tss-esapi/tests/integration_tests/common/mod.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{
     convert::{TryFrom, TryInto},
-    env,
-    str::FromStr,
     sync::Once,
 };
 
@@ -29,13 +27,13 @@ use tss_esapi::{
         Sensitive, Signature, SymmetricCipherParameters, SymmetricDefinition,
         SymmetricDefinitionObject,
     },
-    tcti_ldr::TctiNameConf,
     utils,
 };
 
 mod marshall;
 #[cfg(feature = "serde")]
 mod serde;
+pub mod swtpm;
 mod tpm2b_types_equality_checks;
 mod tpma_types_equality_checks;
 mod tpml_types_equality_checks;
@@ -44,6 +42,7 @@ mod tpmt_types_equality_checks;
 #[cfg(feature = "serde")]
 pub use self::serde::*;
 pub use marshall::*;
+pub use swtpm::{SwtpmSession, create_ctx_with_session, create_ctx_without_session, create_tcti};
 pub use tpm2b_types_equality_checks::*;
 pub use tpma_types_equality_checks::*;
 pub use tpml_types_equality_checks::*;
@@ -185,50 +184,6 @@ pub fn setup_logging() {
     LOG_INIT.call_once(|| {
         env_logger::init();
     });
-}
-
-#[allow(dead_code)]
-pub fn create_tcti() -> TctiNameConf {
-    setup_logging();
-
-    match env::var("TEST_TCTI") {
-        Err(_) => TctiNameConf::Mssim(Default::default()),
-        Ok(tctistr) => TctiNameConf::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
-    }
-}
-
-#[allow(dead_code)]
-pub fn create_ctx_without_session() -> Context {
-    let tcti = create_tcti();
-    Context::new(tcti).unwrap()
-}
-
-#[allow(dead_code)]
-pub fn create_ctx_with_session() -> Context {
-    let mut ctx = create_ctx_without_session();
-    let session = ctx
-        .start_auth_session(
-            None,
-            None,
-            None,
-            SessionType::Hmac,
-            SymmetricDefinition::AES_256_CFB,
-            HashingAlgorithm::Sha256,
-        )
-        .unwrap();
-    let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new()
-        .with_decrypt(true)
-        .with_encrypt(true)
-        .build();
-    ctx.tr_sess_set_attributes(
-        session.unwrap(),
-        session_attributes,
-        session_attributes_mask,
-    )
-    .unwrap();
-    ctx.set_sessions((session, None, None));
-
-    ctx
 }
 
 #[allow(dead_code)]

--- a/tss-esapi/tests/integration_tests/common/swtpm.rs
+++ b/tss-esapi/tests/integration_tests/common/swtpm.rs
@@ -1,0 +1,193 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-test swtpm instance management for isolated, parallel integration tests.
+//!
+//! Each test gets its own `SwtpmSession` which spawns a dedicated swtpm process
+//! communicating over a Unix domain socket in a temporary directory. The session
+//! is cleaned up automatically on drop.
+
+use assert_fs::TempDir;
+use socket2::{Domain, SockAddr, Socket, Type};
+use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
+use std::process::{Child, Stdio};
+use std::time::Duration;
+use tss_esapi::{
+    Context, attributes::SessionAttributesBuilder, constants::SessionType,
+    interface_types::algorithm::HashingAlgorithm, structures::SymmetricDefinition,
+    tcti_ldr::TctiNameConf,
+};
+
+/// Maximum number of swtpm startup attempts before giving up.
+const MAX_SWTPM_RETRIES: usize = 5;
+
+/// An active swtpm session with a temporary directory for state and sockets.
+///
+/// On drop, the swtpm process is killed and the temp directory is cleaned up.
+pub struct SwtpmSession {
+    _process: Child,
+    sock_path: PathBuf,
+    _tmp: TempDir,
+}
+
+impl SwtpmSession {
+    /// Start a new swtpm instance using a Unix domain socket.
+    pub fn new() -> Self {
+        for attempt in 0..MAX_SWTPM_RETRIES {
+            let tmp = TempDir::new().expect("failed to create temp dir");
+            let sock_path = tmp.path().join("swtpm.sock");
+            let ctrl_path = tmp.path().join("swtpm.sock.ctrl");
+
+            let mut process = std::process::Command::new("swtpm")
+                .args([
+                    "socket",
+                    "--tpm2",
+                    "--tpmstate",
+                    &format!("dir={}", tmp.path().display()),
+                    "--server",
+                    &format!("type=unixio,path={}", sock_path.display()),
+                    "--ctrl",
+                    &format!("type=unixio,path={}", ctrl_path.display()),
+                    "--flags",
+                    "startup-clear",
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("failed to start swtpm — is it installed?");
+
+            // Wait for swtpm to be ready by polling the socket.
+            let mut connected = false;
+            for _ in 0..40 {
+                if let Ok(addr) = SockAddr::unix(&sock_path) {
+                    if let Ok(sock) = Socket::new(Domain::UNIX, Type::STREAM, None) {
+                        if sock.connect(&addr).is_ok() {
+                            connected = true;
+                            break;
+                        }
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+
+            if !connected {
+                let _ = process.kill();
+                let _ = process.wait();
+                if attempt + 1 < MAX_SWTPM_RETRIES {
+                    continue;
+                }
+                panic!("swtpm failed to start after {MAX_SWTPM_RETRIES} attempts");
+            }
+
+            return Self {
+                _process: process,
+                sock_path,
+                _tmp: tmp,
+            };
+        }
+        unreachable!()
+    }
+
+    /// Return the TCTI name/configuration for connecting to this swtpm instance.
+    pub fn tcti(&self) -> TctiNameConf {
+        use std::str::FromStr;
+        TctiNameConf::from_str(&format!("swtpm:path={}", self.sock_path.display()))
+            .expect("failed to parse swtpm TCTI string")
+    }
+
+    /// Create an ESAPI `Context` with an HMAC session against this swtpm instance.
+    pub fn create_session_context(&self) -> Context {
+        let mut ctx = Context::new(self.tcti()).unwrap();
+        let session = ctx
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Hmac,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .unwrap();
+        let (session_attributes, session_attributes_mask) = SessionAttributesBuilder::new()
+            .with_decrypt(true)
+            .with_encrypt(true)
+            .build();
+        ctx.tr_sess_set_attributes(
+            session.unwrap(),
+            session_attributes,
+            session_attributes_mask,
+        )
+        .unwrap();
+        ctx.set_sessions((session, None, None));
+        ctx
+    }
+}
+
+impl Drop for SwtpmSession {
+    fn drop(&mut self) {
+        let _ = self._process.kill();
+        let _ = self._process.wait();
+    }
+}
+
+/// A test context that bundles a `SwtpmSession` with an ESAPI `Context`.
+///
+/// Implements `Deref` and `DerefMut` targeting `Context`, so existing test code
+/// that calls methods on `Context` works transparently. The swtpm process stays
+/// alive as long as this struct is held.
+///
+/// Field order matters: `context` is listed first so it is dropped before
+/// `_swtpm`, ensuring the ESAPI context can flush handles while swtpm is
+/// still alive.
+pub struct TestContext {
+    context: Context,
+    _swtpm: SwtpmSession,
+}
+
+impl Deref for TestContext {
+    type Target = Context;
+    fn deref(&self) -> &Context {
+        &self.context
+    }
+}
+
+impl DerefMut for TestContext {
+    fn deref_mut(&mut self) -> &mut Context {
+        &mut self.context
+    }
+}
+
+/// Spawn a fresh swtpm and create an ESAPI `Context` without any session.
+pub fn create_ctx_without_session() -> TestContext {
+    super::setup_logging();
+    let swtpm = SwtpmSession::new();
+    let context = Context::new(swtpm.tcti()).unwrap();
+    TestContext {
+        context,
+        _swtpm: swtpm,
+    }
+}
+
+/// Spawn a fresh swtpm and create an ESAPI `Context` with an HMAC session.
+pub fn create_ctx_with_session() -> TestContext {
+    super::setup_logging();
+    let swtpm = SwtpmSession::new();
+    let context = swtpm.create_session_context();
+    TestContext {
+        _swtpm: swtpm,
+        context,
+    }
+}
+
+/// Spawn a fresh swtpm and return the session along with its TCTI configuration.
+///
+/// This is for code that needs the raw `TctiNameConf` (e.g.
+/// `TransientKeyContextBuilder::with_tcti()`). The caller must keep the
+/// returned `SwtpmSession` alive for the duration of TPM usage.
+pub fn create_tcti() -> (SwtpmSession, TctiNameConf) {
+    super::setup_logging();
+    let swtpm = SwtpmSession::new();
+    let tcti = swtpm.tcti();
+    (swtpm, tcti)
+}

--- a/tss-esapi/tests/integration_tests/context_tests/general_esys_tr_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/general_esys_tr_tests.rs
@@ -1,4 +1,4 @@
-use crate::common::{create_ctx_with_session, create_ctx_without_session, decryption_key_pub};
+use crate::common::{SwtpmSession, create_ctx_without_session, decryption_key_pub};
 use tss_esapi::{
     Context, Error,
     attributes::NvIndexAttributesBuilder,
@@ -454,10 +454,13 @@ mod test_tr_serialize_tr_deserialize {
 
     #[test]
     fn test_tr_serialize_tr_deserialize() -> Result<(), Error> {
+        // Use a shared swtpm so both contexts see the same persistent handles.
+        let swtpm = SwtpmSession::new();
+
         let persistent_addr =
             PersistentTpmHandle::new(u32::from_be_bytes([0x81, 0x00, 0x00, 0x05]))?;
         let persistent = Persistent::Persistent(persistent_addr);
-        let mut context = create_ctx_with_session();
+        let mut context = swtpm.create_session_context();
 
         // Make sure the handle is not already persistent
         if let Ok(clear_handle) =
@@ -482,8 +485,8 @@ mod test_tr_serialize_tr_deserialize {
         let data = context.tr_serialize(persistent_handle)?;
 
         drop(context);
-        // Load handle in a new context
-        let mut new_context = create_ctx_without_session();
+        // Load handle in a new context (same swtpm for persistent handle access)
+        let mut new_context = Context::new(swtpm.tcti())?;
         let new_handle = new_context.tr_deserialize(&data)?.into();
         // Check it is the same key via the public key included in Public
         assert_eq!(public, new_context.read_public(new_handle)?);

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/duplication_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/duplication_commands_tests.rs
@@ -1,9 +1,10 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod test_duplicate {
-    use crate::common::{create_ctx_with_session, create_ctx_without_session};
+    use crate::common::SwtpmSession;
     use std::convert::TryFrom;
     use std::convert::TryInto;
+    use tss_esapi::Context;
     use tss_esapi::attributes::{ObjectAttributesBuilder, SessionAttributesBuilder};
     use tss_esapi::constants::SessionType;
     use tss_esapi::handles::ObjectHandle;
@@ -21,7 +22,9 @@ mod test_duplicate {
 
     #[test]
     fn test_duplicate_and_import() {
-        let mut context = create_ctx_with_session();
+        // Use a shared swtpm so all contexts share TPM state (primary key seeds).
+        let swtpm = SwtpmSession::new();
+        let mut context = swtpm.create_session_context();
 
         // First: create a target parent object.
         // The key that we will duplicate will be a child of this target parent.
@@ -77,7 +80,7 @@ mod test_duplicate {
         // Trial session will be used to compute a policy digest.
         // The policy will allow key duplication to one specified target parent.
         // The target parent would be selected using "parent_name".
-        let mut context = create_ctx_without_session();
+        let mut context = Context::new(swtpm.tcti()).unwrap();
 
         let trial_session = context
             .start_auth_session(
@@ -124,7 +127,7 @@ mod test_duplicate {
             .expect("Could retrieve digest");
 
         drop(context);
-        let mut context = create_ctx_with_session();
+        let mut context = swtpm.create_session_context();
 
         // Fixed TPM and Fixed Parent should be "false" for an object
         // to be eligible for duplication

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/ephemeral_ec_keys_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/ephemeral_ec_keys_tests.rs
@@ -11,7 +11,12 @@ mod test_ec_ephemeral {
             .ec_ephemeral(EccCurve::NistP256)
             .expect("Failed to create EC ephemeral key");
         assert!(!q_point.x().is_empty());
-        assert!(counter > 0);
+
+        // Call again and verify the counter increments.
+        let (_, counter2) = context
+            .ec_ephemeral(EccCurve::NistP256)
+            .expect("Failed to create second EC ephemeral key");
+        assert_eq!(counter2, counter + 1);
     }
 }
 
@@ -79,6 +84,11 @@ mod test_commit {
         let (_k, _l, _e, counter) = context
             .commit(key_handle, EccPoint::default(), None, None)
             .expect("Failed to perform ECC commit");
-        assert!(counter > 0);
+
+        // Call again and verify the counter increments.
+        let (_k2, _l2, _e2, counter2) = context
+            .commit(key_handle, EccPoint::default(), None, None)
+            .expect("Failed to perform second ECC commit");
+        assert_eq!(counter2, counter + 1);
     }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/signing_and_signature_verification_tests.rs
@@ -314,7 +314,7 @@ mod test_sign {
         let mut random = vec![0u8; 47];
         getrandom::getrandom(&mut random).unwrap();
 
-        let signer = EcSigner::<NistP256, _>::new((Mutex::new(&mut context), key_handle)).unwrap();
+        let signer = EcSigner::<NistP256, _>::new((Mutex::new(&mut *context), key_handle)).unwrap();
         let verifying_key = signer.verifying_key();
         let signature: Signature = signer.sign(&random);
 
@@ -345,7 +345,7 @@ mod test_sign {
         getrandom::getrandom(&mut payload).unwrap();
 
         let signer =
-            RsaPkcsSigner::<_, sha2::Sha256>::new((Mutex::new(&mut context), key_handle)).unwrap();
+            RsaPkcsSigner::<_, sha2::Sha256>::new((Mutex::new(&mut *context), key_handle)).unwrap();
         let verifying_key = signer.verifying_key();
         let signature: pkcs1v15::Signature = signer.sign(&payload);
 
@@ -380,7 +380,7 @@ mod test_sign {
         getrandom::getrandom(&mut payload).unwrap();
 
         let signer =
-            RsaPssSigner::<_, sha2::Sha256>::new((Mutex::new(&mut context), key_handle)).unwrap();
+            RsaPssSigner::<_, sha2::Sha256>::new((Mutex::new(&mut *context), key_handle)).unwrap();
         let verifying_key = signer.verifying_key();
         let signature: pss::Signature = signer.sign(&payload);
 

--- a/tss-esapi/tests/integration_tests/tcti_ldr_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/tcti_ldr_tests/mod.rs
@@ -1,16 +1,14 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::str::FromStr;
+use crate::common::SwtpmSession;
 use tss_esapi::tcti_ldr::TctiNameConf;
 
 #[allow(dead_code)]
-pub fn name_conf() -> TctiNameConf {
-    match env::var("TEST_TCTI") {
-        Err(_) => TctiNameConf::Mssim(Default::default()),
-        Ok(tctistr) => TctiNameConf::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
-    }
+pub fn name_conf() -> (SwtpmSession, TctiNameConf) {
+    let swtpm = SwtpmSession::new();
+    let tcti = swtpm.tcti();
+    (swtpm, tcti)
 }
 
 mod tcti_context_tests;

--- a/tss-esapi/tests/integration_tests/tcti_ldr_tests/tcti_context_tests.rs
+++ b/tss-esapi/tests/integration_tests/tcti_ldr_tests/tcti_context_tests.rs
@@ -4,5 +4,6 @@ use tss_esapi::tcti_ldr::TctiContext;
 
 #[test]
 fn new_context() {
-    let _context = TctiContext::initialize(crate::tcti_ldr_tests::name_conf()).unwrap();
+    let (_swtpm, name_conf) = crate::tcti_ldr_tests::name_conf();
+    let _context = TctiContext::initialize(name_conf).unwrap();
 }

--- a/tss-esapi/tests/integration_tests/tcti_ldr_tests/tcti_info_tests.rs
+++ b/tss-esapi/tests/integration_tests/tcti_ldr_tests/tcti_info_tests.rs
@@ -4,7 +4,8 @@ use tss_esapi::tcti_ldr::TctiInfo;
 
 #[test]
 fn new_info() {
-    let info = TctiInfo::get_info(crate::tcti_ldr_tests::name_conf()).unwrap();
+    let (_swtpm, name_conf) = crate::tcti_ldr_tests::name_conf();
+    let info = TctiInfo::get_info(name_conf).unwrap();
     let _version = info.version();
     let _name = info.name();
     let _description = info.description();

--- a/tss-esapi/tests/valgrind.sh
+++ b/tss-esapi/tests/valgrind.sh
@@ -12,21 +12,29 @@ if [[ ! -z ${RUST_TOOLCHAIN_VERSION:+x} ]]; then
 	rustup override set ${RUST_TOOLCHAIN_VERSION}
 fi
 
-#################################
-# Run the TPM simulation server #
-#################################
-tpm_server &
-sleep 5
-tpm2_startup -c -T mssim
-
 ##########################
 # Install cargo-valgrind #
 ##########################
-apt update 
+apt update
 apt install -y valgrind
 cargo install cargo-valgrind
+
+#################################
+# Run the TPM simulation server #
+#################################
+mkdir /tmp/tpmdir
+swtpm_setup --tpm2 \
+    --tpmstate /tmp/tpmdir \
+    --pcr-banks sha1,sha256 \
+    --display
+swtpm socket --tpm2 \
+    --tpmstate dir=/tmp/tpmdir \
+    --flags startup-clear \
+    --ctrl type=unixio,path=/tmp/tpmdir/swtpm.sock.ctrl \
+    --server type=unixio,path=/tmp/tpmdir/swtpm.sock \
+    --daemon
 
 #################
 # Run the tests #
 #################
-TEST_TCTI=mssim: RUST_BACKTRACE=1 RUST_LOG=info cargo valgrind test --  --test-threads=1 --nocapture
+TEST_TCTI="swtpm:path=/tmp/tpmdir/swtpm.sock" RUST_BACKTRACE=1 RUST_LOG=info cargo valgrind test -- --test-threads=1 --nocapture


### PR DESCRIPTION
This PR overhauls the test infrastructure to give each integration test its own dedicated `swtpm` process, while keeping a single shared `swtpm` for doctests. All `swtpm` instances now communicate over Unix domain sockets rather than TCP, and `tpm2-abrmd` is removed from the test path entirely.

Partly addresses #627. Supersedes #630.

### Background

Previously, every integration tests and doctests connected to a single, shared TPM simulator fronted by `tpm2-abrmd`. This had two consequences:

- It was impossible in principle to prevent state leaks during testing, which compromised the reliability of the tests.
- `tpm2-abrmd` appears to have been introduced with the intention of enabling parallel testing on a single shared TPM. However, it does not support parallel execution (since the root cause of blocking is state leakage).

For more details, please refer to the discussion in #627.

### Changes

#### Main changes

- **Per-test swtpm for integration tests**: All integration tests now uses their own `swtpm` instances.
- **Parallelism in testing**: Parallel execution of unit and integration tests are enabled.
- **Shared swtpm for doctests retained**: Since doctests and example code still require a shared TPM instance, we retain a single shared `swtpm` instance in `all-{ubuntu,fedora,opensuse}.sh` and `examples.sh`. Due to state leakage issues, doctests still cannot be run in parallel and are therefore executed sequentially. This decision is based on the discussion in [#630](#630).

#### Other changes

- **Consistent use of swtpm**: Previously the Ubuntu CI used `mssim` while Fedora and openSUSE used `swtpm`. Both now use `swtpm` uniformly, simplifying the CI scripts.
- **tabrmd removed**: The integration tests no longer need TPMRM (each gets a fresh instance).
- **Unix domain sockets**: Both the per-test `swtpm` instances and the shared doctest instances now bind to UDS paths (e.g. `/tmp/tpmdir/swtpm.sock`) rather than TCP ports. This improves performance and effectively prevents port contention.
