### PR TITLE
ci: cancel in-progress runs on new pushes to the same ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: Continuous Integration
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Use the following command to fix words locally:
   # codespell --write-changes


### PR DESCRIPTION
- Add a `concurrency` block to `ci.yml`, grouping runs by `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`.
- When new commits are pushed to the same branch/PR, in-flight CI runs for older refs are automatically aborted so that only the latest push is built.
- Reduces wasted GitHub Actions runner minutes caused by force-pushes or rapid successive pushes within the same PR.
