### PR TITLE
Fix problem with tpm2-tss dependencies in bundled build.

### DIFF
--- a/tss-esapi-sys/Cargo.toml
+++ b/tss-esapi-sys/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85.0"
 
 [build-dependencies]
 bindgen = { version = "0.72.1", optional = true }
-pkg-config = "0.3.32"
+pkg-config = "0.3.33"
 target-lexicon = "0.13.5"
 cfg-if = "1.0.4"
 semver = "1.0.27"

--- a/tss-esapi-sys/README.md
+++ b/tss-esapi-sys/README.md
@@ -21,6 +21,7 @@ are discoverable in this way on your system. Our build script looks for
 `tss2-sys`, `tss2-esys`, `tss2-tctildr` and `tss2-mu`. A minimum version of `4.1.3` is
 required for all of them. On windows `tss2-tcti-tbs` is also required.
 
+
 Having installed the open-source implementation libraries at `/usr/local/lib` (by default), it
 might happen that `pkg-config` can not find them. Run the following command if that is the
 case:
@@ -39,7 +40,7 @@ NOTE: Only a limited set of bindings are committed and their target triplet
 is included in the name of the file - if the triplet you require is not
 available, feel free to raise a Pull Request to add it or to use build-time
 generation of bindings. All the committed bindings **MUST** be generated from
-the library version found under the `vendor` submodule.
+the previous mentioned minimum version.
 
 ## Bundling TPM-TSS
 
@@ -55,6 +56,9 @@ the `TPM2_TSS_SOURCE_VERSION` environment variable.
    having to worry about the `tpm2-tss` library dependencies. But it is still
    necessary to make the shared libraries available to the executable that uses
    the library.
+* The dependencies of `tpm2-tss` needs to be installed and available to find
+  using `pkg-config` on all platform besides Windows, because on Windows it is
+  handled differently. See the [Windows section}(#Windows).
 * On Windows it might be necessary to manually create the `VERSION` file
    when a local source is being used.
 
@@ -105,7 +109,19 @@ brew install libftdi
 ### OpenSUSE / SUSE
 
 ```
-sudo zypper in autoconf autoconf-archive automake libjson-c-devel libtool libtpms-devel gawk make
+sudo zypper in \
+   autoconf \
+   autoconf-archive \
+   automake \
+   gcc-c++ \
+   libusb-devel \
+   libjson-c-devel \
+   libuuid-devel \
+   libopenssl-3-devel \
+   libtool \
+   libtpms-devel \
+   gawk \
+   make
 ```
 
 ## Cross compiling

--- a/tss-esapi-sys/README.md
+++ b/tss-esapi-sys/README.md
@@ -91,6 +91,10 @@ Compiling for windows requires a bit of setup to work with the bundled feature.
   and windows sdk 10.0 (Other versions of Visual Studio may work but are untested 
   at this point).
 
+NOTE: On Windows there it is also necessary to make the runtime files dependencies
+of `tpm2-tss` discoverable, e.g. the OpenSSL DLLs. See [search order](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order). In order to run an executable that
+depends on this library.
+
 ### MacOS
 
 Compiling on MacOS requires the bundling feature. This requires dependencies

--- a/tss-esapi-sys/README.md
+++ b/tss-esapi-sys/README.md
@@ -56,9 +56,9 @@ the `TPM2_TSS_SOURCE_VERSION` environment variable.
    having to worry about the `tpm2-tss` library dependencies. But it is still
    necessary to make the shared libraries available to the executable that uses
    the library.
-* The dependencies of `tpm2-tss` needs to be installed and discoverable via
-  `pkg-config` on all platform except Windows, because on Windows it is
-  handled differently. See the [Windows section](#windows).
+* The dependencies of `tpm2-tss` need to be installed and discoverable via
+  `pkg-config` on all platforms except Windows, on Windows this is handled
+   differently. See the [Windows section](#windows).
 * On Windows it might be necessary to manually create the `VERSION` file
    when a local source is being used.
 

--- a/tss-esapi-sys/README.md
+++ b/tss-esapi-sys/README.md
@@ -40,7 +40,7 @@ NOTE: Only a limited set of bindings are committed and their target triplet
 is included in the name of the file - if the triplet you require is not
 available, feel free to raise a Pull Request to add it or to use build-time
 generation of bindings. All the committed bindings **MUST** be generated from
-the previous mentioned minimum version.
+the previously mentioned minimum version.
 
 ## Bundling TPM-TSS
 
@@ -56,9 +56,9 @@ the `TPM2_TSS_SOURCE_VERSION` environment variable.
    having to worry about the `tpm2-tss` library dependencies. But it is still
    necessary to make the shared libraries available to the executable that uses
    the library.
-* The dependencies of `tpm2-tss` needs to be installed and available to find
-  using `pkg-config` on all platform besides Windows, because on Windows it is
-  handled differently. See the [Windows section}(#Windows).
+* The dependencies of `tpm2-tss` needs to be installed and discoverable via
+  `pkg-config` on all platform except Windows, because on Windows it is
+  handled differently. See the [Windows section](#windows).
 * On Windows it might be necessary to manually create the `VERSION` file
    when a local source is being used.
 

--- a/tss-esapi-sys/README.md
+++ b/tss-esapi-sys/README.md
@@ -57,8 +57,8 @@ the `TPM2_TSS_SOURCE_VERSION` environment variable.
    necessary to make the shared libraries available to the executable that uses
    the library.
 * The dependencies of `tpm2-tss` need to be installed and discoverable via
-   `pkg-config` on all platforms except Windows, on Windows this is handled
-    differently. See the [Windows section](#windows).
+  `pkg-config` on all platforms except Windows, on Windows this is handled
+  differently. See the [Windows section](#windows).
 * On Windows it might be necessary to manually create the `VERSION` file
    when a local source is being used.
 
@@ -91,9 +91,9 @@ Compiling for windows requires a bit of setup to work with the bundled feature.
   and windows sdk 10.0 (Other versions of Visual Studio may work but are untested 
   at this point).
 
-NOTE: On Windows there it is also necessary to make the runtime files dependencies
-of `tpm2-tss` discoverable, e.g. the OpenSSL DLLs. See [search order](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order). In order to run an executable that
-depends on this library.
+NOTE: On Windows it is also necessary to ensure the runtime dependencies of `tpm2-tss`
+(e.g. the OpenSSL DLLs) are discoverable. See the Windows DLL
+[search order](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order).
 
 ### MacOS
 

--- a/tss-esapi-sys/README.md
+++ b/tss-esapi-sys/README.md
@@ -57,8 +57,8 @@ the `TPM2_TSS_SOURCE_VERSION` environment variable.
    necessary to make the shared libraries available to the executable that uses
    the library.
 * The dependencies of `tpm2-tss` need to be installed and discoverable via
-  `pkg-config` on all platforms except Windows, on Windows this is handled
-   differently. See the [Windows section](#windows).
+   `pkg-config` on all platforms except Windows, on Windows this is handled
+    differently. See the [Windows section](#windows).
 * On Windows it might be necessary to manually create the `VERSION` file
    when a local source is being used.
 

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -439,6 +439,16 @@ pub mod tpm2_tss {
                         panic!("Unable to find location to search for the bundled pkgconfig files.")
                     };
 
+                    // Add the tpm2-tss libraries pkgconfig path first among the paths.
+                    let pkg_config_paths = match std::env::var_os("PKG_CONFIG_PATH") {
+                        Some(existing_paths) => {
+                            let mut paths = vec![tpm2_tss_pkg_config_path];
+                            paths.append(&mut std::env::split_paths(&existing_paths).collect::<Vec<_>>());
+                            std::env::join_paths(paths).expect("Should be possible to join all the pkg config paths into a PATH string.")
+                        },
+                        None => std::env::join_paths(vec![tpm2_tss_pkg_config_path]).expect("Should be possible to convert tpm2-tss pkgconfig path to a PATH str."),
+                    };
+
                     // SAFETY: The build script is not multi threaded so this is safe to do.
                     unsafe {std::env::set_var(
                         "PKG_CONFIG_PATH",
@@ -781,8 +791,15 @@ pub mod tpm2_tss {
             with_header_files: bool,
             lib_version: &str,
         ) -> Option<Self> {
+            // Make PKG config report as much as possible to cargo
+            // so there is no chance of ending up with `undefined references`.
             pkg_config::Config::new()
                 .atleast_version(lib_version)
+                .cargo_metadata(true)
+                .env_metadata(true)
+                .print_system_libs(true)
+                .print_system_cflags(true)
+                .statik(true)
                 .probe(lib_name)
                 .ok()
                 .map(|pkg_config| {

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -112,9 +112,9 @@ pub mod tpm2_tss {
                         panic!("For the {} the {} must exist.", self.lib_name, self.win_path_str);
                     }
                     let lib_dir: PathBuf = win_path.join("lib");
-                    let bin_dir: PathBuf = win_path.join("bin");
+                    // for linking
                     println!("cargo:rustc-link-search=all={}", lib_dir.display());
-                    println!("cargo:rustc-link-search=all={}", bin_dir.display());
+                    println!("cargo:rustc-link-lib={}", self.lib_name);
                 } else {
                     let lib = pkg_config::Config::new()
                         .atleast_version(self.lib_version)
@@ -703,7 +703,7 @@ pub mod tpm2_tss {
             cfg_if::cfg_if! {
                 if #[cfg(windows)] {
                     let include_path = _source_path.join("include").join("tss2");
-                    println!("cargo:rustc-link-lib=dylib={lib_name}");
+                    println!("cargo:rustc-link-lib={lib_name}");
                     Some(Self {
                         header_file: Self::header_file(lib_name, &include_path, true),
                         version: lib_version.to_string(),

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -158,8 +158,11 @@ pub mod tpm2_tss {
         pub fn bundled(out_path: &Path) -> Self {
             let version = Self::version();
             let source_path = Self::source(out_path, &version);
+            for dep in DEPENDENCIES.iter() {
+                dep.probe();
+            }
             Self::compile(&source_path);
-            let result = Self {
+            Self {
                 _tss2_sys: Library::bundled_required("tss2-sys", &source_path, &version, false),
                 tss2_esys: Library::bundled_required("tss2-esys", &source_path, &version, true),
                 tss2_tctildr: Library::bundled_required(
@@ -170,11 +173,7 @@ pub mod tpm2_tss {
                 ),
                 tss2_mu: Library::bundled_required("tss2-mu", &source_path, &version, false),
                 tss2_tcti_tbs: Library::bundled_optional("tss2-tcti-tbs", &source_path, &version),
-            };
-            for dep in DEPENDENCIES.iter() {
-                dep.probe();
             }
-            result
         }
 
         /// Probes the system for an installation.

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -430,8 +430,9 @@ pub mod tpm2_tss {
                 }
                 else {
                     let install_path = Self::compile_with_autotools(source_path);
+
                     // On some systems the files are installed to the lib64 dir
-                    let pkg_config_path = if install_path.join("lib64").is_dir() {
+                    let tpm2_tss_pkg_config_path = if install_path.join("lib64").is_dir() {
                         install_path.join("lib64").join("pkgconfig")
                     } else if install_path.join("lib").is_dir() {
                         install_path.join("lib").join("pkgconfig")
@@ -444,16 +445,17 @@ pub mod tpm2_tss {
                         Some(existing_paths) => {
                             let mut paths = vec![tpm2_tss_pkg_config_path];
                             paths.append(&mut std::env::split_paths(&existing_paths).collect::<Vec<_>>());
-                            std::env::join_paths(paths).expect("Should be possible to join all the pkg config paths into a PATH string.")
+                            std::env::join_paths(paths)
+                                .expect("Should be possible to join all the pkg config paths into a PATH string.")
                         },
-                        None => std::env::join_paths(vec![tpm2_tss_pkg_config_path]).expect("Should be possible to convert tpm2-tss pkgconfig path to a PATH str."),
+                        None => {
+                            std::env::join_paths(vec![tpm2_tss_pkg_config_path])
+                                .expect("Should be possible to convert tpm2-tss pkgconfig path to a PATH str.")
+                        },
                     };
 
                     // SAFETY: The build script is not multi threaded so this is safe to do.
-                    unsafe {std::env::set_var(
-                        "PKG_CONFIG_PATH",
-                        format!("{}", pkg_config_path.display()),
-                    )};
+                    unsafe {std::env::set_var("PKG_CONFIG_PATH", pkg_config_paths)};
                 }
             }
         }

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -111,8 +111,8 @@ pub mod tpm2_tss {
                     if !win_path.exists() {
                         panic!("For the {} the {} must exist.", self.lib_name, self.win_path_str);
                     }
-                    lib_dir: PathBuf = win_path.join("lib");
-                    bin_dir: PathBuf = win_path.join("bin");
+                    let lib_dir: PathBuf = win_path.join("lib");
+                    let bin_dir: PathBuf = win_path.join("bin");
                     println!("cargo:rustc-link-search=all={}", lib_dir.display());
                     println!("cargo:rustc-link-search=all={}", bin_dir.display());
                 } else {

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -107,21 +107,21 @@ pub mod tpm2_tss {
             cfg_if::cfg_if! {
                 if #[cfg(windows)] {
                     // TODO: Find some better way to check dependency.
-                    win_path = Path::new(self.win_path_str):
+                    let win_path = Path::new(self.win_path_str);
                     if !win_path.exists() {
-                        panic!("For the {} the {} must exist.", self.lib_name, self.win_path.display());
+                        panic!("For the {} the {} must exist.", self.lib_name, self.win_path_str);
                     }
                     lib_dir: PathBuf = win_path.join("lib");
                     bin_dir: PathBuf = win_path.join("bin");
-                    println!("cargo::rustc-link-search=all={}", lib_dir.display());
-                    println!("cargo::rustc-link-search=all={}", bin_dir.display());
+                    println!("cargo:rustc-link-search=all={}", lib_dir.display());
+                    println!("cargo:rustc-link-search=all={}", bin_dir.display());
                 } else {
                     let lib = pkg_config::Config::new()
                         .atleast_version(self.lib_version)
                         .probe(self.lib_name)
                         .unwrap_or_else(|_| panic!("The {} of min version of {} is needed for the bundled installation.", self.lib_name, self.lib_version));
                     for link_path in lib.link_paths {
-                        println!("cargo::rustc-link-search=all={}", link_path.display());
+                        println!("cargo:rustc-link-search=all={}", link_path.display());
                     }
                 }
             }
@@ -130,10 +130,10 @@ pub mod tpm2_tss {
 
     /// All the dependencies of tpm2-tss.
     ///
-    /// This is not used in all configurations there for
+    /// This is not used in all configurations therefore
     /// the `allow(unused)`.
     #[allow(unused)]
-    const DEPENDENCIES: [Dependency; 1] = [Dependency::new(
+    const DEPENDENCIES: [Dependency<'static>; 1] = [Dependency::new(
         "libcrypto",
         "1.1.0",
         "C:\\OpenSSL-v11-Win64",
@@ -157,7 +157,7 @@ pub mod tpm2_tss {
         #[cfg(feature = "bundled")]
         /// Uses a bundled build for the installation.
         pub fn bundled(out_path: &Path) -> Self {
-            for dep in DEPENDENCIES {
+            for dep in DEPENDENCIES.iter() {
                 dep.probe();
             }
             let version = Self::version();

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -430,10 +430,19 @@ pub mod tpm2_tss {
                 }
                 else {
                     let install_path = Self::compile_with_autotools(source_path);
+                    // On some systems the files are installed to the lib64 dir
+                    let pkg_config_path = if install_path.join("lib64").is_dir() {
+                        install_path.join("lib64").join("pkgconfig")
+                    } else if install_path.join("lib").is_dir() {
+                        install_path.join("lib").join("pkgconfig")
+                    } else {
+                        panic!("Unable to find location to search for the bundled pkgconfig files.")
+                    };
+
                     // SAFETY: The build script is not multi threaded so this is safe to do.
                     unsafe {std::env::set_var(
                         "PKG_CONFIG_PATH",
-                        format!("{}", install_path.join("lib").join("pkgconfig").display()),
+                        format!("{}", pkg_config_path.display()),
                     )};
                 }
             }

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -119,7 +119,7 @@ pub mod tpm2_tss {
                     let lib = pkg_config::Config::new()
                         .atleast_version(self.lib_version)
                         .probe(self.lib_name)
-                        .expect(&format!("The {} of min version of {} is needed for the bundled installation.", self.lib_name, self.lib_version));
+                        .unwrap_or_else(|_| panic!("The {} of min version of {} is needed for the bundled installation.", self.lib_name, self.lib_version));
                     for link_path in lib.link_paths {
                         println!("cargo::rustc-link-search=all={}", link_path.display());
                     }
@@ -129,6 +129,10 @@ pub mod tpm2_tss {
     }
 
     /// All the dependencies of tpm2-tss.
+    ///
+    /// This is not used in all configurations there for
+    /// the `allow(unused)`.
+    #[allow(unused)]
     const DEPENDENCIES: [Dependency; 1] = [Dependency::new(
         "libcrypto",
         "1.1.0",

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -116,13 +116,12 @@ pub mod tpm2_tss {
                     println!("cargo:rustc-link-search=all={}", lib_dir.display());
                     println!("cargo:rustc-link-lib={}", self.lib_name);
                 } else {
-                    let lib = pkg_config::Config::new()
+                    // The cargo meta data will be printed automatically.
+                    let _ = pkg_config::Config::new()
+                        .cargo_metadata(true) // This is on by default but making it explicit here.
                         .atleast_version(self.lib_version)
                         .probe(self.lib_name)
-                        .unwrap_or_else(|_| panic!("The {} of min version of {} is needed for the bundled installation.", self.lib_name, self.lib_version));
-                    for link_path in lib.link_paths {
-                        println!("cargo:rustc-link-search=all={}", link_path.display());
-                    }
+                        .unwrap_or_else(|e| panic!("The {} of min version of {} is needed for the bundled installation ({}).", self.lib_name, self.lib_version, e));
                 }
             }
         }

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -109,7 +109,7 @@ pub mod tpm2_tss {
                     // TODO: Find some better way to check dependency.
                     let win_path = Path::new(self.win_path_str);
                     if !win_path.exists() {
-                        panic!("For the {} the {} must exist.", self.lib_name, self.win_path_str);
+                        panic!("Bundled build requires `{}` to be installed at `{}`.", self.lib_name, self.win_path_str);
                     }
                     let lib_dir: PathBuf = win_path.join("lib");
                     // for linking
@@ -121,7 +121,7 @@ pub mod tpm2_tss {
                         .cargo_metadata(true) // This is on by default but making it explicit here.
                         .atleast_version(self.lib_version)
                         .probe(self.lib_name)
-                        .unwrap_or_else(|e| panic!("The {} of min version of {} is needed for the bundled installation ({}).", self.lib_name, self.lib_version, e));
+                        .unwrap_or_else(|e| panic!("Bundled build requires `{}` >= {} to be discoverable via pkg-config ({}).", self.lib_name, self.lib_version, e));
                 }
             }
         }
@@ -156,13 +156,10 @@ pub mod tpm2_tss {
         #[cfg(feature = "bundled")]
         /// Uses a bundled build for the installation.
         pub fn bundled(out_path: &Path) -> Self {
-            for dep in DEPENDENCIES.iter() {
-                dep.probe();
-            }
             let version = Self::version();
             let source_path = Self::source(out_path, &version);
             Self::compile(&source_path);
-            Self {
+            let result = Self {
                 _tss2_sys: Library::bundled_required("tss2-sys", &source_path, &version, false),
                 tss2_esys: Library::bundled_required("tss2-esys", &source_path, &version, true),
                 tss2_tctildr: Library::bundled_required(
@@ -173,7 +170,11 @@ pub mod tpm2_tss {
                 ),
                 tss2_mu: Library::bundled_required("tss2-mu", &source_path, &version, false),
                 tss2_tcti_tbs: Library::bundled_optional("tss2-tcti-tbs", &source_path, &version),
+            };
+            for dep in DEPENDENCIES.iter() {
+                dep.probe();
             }
+            result
         }
 
         /// Probes the system for an installation.

--- a/tss-esapi-sys/build.rs
+++ b/tss-esapi-sys/build.rs
@@ -84,6 +84,57 @@ pub mod tpm2_tss {
     const MINIMUM_VERSION: &str = "4.1.3";
     const INSTALLATION_PATH_ENV_VAR_NAME: &str = "TPM2_TSS_PATH";
 
+    /// A tpm2-tss dependency
+    pub struct Dependency<'a> {
+        #[allow(unused)]
+        lib_name: &'a str,
+        #[allow(unused)]
+        lib_version: &'a str,
+        #[allow(unused)]
+        win_path_str: &'a str,
+    }
+
+    impl<'a> Dependency<'a> {
+        pub const fn new(lib_name: &'a str, lib_version: &'a str, win_path_str: &'a str) -> Self {
+            Self {
+                lib_name,
+                lib_version,
+                win_path_str,
+            }
+        }
+
+        pub fn probe(&self) {
+            cfg_if::cfg_if! {
+                if #[cfg(windows)] {
+                    // TODO: Find some better way to check dependency.
+                    win_path = Path::new(self.win_path_str):
+                    if !win_path.exists() {
+                        panic!("For the {} the {} must exist.", self.lib_name, self.win_path.display());
+                    }
+                    lib_dir: PathBuf = win_path.join("lib");
+                    bin_dir: PathBuf = win_path.join("bin");
+                    println!("cargo::rustc-link-search=all={}", lib_dir.display());
+                    println!("cargo::rustc-link-search=all={}", bin_dir.display());
+                } else {
+                    let lib = pkg_config::Config::new()
+                        .atleast_version(self.lib_version)
+                        .probe(self.lib_name)
+                        .expect(&format!("The {} of min version of {} is needed for the bundled installation.", self.lib_name, self.lib_version));
+                    for link_path in lib.link_paths {
+                        println!("cargo::rustc-link-search=all={}", link_path.display());
+                    }
+                }
+            }
+        }
+    }
+
+    /// All the dependencies of tpm2-tss.
+    const DEPENDENCIES: [Dependency; 1] = [Dependency::new(
+        "libcrypto",
+        "1.1.0",
+        "C:\\OpenSSL-v11-Win64",
+    )];
+
     /// The installed tpm2-tss libraries that are of
     /// interest.
     pub struct Installation {
@@ -102,6 +153,9 @@ pub mod tpm2_tss {
         #[cfg(feature = "bundled")]
         /// Uses a bundled build for the installation.
         pub fn bundled(out_path: &Path) -> Self {
+            for dep in DEPENDENCIES {
+                dep.probe();
+            }
             let version = Self::version();
             let source_path = Self::source(out_path, &version);
             Self::compile(&source_path);


### PR DESCRIPTION
When doing bundled build where the output is an
executable, i.e. examples, cargo needs to know
where to look for dependencies when compiling
tpm2-tss otherwise one ends up with several
missing symbols errors in the linking stage.

This adds functionality for probing dependencies
of tpm2-tss and report the search paths for the
libraries of those dependencies to cargo.

Fixes #646