### PR TITLE
refactor(test): install valgrind inside Ubuntu container

### DIFF
--- a/tss-esapi/tests/Dockerfile-ubuntu
+++ b/tss-esapi/tests/Dockerfile-ubuntu
@@ -5,6 +5,10 @@ FROM base AS rust-toolchain
 RUN (curl https://sh.rustup.rs -sSf || exit 1) | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# Install cargo-valgrind
+RUN apt-get update && apt-get install -y valgrind && rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-valgrind
+
 FROM rust-toolchain AS tpm2-tss
 # Download and install the TSS library
 ENV TPM2_TSS_BINDINGS_VERSION=4.1.3

--- a/tss-esapi/tests/valgrind.sh
+++ b/tss-esapi/tests/valgrind.sh
@@ -12,13 +12,6 @@ if [[ ! -z ${RUST_TOOLCHAIN_VERSION:+x} ]]; then
 	rustup override set ${RUST_TOOLCHAIN_VERSION}
 fi
 
-##########################
-# Install cargo-valgrind #
-##########################
-apt update
-apt install -y valgrind
-cargo install cargo-valgrind
-
 #############################################
 # Run the TPM simulation server for doctest #
 #############################################


### PR DESCRIPTION
Move the valgrind installation step from `valgrind.sh` to `Dockerfile-ubuntu` so the test script no longer assumes a Debian/Ubuntu host (no more hard-coded `apt`). It makes `valgrind.sh` distro-independent, allowing it to be reused on other Linux distributions (e.g. Fedora) and run locally outside of CI without modification.

### Note

The Fedora and openSUSE Dockerfiles are presently scoped to `cargo test` only — in particular, the openSUSE image invokes `all-opensuse.sh` as its entrypoint and is not reusable for other purposes. Updating those Dockerfiles to install the same tooling as `Dockerfile-ubuntu` would enable running the full CI matrix (including valgrind) across all distros, but that work is intentionally *out of scope* for this PR.