### PR TITLE
feat(esapi): implement clocks_and_timers TPM commands

### DIFF
--- a/tss-esapi/src/constants/clock_adjust.rs
+++ b/tss-esapi/src/constants/clock_adjust.rs
@@ -1,0 +1,70 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    Error, Result, WrapperErrorKind,
+    constants::tss::{
+        TPM2_CLOCK_COARSE_FASTER, TPM2_CLOCK_COARSE_SLOWER, TPM2_CLOCK_FINE_FASTER,
+        TPM2_CLOCK_FINE_SLOWER, TPM2_CLOCK_MEDIUM_FASTER, TPM2_CLOCK_MEDIUM_SLOWER,
+        TPM2_CLOCK_NO_CHANGE,
+    },
+    tss2_esys::TPM2_CLOCK_ADJUST,
+};
+use log::error;
+use std::convert::TryFrom;
+
+/// Clock-rate adjustment for TPM clock updates.
+///
+/// # Details
+/// This corresponds to the `TPM2_CLOCK_ADJUST` type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ClockAdjust {
+    /// Slow the clock update rate by one coarse adjustment step.
+    CoarseSlower,
+    /// Slow the clock update rate by one medium adjustment step.
+    MediumSlower,
+    /// Slow the clock update rate by one fine adjustment step.
+    FineSlower,
+    /// Do not change the clock update rate.
+    NoChange,
+    /// Speed the clock update rate by one fine adjustment step.
+    FineFaster,
+    /// Speed the clock update rate by one medium adjustment step.
+    MediumFaster,
+    /// Speed the clock update rate by one coarse adjustment step.
+    CoarseFaster,
+}
+
+impl From<ClockAdjust> for TPM2_CLOCK_ADJUST {
+    fn from(clock_adjust: ClockAdjust) -> Self {
+        match clock_adjust {
+            ClockAdjust::CoarseSlower => TPM2_CLOCK_COARSE_SLOWER,
+            ClockAdjust::MediumSlower => TPM2_CLOCK_MEDIUM_SLOWER,
+            ClockAdjust::FineSlower => TPM2_CLOCK_FINE_SLOWER,
+            ClockAdjust::NoChange => TPM2_CLOCK_NO_CHANGE,
+            ClockAdjust::FineFaster => TPM2_CLOCK_FINE_FASTER,
+            ClockAdjust::MediumFaster => TPM2_CLOCK_MEDIUM_FASTER,
+            ClockAdjust::CoarseFaster => TPM2_CLOCK_COARSE_FASTER,
+        }
+    }
+}
+
+impl TryFrom<TPM2_CLOCK_ADJUST> for ClockAdjust {
+    type Error = Error;
+
+    fn try_from(tpm2_clock_adjust: TPM2_CLOCK_ADJUST) -> Result<Self> {
+        match tpm2_clock_adjust {
+            TPM2_CLOCK_COARSE_SLOWER => Ok(ClockAdjust::CoarseSlower),
+            TPM2_CLOCK_MEDIUM_SLOWER => Ok(ClockAdjust::MediumSlower),
+            TPM2_CLOCK_FINE_SLOWER => Ok(ClockAdjust::FineSlower),
+            TPM2_CLOCK_NO_CHANGE => Ok(ClockAdjust::NoChange),
+            TPM2_CLOCK_FINE_FASTER => Ok(ClockAdjust::FineFaster),
+            TPM2_CLOCK_MEDIUM_FASTER => Ok(ClockAdjust::MediumFaster),
+            TPM2_CLOCK_COARSE_FASTER => Ok(ClockAdjust::CoarseFaster),
+            _ => {
+                error!("Invalid TPM2_CLOCK_ADJUST value: {}", tpm2_clock_adjust);
+                Err(Error::local_error(WrapperErrorKind::InvalidParam))
+            }
+        }
+    }
+}

--- a/tss-esapi/src/constants/mod.rs
+++ b/tss-esapi/src/constants/mod.rs
@@ -40,6 +40,10 @@ pub mod session_type;
 /// Constants -> TPM_CAP section of the specification
 pub mod capabilities;
 
+/// Representation of the constants defined in
+/// Constants -> TPM2_CLOCK_ADJUST section of the specification.
+pub mod clock_adjust;
+
 /// Representation of the return code TSS2_RC (TPM_RC)
 pub mod return_code;
 
@@ -60,6 +64,7 @@ pub mod command_code;
 pub mod pcr_property_tag;
 
 pub use capabilities::CapabilityType;
+pub use clock_adjust::ClockAdjust;
 pub use command_code::CommandCode;
 pub use ecc::EccCurveIdentifier;
 pub use nv_index_type::NvIndexType;

--- a/tss-esapi/src/context/tpm_commands/clocks_and_timers.rs
+++ b/tss-esapi/src/context/tpm_commands/clocks_and_timers.rs
@@ -1,9 +1,157 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode,
+    constants::ClockAdjust,
+    handles::AuthHandle,
+    structures::TimeInfo,
+    tss2_esys::{Esys_ClockRateAdjust, Esys_ClockSet, Esys_ReadClock},
+};
+use log::error;
+use std::{convert::TryFrom, ptr::null_mut};
 
 impl Context {
-    // Missing function: ReadClock
-    // Missing function: ClockSet
-    // Missing function: ClockRateAdjust
+    /// Read the current time and clock info.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command returns the current values of Time and Clock.
+    ///
+    /// # Returns
+    ///
+    /// A [TimeInfo] structure containing the current time and clock information.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let time_info = context.read_clock().unwrap();
+    /// println!("Time: {}", time_info.time());
+    /// ```
+    pub fn read_clock(&mut self) -> Result<TimeInfo> {
+        let mut current_time_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ReadClock(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &mut current_time_ptr,
+                )
+            },
+            |ret| {
+                error!("Error reading clock: {:#010X}", ret);
+            },
+        )?;
+        TimeInfo::try_from(Context::ffi_data_to_owned(current_time_ptr)?)
+    }
+
+    /// Set the clock to a new value.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the authorization (Owner or Platform).
+    /// * `new_time` - The new clock setting in milliseconds.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to advance the value of the TPM's Clock. The
+    /// > command will fail if newTime is less than the current value of Clock
+    /// > or if the new time is greater than 0xFFFF000000000000.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::{handles::AuthHandle, interface_types::session_handles::AuthSession};
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// let time_info = context.read_clock().unwrap();
+    /// let new_time = time_info.clock_info().clock() + 100_000;
+    /// context
+    ///     .execute_with_session(Some(AuthSession::Password), |ctx| {
+    ///         ctx.clock_set(AuthHandle::Owner, new_time)
+    ///     })
+    ///     .unwrap();
+    /// ```
+    pub fn clock_set(&mut self, auth_handle: AuthHandle, new_time: u64) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ClockSet(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    new_time,
+                )
+            },
+            |ret| {
+                error!("Error setting clock: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Adjust the TPM clock update rate.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the authorization (Owner or Platform).
+    /// * `rate_adjust` - The clock update-rate adjustment to apply.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command adjusts the rate of advance of Clock and Time to provide
+    /// > a better approximation to real time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::{
+    /// #     constants::ClockAdjust,
+    /// #     handles::AuthHandle,
+    /// #     interface_types::session_handles::AuthSession,
+    /// # };
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context
+    ///     .execute_with_session(Some(AuthSession::Password), |ctx| {
+    ///         ctx.clock_rate_adjust(AuthHandle::Owner, ClockAdjust::NoChange)
+    ///     })
+    ///     .unwrap();
+    /// ```
+    pub fn clock_rate_adjust(
+        &mut self,
+        auth_handle: AuthHandle,
+        rate_adjust: ClockAdjust,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_ClockRateAdjust(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    rate_adjust.into(),
+                )
+            },
+            |ret| {
+                error!("Error adjusting clock rate: {:#010X}", ret);
+            },
+        )
+    }
 }

--- a/tss-esapi/tests/integration_tests/constants_tests/clock_adjust_tests.rs
+++ b/tss-esapi/tests/integration_tests/constants_tests/clock_adjust_tests.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+use tss_esapi::{
+    Error, WrapperErrorKind,
+    constants::{
+        ClockAdjust,
+        tss::{
+            TPM2_CLOCK_COARSE_FASTER, TPM2_CLOCK_COARSE_SLOWER, TPM2_CLOCK_FINE_FASTER,
+            TPM2_CLOCK_FINE_SLOWER, TPM2_CLOCK_MEDIUM_FASTER, TPM2_CLOCK_MEDIUM_SLOWER,
+            TPM2_CLOCK_NO_CHANGE,
+        },
+    },
+    tss2_esys::TPM2_CLOCK_ADJUST,
+};
+
+#[test]
+fn test_valid_conversions() {
+    let test_cases = [
+        (ClockAdjust::CoarseSlower, TPM2_CLOCK_COARSE_SLOWER),
+        (ClockAdjust::MediumSlower, TPM2_CLOCK_MEDIUM_SLOWER),
+        (ClockAdjust::FineSlower, TPM2_CLOCK_FINE_SLOWER),
+        (ClockAdjust::NoChange, TPM2_CLOCK_NO_CHANGE),
+        (ClockAdjust::FineFaster, TPM2_CLOCK_FINE_FASTER),
+        (ClockAdjust::MediumFaster, TPM2_CLOCK_MEDIUM_FASTER),
+        (ClockAdjust::CoarseFaster, TPM2_CLOCK_COARSE_FASTER),
+    ];
+
+    for (clock_adjust, expected_tpm_value) in test_cases {
+        assert_eq!(
+            expected_tpm_value,
+            TPM2_CLOCK_ADJUST::from(clock_adjust),
+            "ClockAdjust did not convert to the expected TPM value"
+        );
+        assert_eq!(
+            clock_adjust,
+            ClockAdjust::try_from(expected_tpm_value)
+                .expect("Failed to convert TPM value to ClockAdjust"),
+            "TPM value did not convert to the expected ClockAdjust"
+        );
+    }
+}
+
+#[test]
+fn test_invalid_conversions() {
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+        ClockAdjust::try_from(4),
+        "Conversion of invalid value did not result in expected error"
+    );
+}

--- a/tss-esapi/tests/integration_tests/constants_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/constants_tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 mod algorithm_tests;
 mod capabilities_tests;
+mod clock_adjust_tests;
 mod command_code_tests;
 mod nv_index_type_tests;
 mod pcr_property_tag_tests;

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/clocks_and_timers_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/clocks_and_timers_tests.rs
@@ -1,2 +1,57 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+
+mod test_read_clock {
+    use crate::common::create_ctx_without_session;
+    use std::{thread::sleep, time::Duration};
+
+    #[test]
+    fn test_read_clock() {
+        let mut context = create_ctx_without_session();
+
+        let first_time_info = context.read_clock().unwrap();
+        sleep(Duration::from_millis(10));
+        let second_time_info = context.read_clock().unwrap();
+
+        assert!(second_time_info.time() >= first_time_info.time());
+        assert!(second_time_info.clock_info().clock() >= first_time_info.clock_info().clock());
+    }
+}
+
+mod test_clock_set {
+    use crate::common::create_ctx_without_session;
+    use tss_esapi::{handles::AuthHandle, interface_types::session_handles::AuthSession};
+
+    #[test]
+    fn test_clock_set() {
+        let mut context = create_ctx_without_session();
+        let time_info = context.read_clock().unwrap();
+        let new_time = time_info.clock_info().clock() + 100_000;
+
+        context
+            .execute_with_session(Some(AuthSession::Password), |ctx| {
+                ctx.clock_set(AuthHandle::Owner, new_time)
+            })
+            .unwrap();
+
+        assert!(context.read_clock().unwrap().clock_info().clock() >= new_time);
+    }
+}
+
+mod test_clock_rate_adjust {
+    use crate::common::create_ctx_without_session;
+    use tss_esapi::{
+        constants::ClockAdjust, handles::AuthHandle, interface_types::session_handles::AuthSession,
+    };
+
+    #[test]
+    fn test_clock_rate_adjust_no_change() {
+        let mut context = create_ctx_without_session();
+
+        context
+            .execute_with_session(Some(AuthSession::Password), |ctx| {
+                ctx.clock_rate_adjust(AuthHandle::Owner, ClockAdjust::NoChange)
+            })
+            .unwrap();
+    }
+}


### PR DESCRIPTION
This pull request implements the following TPM commands with their integration tests:

- `read_clock` (ESAPI Spec 11.3.97)
- `clock_set` (11.3.98)
- `clock_rate_adjust` (11.3.99)

To implement `clock_rate_adjust`, it also implements the wrapper type for `TPM2_CLOCK_ADJUST` in a new module `constants/clock_adjust.rs`.

The former two commands were extracted from #625.