### PR TITLE
test(esapi): remove dbus-run-session from Docker runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu --target tpm2-tools
       - name: Run the container
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
       - name: Run the cross-compilation script
         run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/cross-compile.sh
 
@@ -54,7 +54,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --build-arg TPM2_TSS_VERSION=4.1.3 --file tss-esapi/tests/Dockerfile-ubuntu --target tpm2-tools
       - name: Run the container
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
 
   test-ubuntu-v4-path:
     name: Ubuntu tests on v4.x.y of tpm2-tss libraries found using a path
@@ -64,7 +64,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --build-arg TPM2_TSS_VERSION=4.1.3 --file tss-esapi/tests/Dockerfile-ubuntu --target tpm2-tss-install-dir
       - name: Run the container
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-ubuntu.sh
 
   tests-fedora:
     name: Fedora tests
@@ -75,7 +75,7 @@ jobs:
       - name: Build the container
         run: docker build -t fedoracontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-fedora
       - name: Run the tests
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env USE_FROZEN_LOCKFILE=1 fedoracontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-fedora.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env USE_FROZEN_LOCKFILE=1 fedoracontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-fedora.sh
 
   tests-fedora-rawhide:
     name: Fedora rawhide tests
@@ -86,7 +86,7 @@ jobs:
       - name: Build the container
         run: docker build -t fedoracontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-fedora-rawhide
       - name: Run the tests
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --security-opt seccomp=unconfined fedoracontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/all-fedora.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --security-opt seccomp=unconfined fedoracontainer /tmp/rust-tss-esapi/tss-esapi/tests/all-fedora.sh
 
   tests-valgrind:
     name: Valgrind test run
@@ -96,7 +96,7 @@ jobs:
       - name: Build the container
         run: docker build -t ubuntucontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-ubuntu --target tpm2-tools
       - name: Run the tests
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi -e RUST_TOOLCHAIN_VERSION="1.87" ubuntucontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/valgrind.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi -e RUST_TOOLCHAIN_VERSION="1.87" ubuntucontainer /tmp/rust-tss-esapi/tss-esapi/tests/valgrind.sh
 
   # Check that the documentation builds as well.
   docs:
@@ -144,4 +144,4 @@ jobs:
       - name: Build the container
         run: docker build -t fedoracontainer tss-esapi/tests/ --file tss-esapi/tests/Dockerfile-fedora
       - name: Run the container
-        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env USE_FROZEN_LOCKFILE=1 fedoracontainer dbus-run-session -- /tmp/rust-tss-esapi/tss-esapi/tests/examples.sh
+        run: docker run -v $(pwd):/tmp/rust-tss-esapi -w /tmp/rust-tss-esapi/tss-esapi --env USE_FROZEN_LOCKFILE=1 fedoracontainer /tmp/rust-tss-esapi/tss-esapi/tests/examples.sh


### PR DESCRIPTION
Since `tpm2-abrmd` is no longer used, `dbus-run-session` is also no longer needed. This pull request remove all unnecessary `dbus-run-session` in the CI workflow.
