### PR TITLE
refactor(ci): containerize run-ci-locally.sh

### DIFF
--- a/tss-esapi/tests/Dockerfile-fedora-full
+++ b/tss-esapi/tests/Dockerfile-fedora-full
@@ -1,0 +1,38 @@
+# Copyright 2026 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Self-contained Fedora image for run-ci-locally.sh.
+# Includes everything every CI job needs.
+
+FROM fedora:42
+
+RUN dnf install -y \
+    libtool automake autoconf autoconf-archive openssl-devel-engine \
+    swtpm swtpm-tools llvm llvm-devel clang pkg-config \
+    git valgrind codespell tpm2-tools \
+    && dnf builddep -y tpm2-tss \
+    && dnf clean all
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | bash -s -- -y --default-toolchain stable --profile minimal \
+        --component rustfmt --component clippy
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN rustup toolchain install 1.85.0 --profile minimal \
+        --component rustfmt --component clippy
+
+RUN cargo install cargo-valgrind
+
+# Download and install the TSS library
+ENV TPM2_TSS_BINDINGS_VERSION=4.1.3
+ARG TPM2_TSS_VERSION=$TPM2_TSS_BINDINGS_VERSION
+ENV TPM2_TSS_VERSION=$TPM2_TSS_VERSION
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch $TPM2_TSS_VERSION
+RUN cd tpm2-tss \
+	&& ./bootstrap \
+	&& ./configure \
+	&& make -j$(nproc) \
+	&& make install \
+	&& ldconfig

--- a/tss-esapi/tests/Dockerfile-fedora-full
+++ b/tss-esapi/tests/Dockerfile-fedora-full
@@ -9,7 +9,7 @@ FROM fedora:42
 RUN dnf install -y \
     libtool automake autoconf autoconf-archive openssl-devel-engine \
     swtpm swtpm-tools llvm llvm-devel clang pkg-config \
-    git valgrind codespell tpm2-tools \
+    git valgrind codespell tpm2-tools rsync \
     && dnf builddep -y tpm2-tss \
     && dnf clean all
 
@@ -35,4 +35,5 @@ RUN cd tpm2-tss \
 	&& ./configure \
 	&& make -j$(nproc) \
 	&& make install \
-	&& ldconfig
+	&& ldconfig \
+    && rm -rf /tpm2-tss

--- a/tss-esapi/tests/Dockerfile-ubuntu-full
+++ b/tss-esapi/tests/Dockerfile-ubuntu-full
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     libtool libcmocka0 libcmocka-dev libcurl4-openssl-dev libftdi-dev libini-config-dev \
     libjson-c-dev libltdl-dev libssl-dev libusb-1.0-0-dev uthash-dev uuid-dev \
     swtpm swtpm-tools llvm clang pkg-config \
-    curl git valgrind codespell tpm2-tools \
+    curl git valgrind codespell tpm2-tools rsync \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
@@ -36,4 +36,5 @@ RUN cd tpm2-tss \
 	&& ./configure \
 	&& make -j$(nproc) \
 	&& make install \
-	&& ldconfig
+	&& ldconfig \
+    && rm -rf /tpm2-tss

--- a/tss-esapi/tests/Dockerfile-ubuntu-full
+++ b/tss-esapi/tests/Dockerfile-ubuntu-full
@@ -1,0 +1,39 @@
+# Copyright 2026 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Self-contained Ubuntu image for run-ci-locally.sh.
+# Includes everything every CI job needs.
+
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    autoconf autoconf-archive automake build-essential doxygen pkg-config \
+    libtool libcmocka0 libcmocka-dev libcurl4-openssl-dev libftdi-dev libini-config-dev \
+    libjson-c-dev libltdl-dev libssl-dev libusb-1.0-0-dev uthash-dev uuid-dev \
+    swtpm swtpm-tools llvm clang pkg-config \
+    curl git valgrind codespell tpm2-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | bash -s -- -y --default-toolchain stable --profile minimal \
+        --component rustfmt --component clippy
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN rustup toolchain install 1.85.0 --profile minimal \
+        --component rustfmt --component clippy
+
+RUN cargo install cargo-valgrind
+
+# Download and install the TSS library
+ENV TPM2_TSS_BINDINGS_VERSION=4.1.3
+ARG TPM2_TSS_VERSION=$TPM2_TSS_BINDINGS_VERSION
+ENV TPM2_TSS_VERSION=$TPM2_TSS_VERSION
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch $TPM2_TSS_VERSION
+RUN cd tpm2-tss \
+	&& ./bootstrap \
+	&& ./configure \
+	&& make -j$(nproc) \
+	&& make install \
+	&& ldconfig

--- a/tss-esapi/tests/run-ci-locally.sh
+++ b/tss-esapi/tests/run-ci-locally.sh
@@ -13,7 +13,9 @@ set -euf -o pipefail
 #################
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-PROJECT_DIR_IN_CONTAINER="/tmp/rust-tss-esapi"
+
+SOURCE_DIR_IN_CONTAINER="/src"
+PROJECT_DIR_IN_CONTAINER="/work"
 CRATE_DIR_IN_CONTAINER="${PROJECT_DIR_IN_CONTAINER}/tss-esapi"
 
 DEFAULT_DOCKERFILE="Dockerfile-fedora-full"
@@ -40,12 +42,15 @@ RESET='\033[0m'
 ###########
 # Helpers #
 ###########
+CONTAINER_BOOTSTRAP="rsync -a --exclude=/target ${SOURCE_DIR_IN_CONTAINER}/ ${PROJECT_DIR_IN_CONTAINER}/ \
+    && cd ${CRATE_DIR_IN_CONTAINER} \
+    && exec \"\$@\""
+
 function in_container {
     "${TSS_ESAPI_CONTAINER_RUNTIME}" run --rm \
-        -v "${PROJECT_DIR}:${PROJECT_DIR_IN_CONTAINER}" \
-        -w "${CRATE_DIR_IN_CONTAINER}" \
+        -v "${PROJECT_DIR}:${SOURCE_DIR_IN_CONTAINER}:ro" \
         "${TSS_ESAPI_IMAGE_TAG}" \
-        "$@"
+        bash -c "${CONTAINER_BOOTSTRAP}" -- "$@"
 }
 
 function in_container_env {
@@ -57,10 +62,9 @@ function in_container_env {
     done
     "${TSS_ESAPI_CONTAINER_RUNTIME}" run --rm \
         "${envs[@]}" \
-        -v "${PROJECT_DIR}:${PROJECT_DIR_IN_CONTAINER}" \
-        -w "${CRATE_DIR_IN_CONTAINER}" \
+        -v "${PROJECT_DIR}:${SOURCE_DIR_IN_CONTAINER}:ro" \
         "${TSS_ESAPI_IMAGE_TAG}" \
-        "$@"
+        bash -c "${CONTAINER_BOOTSTRAP}" -- "$@"
 }
 
 function run_job {
@@ -118,6 +122,7 @@ function check_required_tools {
         "codespell:codespell"
         "pkg-config:pkg-config"
         "clang:Clang/LLVM"
+        "rsync:rsync (used by the in_container bootstrap to stage source)"
     )
 
     local cmd_names=()
@@ -127,13 +132,15 @@ function check_required_tools {
 
     echo -e "${BOLD}Checking required tools in image...${RESET}"
     local missing
-    missing=$(in_container bash -c "
-        for cmd in ${cmd_names[*]}; do
-            if ! command -v \"\$cmd\" >/dev/null 2>&1; then
-                echo \"\$cmd\"
-            fi
-        done
-    " || true)
+    missing=$("${TSS_ESAPI_CONTAINER_RUNTIME}" run --rm \
+        "${TSS_ESAPI_IMAGE_TAG}" \
+        bash -c "
+            for cmd in ${cmd_names[*]}; do
+                if ! command -v \"\$cmd\" >/dev/null 2>&1; then
+                    echo \"\$cmd\"
+                fi
+            done
+        " || true)
 
     if [[ -n "$missing" ]]; then
         echo "ERROR: Missing required tools in image ${TSS_ESAPI_IMAGE_TAG}:"
@@ -176,15 +183,11 @@ function job_formatting {
 }
 
 function job_msrv {
-    local lockfile="${PROJECT_DIR}/Cargo.lock"
-    local backup="${lockfile}.bak"
-    cp -p -- "${lockfile}" "${backup}"
     run_job "MSRV build (${TSS_ESAPI_MSRV})" \
         in_container_env RUST_TOOLCHAIN_VERSION="${TSS_ESAPI_MSRV}" \
             bash -c 'rustup override set "${RUST_TOOLCHAIN_VERSION}" \
                 && cp tests/Cargo.lock.frozen ../Cargo.lock \
                 && cargo build -p tss-esapi'
-    mv -- "${backup}" "${lockfile}"
 }
 
 function job_build {

--- a/tss-esapi/tests/run-ci-locally.sh
+++ b/tss-esapi/tests/run-ci-locally.sh
@@ -3,74 +3,32 @@
 # Copyright 2026 Contributors to the Parsec project.
 # SPDX-License-Identifier: Apache-2.0
 
-# Run CI checks locally on Fedora with a swtpm simulator.
-# Replicates the CI jobs from .github/workflows/ci.yml without Docker.
-#
-# Usage: dbus-run-session -- ./tests/run-ci-locally.sh [JOB...]
-#
-# JOB can be a number, a keyword, or a display name (case-insensitive):
-#   1  spelling          "Check spelling"
-#   2  formatting        "Check formatting"
-#   3  msrv              "MSRV build (1.85.0)"
-#   4  build             "Build with generate-bindings"
-#   5  clippy-msrv       "Clippy MSRV (1.85.0)"
-#   6  clippy-latest     "Clippy latest"
-#   7  docs              "Check documentation"
-#   8  tests             "Tests with generate-bindings"
-#   9  valgrind          "Valgrind tests (1.85.0)"
-#   all                  Run all jobs
-#   list                 Show available jobs
-#
-# If no JOB is given, "all" is assumed.
-# Multiple jobs can be specified: ./tests/run-ci-locally.sh 5 6 docs
-#
-# Prerequisites (Fedora):
-#   dnf install swtpm swtpm-tools tpm2-abrmd tpm2-tools tpm2-tss-devel \
-#               rust clippy cargo llvm llvm-devel clang pkg-config \
-#               codespell dbus-daemon
+# Run CI checks locally inside a container, mirroring .github/workflows/ci.yml.
+# See `./tests/run-ci-locally.sh help` for usage.
 
 set -euf -o pipefail
 
-##########################
-# Check required tools   #
-##########################
-REQUIRED_CMDS=(
-    "cargo:Rust toolchain"
-    "rustup:Rust toolchain manager"
-    "clippy-driver:Clippy (rustup component add clippy)"
-    "rustfmt:rustfmt (rustup component add rustfmt)"
-    "pkg-config:pkg-config"
-    "clang:Clang/LLVM"
-    "swtpm:Software TPM (swtpm)"
-    "swtpm_setup:Software TPM setup (swtpm-tools)"
-    "tpm2-abrmd:TPM2 Access Broker (tpm2-abrmd)"
-    "tpm2_pcrread:TPM2 tools (tpm2-tools)"
-)
-
-MISSING=()
-for entry in "${REQUIRED_CMDS[@]}"; do
-    cmd="${entry%%:*}"
-    desc="${entry#*:}"
-    if ! command -v "$cmd" &>/dev/null; then
-        MISSING+=("  - $cmd ($desc)")
-    fi
-done
-
-if [[ ${#MISSING[@]} -gt 0 ]]; then
-    echo "ERROR: Missing required tools:"
-    printf '%s\n' "${MISSING[@]}"
-    echo ""
-    echo "Install them and try again."
-    exit 1
-fi
-
+#################
+# Configuration #
+#################
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-CRATE_DIR="${PROJECT_DIR}/tss-esapi"
+PROJECT_DIR_IN_CONTAINER="/tmp/rust-tss-esapi"
+CRATE_DIR_IN_CONTAINER="${PROJECT_DIR_IN_CONTAINER}/tss-esapi"
 
+DEFAULT_DOCKERFILE="Dockerfile-fedora-full"
+DEFAULT_IMAGE_TAG="rust-tss-esapi-fedora:latest"
+
+TSS_ESAPI_MSRV="${TSS_ESAPI_MSRV:-1.85.0}"
+TSS_ESAPI_CONTAINER_RUNTIME="${TSS_ESAPI_CONTAINER_RUNTIME:-docker}"
+TSS_ESAPI_DOCKERFILE="${TSS_ESAPI_DOCKERFILE:-${SCRIPT_DIR}/${DEFAULT_DOCKERFILE}}"
+TSS_ESAPI_IMAGE_TAG="${TSS_ESAPI_IMAGE_TAG:-${DEFAULT_IMAGE_TAG}}"
+
+##############
+# CI results #
+##############
 PASS=0
 FAIL=0
-SKIP=0
 RESULTS=()
 
 RED='\033[0;31m'
@@ -79,59 +37,30 @@ YELLOW='\033[0;33m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
-SWTPM_PID=""
-ABRMD_PID=""
-TPMDIR=""
-
-function cleanup {
-    if [[ -n "$ABRMD_PID" ]]; then
-        kill "$ABRMD_PID" 2>/dev/null || true
-        wait "$ABRMD_PID" 2>/dev/null || true
-    fi
-    if [[ -n "$SWTPM_PID" ]]; then
-        kill "$SWTPM_PID" 2>/dev/null || true
-        wait "$SWTPM_PID" 2>/dev/null || true
-    fi
-    if [[ -n "$TPMDIR" && -d "$TPMDIR" ]]; then
-        rm -rf "$TPMDIR"
-    fi
+###########
+# Helpers #
+###########
+function in_container {
+    "${TSS_ESAPI_CONTAINER_RUNTIME}" run --rm \
+        -v "${PROJECT_DIR}:${PROJECT_DIR_IN_CONTAINER}" \
+        -w "${CRATE_DIR_IN_CONTAINER}" \
+        "${TSS_ESAPI_IMAGE_TAG}" \
+        "$@"
 }
-trap cleanup EXIT
 
-function start_tpm {
-    if [[ -n "$SWTPM_PID" ]]; then
-        return
-    fi
-
-    # Kill leftover processes from previous runs
-    pkill -f "swtpm socket.*port=2321" 2>/dev/null || true
-    pkill -f "tpm2-abrmd" 2>/dev/null || true
-    sleep 1
-
-    TPMDIR=$(mktemp -d)
-    swtpm_setup --tpm2 \
-        --tpmstate "${TPMDIR}" \
-        --createek --decryption --create-ek-cert \
-        --create-platform-cert \
-        --pcr-banks sha1,sha256 \
-        --display
-
-    swtpm socket --tpm2 \
-        --tpmstate dir="${TPMDIR}" \
-        --flags startup-clear \
-        --ctrl type=tcp,port=2322 \
-        --server type=tcp,port=2321 \
-        --daemon
-    SWTPM_PID=$(pgrep -n swtpm)
-
-    tpm2-abrmd \
-        --logger=stdout \
-        --tcti=swtpm: \
-        --allow-root \
-        --session \
-        --flush-all &
-    ABRMD_PID=$!
-    sleep 2
+function in_container_env {
+    # Like in_container but takes KEY=VAL env pairs before the command.
+    local envs=()
+    while [[ $# -gt 0 && "$1" == *"="* ]]; do
+        envs+=(-e "$1")
+        shift
+    done
+    "${TSS_ESAPI_CONTAINER_RUNTIME}" run --rm \
+        "${envs[@]}" \
+        -v "${PROJECT_DIR}:${PROJECT_DIR_IN_CONTAINER}" \
+        -w "${CRATE_DIR_IN_CONTAINER}" \
+        "${TSS_ESAPI_IMAGE_TAG}" \
+        "$@"
 }
 
 function run_job {
@@ -148,104 +77,147 @@ function run_job {
     fi
 }
 
-function skip_job {
-    local name="$1"
-    local reason="$2"
-    echo ""
-    echo -e "${BOLD}======== ${name} ========${RESET}"
-    echo -e "${YELLOW}SKIP: ${reason}${RESET}"
-    RESULTS+=("${YELLOW}SKIP${RESET} ${name} (${reason})")
-    ((SKIP++)) || true
+####################
+# Setup functions  #
+####################
+# Verify the configured runtime and Dockerfile exist on the host.
+function preflight {
+    if ! command -v "${TSS_ESAPI_CONTAINER_RUNTIME}" &>/dev/null; then
+        echo "ERROR: container runtime '${TSS_ESAPI_CONTAINER_RUNTIME}' not found in PATH"
+        echo "       (set TSS_ESAPI_CONTAINER_RUNTIME to override)"
+        exit 1
+    fi
+    if [[ ! -f "${TSS_ESAPI_DOCKERFILE}" ]]; then
+        echo "ERROR: Dockerfile not found: ${TSS_ESAPI_DOCKERFILE}"
+        echo "       (set TSS_ESAPI_DOCKERFILE to override)"
+        exit 1
+    fi
 }
 
-function job_spelling {
-    cd "${CRATE_DIR}"
-    if codespell --version &>/dev/null; then
-        run_job "Check spelling" \
-            codespell --ignore-words-list "crate,daa,keypair,AcSend,ser" \
-            --skip "*/target,*-sys,${CRATE_DIR}/examples/symmetric_file_encrypt_decrypt_example.txt" \
-            "${CRATE_DIR}"
-    else
-        skip_job "Check spelling" "codespell not installed"
+# Build (or rebuild via cache) the image used to run jobs.
+function build_image {
+    echo -e "${BOLD}Building image ${TSS_ESAPI_IMAGE_TAG} from ${TSS_ESAPI_DOCKERFILE}...${RESET}"
+    "${TSS_ESAPI_CONTAINER_RUNTIME}" build \
+        -t "${TSS_ESAPI_IMAGE_TAG}" \
+        -f "${TSS_ESAPI_DOCKERFILE}" \
+        "$(dirname "${TSS_ESAPI_DOCKERFILE}")"
+}
+
+# Probe the image once for every binary the jobs depend on. Abort with a
+# combined "ERROR: Missing required tools" report if any are absent.
+function check_required_tools {
+    local required_cmds=(
+        "cargo:Rust toolchain"
+        "rustup:Rust toolchain manager"
+        "rustfmt:rustfmt (rustup component add rustfmt)"
+        "clippy-driver:Clippy (rustup component add clippy)"
+        "swtpm:Software TPM (swtpm)"
+        "swtpm_setup:Software TPM setup (swtpm-tools)"
+        "valgrind:Valgrind"
+        "cargo-valgrind:cargo-valgrind subcommand (cargo install cargo-valgrind)"
+        "codespell:codespell"
+        "pkg-config:pkg-config"
+        "clang:Clang/LLVM"
+    )
+
+    local cmd_names=()
+    for entry in "${required_cmds[@]}"; do
+        cmd_names+=("${entry%%:*}")
+    done
+
+    echo -e "${BOLD}Checking required tools in image...${RESET}"
+    local missing
+    missing=$(in_container bash -c "
+        for cmd in ${cmd_names[*]}; do
+            if ! command -v \"\$cmd\" >/dev/null 2>&1; then
+                echo \"\$cmd\"
+            fi
+        done
+    " || true)
+
+    if [[ -n "$missing" ]]; then
+        echo "ERROR: Missing required tools in image ${TSS_ESAPI_IMAGE_TAG}:"
+        while IFS= read -r missing_cmd; do
+            for entry in "${required_cmds[@]}"; do
+                local cmd="${entry%%:*}"
+                local desc="${entry#*:}"
+                if [[ "$cmd" == "$missing_cmd" ]]; then
+                    echo "  - $cmd ($desc)"
+                    break
+                fi
+            done
+        done <<< "$missing"
+        echo ""
+        echo "Either fix the Dockerfile (${TSS_ESAPI_DOCKERFILE}) or use the default {$DEFAULT_DOCKERFILE}."
+        exit 1
     fi
+}
+
+# One-shot setup wrapper called before any test job runs.
+function ensure_image_ready {
+    preflight
+    build_image
+    check_required_tools
+}
+
+###################
+# Job definitions #
+###################
+function job_spelling {
+    run_job "Check spelling" \
+        in_container codespell \
+            --ignore-words-list "crate,daa,keypair,AcSend,ser" \
+            --exclude-file examples/symmetric_file_encrypt_decrypt_example.txt
 }
 
 function job_formatting {
-    cd "${PROJECT_DIR}"
-    run_job "Check formatting" cargo fmt --all -- --check
+    run_job "Check formatting" \
+        in_container cargo fmt --all -- --check
 }
 
 function job_msrv {
-    cd "${CRATE_DIR}"
-    if rustup toolchain list | grep -q "1.85"; then
-        cp tests/Cargo.lock.frozen ../Cargo.lock
-        run_job "MSRV build (1.85.0)" cargo +1.85.0 build -p tss-esapi
-        rm -f ../Cargo.lock
-    else
-        skip_job "MSRV build (1.85.0)" "rustup toolchain 1.85.0 not installed (rustup install 1.85.0)"
-    fi
+    local lockfile="${PROJECT_DIR}/Cargo.lock"
+    local backup="${lockfile}.bak"
+    cp -p -- "${lockfile}" "${backup}"
+    run_job "MSRV build (${TSS_ESAPI_MSRV})" \
+        in_container_env RUST_TOOLCHAIN_VERSION="${TSS_ESAPI_MSRV}" \
+            bash -c 'rustup override set "${RUST_TOOLCHAIN_VERSION}" \
+                && cp tests/Cargo.lock.frozen ../Cargo.lock \
+                && cargo build -p tss-esapi'
+    mv -- "${backup}" "${lockfile}"
 }
 
 function job_build {
-    cd "${CRATE_DIR}"
     run_job "Build with generate-bindings" \
-        cargo build --features generate-bindings
+        in_container cargo build --features generate-bindings
 }
 
 function job_clippy_msrv {
-    cd "${CRATE_DIR}"
-    if rustup toolchain list | grep -q "1.85"; then
-        cp tests/Cargo.lock.frozen ../Cargo.lock
-        run_job "Clippy MSRV (1.85.0)" \
-            cargo +1.85.0 clippy --all-targets --all-features -- -D clippy::all -D clippy::cargo
-        rm -f ../Cargo.lock
-    else
-        skip_job "Clippy MSRV (1.85.0)" "rustup toolchain 1.85.0 not installed"
-    fi
+    run_job "Clippy MSRV (${TSS_ESAPI_MSRV})" \
+        in_container_env RUST_TOOLCHAIN_VERSION="${TSS_ESAPI_MSRV}" \
+            ./tests/lint-checks.sh
 }
 
 function job_clippy_latest {
-    cd "${CRATE_DIR}"
     run_job "Clippy latest" \
-        cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::cargo
+        in_container ./tests/lint-checks.sh
 }
 
 function job_docs {
-    cd "${CRATE_DIR}"
     run_job "Check documentation" \
-        env RUSTDOCFLAGS="-Dwarnings" cargo doc --document-private-items --no-deps
+        in_container_env RUSTDOCFLAGS=-Dwarnings \
+            cargo doc --document-private-items --no-deps
 }
 
 function job_tests {
-    cd "${CRATE_DIR}"
-    start_tpm
     run_job "Tests with generate-bindings" \
-        env TEST_TCTI=tabrmd:bus_type=session \
-            RUST_BACKTRACE=1 RUST_LOG=info \
-        cargo test --features generate-bindings -- --test-threads=1 --nocapture
+        in_container ./tests/all-fedora.sh
 }
 
 function job_valgrind {
-    cd "${CRATE_DIR}"
-    if ! command -v valgrind &>/dev/null; then
-        skip_job "Valgrind tests" "valgrind not installed"
-        return
-    fi
-    if ! cargo valgrind --help &>/dev/null; then
-        skip_job "Valgrind tests" "cargo-valgrind not installed (cargo install cargo-valgrind)"
-        return
-    fi
-    start_tpm
-    if rustup toolchain list | grep -q "1.85"; then
-        cp tests/Cargo.lock.frozen ../Cargo.lock
-        run_job "Valgrind tests (1.85.0)" \
-            env TEST_TCTI=tabrmd:bus_type=session \
-                RUST_BACKTRACE=1 RUST_LOG=info \
-            cargo +1.85.0 valgrind test -- --test-threads=1 --nocapture
-        rm -f ../Cargo.lock
-    else
-        skip_job "Valgrind tests (1.85.0)" "rustup toolchain 1.85.0 not installed"
-    fi
+    run_job "Valgrind tests (${TSS_ESAPI_MSRV})" \
+        in_container_env RUST_TOOLCHAIN_VERSION="${TSS_ESAPI_MSRV}" \
+            ./tests/valgrind.sh
 }
 
 function print_summary {
@@ -255,7 +227,7 @@ function print_summary {
         echo -e "  $r"
     done
     echo ""
-    echo -e "  ${GREEN}${PASS} passed${RESET}, ${RED}${FAIL} failed${RESET}, ${YELLOW}${SKIP} skipped${RESET}"
+    echo -e "  ${GREEN}${PASS} passed${RESET}, ${RED}${FAIL} failed${RESET}"
 
     if [[ $FAIL -gt 0 ]]; then
         echo ""
@@ -268,42 +240,67 @@ function print_summary {
     fi
 }
 
-# Job registry: NUM:KEYWORD:DISPLAY_NAME:FUNCTION
+################
+# Job registry #
+################
 JOB_REGISTRY=(
     "1:spelling:Check spelling:job_spelling"
     "2:formatting:Check formatting:job_formatting"
-    "3:msrv:MSRV build (1.85.0):job_msrv"
+    "3:msrv:MSRV build (${TSS_ESAPI_MSRV}):job_msrv"
     "4:build:Build with generate-bindings:job_build"
-    "5:clippy-msrv:Clippy MSRV (1.85.0):job_clippy_msrv"
+    "5:clippy-msrv:Clippy MSRV (${TSS_ESAPI_MSRV}):job_clippy_msrv"
     "6:clippy-latest:Clippy latest:job_clippy_latest"
     "7:docs:Check documentation:job_docs"
     "8:tests:Tests with generate-bindings:job_tests"
-    "9:valgrind:Valgrind tests (1.85.0):job_valgrind"
+    "9:valgrind:Valgrind tests (${TSS_ESAPI_MSRV}):job_valgrind"
 )
 
 ALL_ORDER=(1 2 3 4 5 6 7 8 9)
 
-function list_jobs {
-    echo "Available jobs:"
+function show_help {
+    cat <<EOF
+Run CI checks locally inside a container, mirroring .github/workflows/ci.yml.
+
+Usage: ./tests/run-ci-locally.sh [JOB...]
+
+If no JOB is given, this help is shown. Use 'all' to run every job.
+
+Available jobs:
+EOF
     for entry in "${JOB_REGISTRY[@]}"; do
         IFS=: read -r num keyword display _func <<< "$entry"
-        printf "  %s  %-16s  %s\n" "$num" "$keyword" "\"$display\""
+        printf "  %s  %-16s  %s\n" "$num" "$keyword" "$display"
     done
-    echo ""
-    echo "  all                 Run all jobs"
-    echo "  list                Show this list"
+    cat <<EOF
+  all                  Run all jobs
+  help                 Show this help
+
+JOB can be the number, the keyword, or the display name (case-insensitive).
+Multiple jobs may be specified, e.g.: ./tests/run-ci-locally.sh 5 6 docs
+
+Environment variables:
+  TSS_ESAPI_MSRV               MSRV (default: 1.85.0)
+  TSS_ESAPI_CONTAINER_RUNTIME  Docker-compatible container runtime
+                               (default: docker; e.g. podman)
+  TSS_ESAPI_DOCKERFILE         Path to the Dockerfile to build from
+                               (default: ./Dockerfile-fedora-full)
+  TSS_ESAPI_IMAGE_TAG          Image tag
+                               (default: rust-tss-esapi-fedora:latest)
+
+If the image is missing required tools (rustup, swtpm, valgrind, codespell,
+etc.), the script aborts before running any job.
+
+EOF
 }
 
 function resolve_job {
     local input="$1"
     local input_lower
     input_lower=$(echo "$input" | tr '[:upper:]' '[:lower:]')
-
     for entry in "${JOB_REGISTRY[@]}"; do
         IFS=: read -r num keyword display func <<< "$entry"
         local display_lower
         display_lower=$(echo "$display" | tr '[:upper:]' '[:lower:]')
-
         if [[ "$input" == "$num" || "$input_lower" == "$keyword" || "$input_lower" == "$display_lower" ]]; then
             echo "$func"
             return 0
@@ -312,11 +309,25 @@ function resolve_job {
     return 1
 }
 
-# Parse arguments
+####################
+# Argument parsing #
+####################
 JOBS=("$@")
 if [[ ${#JOBS[@]} -eq 0 ]]; then
-    JOBS=("all")
+    JOBS=("help")
 fi
+
+# If the user asked for help (alone or alongside other jobs), short-circuit.
+# No image setup, no jobs run.
+for job in "${JOBS[@]}"; do
+    if [[ "$job" == "help" || "$job" == "--help" || "$job" == "-h" ]]; then
+        show_help
+        exit 0
+    fi
+done
+
+# Real work: build the image and verify it's complete before running anything.
+ensure_image_ready
 
 for job in "${JOBS[@]}"; do
     if [[ "$job" == "all" ]]; then
@@ -324,9 +335,6 @@ for job in "${JOBS[@]}"; do
             func=$(resolve_job "$num")
             "$func"
         done
-    elif [[ "$job" == "list" || "$job" == "--list" || "$job" == "-l" ]]; then
-        list_jobs
-        exit 0
     else
         func=$(resolve_job "$job")
         if [[ -n "$func" ]]; then
@@ -334,7 +342,7 @@ for job in "${JOBS[@]}"; do
         else
             echo "Unknown job: $job"
             echo ""
-            list_jobs
+            show_help
             exit 1
         fi
     fi


### PR DESCRIPTION
This pull request restructures the local CI script `run-ci-locally.sh` (originally introduced in #636) so that every job runs inside a container and dispatches into the same test scripts (`all-fedora.sh`, `lint-checks.sh`, ...) that GitHub Actions (`ci.yml`) invokes. This change ensures sync between local CI and GitHub CI, eliminating code duplication between the two.

The Docker files `Dockerfile-fedora-full` and `Dockerfile-ubuntu-full` are added as the default images for local CI runs (separate from the Docker files for GitHub Actions, since local CI may require extra tools like `codespell`).

Based on the discussion with the original author in #635.

### User-facing changes

- The following parameters are now configurable:
  - `TSS_ESAPI_MSRV` - MSRV (default: `1.85.0`)
  - `TSS_ESAPI_CONTAINER_RUNTIME` - Docker-compatible container runtime (default: `docker`; e.g. `podman`)
  - `TSS_ESAPI_DOCKERFILE` - Docker file where the local CI runs (default: `tss-esapi/tests/Dockerfile-fedora-all`)
  - `TSS_ESAPI_IMAGE_TAG` - Tag for the container built (default: `tss-esapi-fedora:latest`)
- `help` replaces `list`; running with no args now prints help instead of running every job.

### Testing

```sh
sudo apt update

# Docker runtime
sudo apt install -y docker.io
sudo usermod -aG docker "$USER"
newgrp docker

# Podman runtime
sudo apt install -y podman

# Clone this branch
git clone https://github.com/hyperfinitism/rust-tss-esapi -b feature/containerise-local-ci
cd rust-tss-esapi/tss-esapi

# Show help
./tests/run-ci-locally.sh help

# Run all CI jobs inside Fedora container via Docker
./tests/run-ci-locally.sh all

# Run all CI jobs inside Ubuntu container via Docker
TSS_ESAPI_DOCKERFILE="tests/Dockerfile-ubuntu-full" TSS_ESAPI_IMAGE_TAG="rust-tss-esapi-ubuntu:latest" ./tests/run-ci-locally.sh all

# Run specific CI jobs inside Fedora container via Podman
TSS_ESAPI_CONTAINER_RUNTIME="podman" ./tests/run-ci-locally.sh clippy-msrv docs
```

Expected:

```text
======== Summary ========
  PASS Check spelling
  PASS Check formatting
  PASS MSRV build (1.85.0)
  PASS Build with generate-bindings
  PASS Clippy MSRV (1.85.0)
  PASS Clippy latest
  PASS Check documentation
  PASS Tests with generate-bindings
  PASS Valgrind tests (1.85.0)

  9 passed, 0 failed

CI would PASS
```
