### PR TITLE
feat(esapi): implement a missing TPM command in command_audit

### DIFF
--- a/tss-esapi/src/context/tpm_commands/command_audit.rs
+++ b/tss-esapi/src/context/tpm_commands/command_audit.rs
@@ -1,7 +1,76 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode, handles::AuthHandle, interface_types::algorithm::HashingAlgorithm,
+    structures::CommandCodeList, tss2_esys::Esys_SetCommandCodeAuditStatus,
+};
+use log::error;
 
 impl Context {
-    // Missing function: SetCommandCodeAuditStatus
+    /// Set the command code audit status.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_handle` - An [AuthHandle] for the authorization (Owner or Platform).
+    /// * `audit_algorithm` - The [HashingAlgorithm] for the audit digest.
+    /// * `set_list` - A [CommandCodeList] of command codes to add to the audit list.
+    /// * `clear_list` - A [CommandCodeList] of command codes to remove from the audit list.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command may be used by the Privacy Administrator or platform
+    /// > to change the audit status of a command or to set the hash
+    /// > algorithm used for the audit digest.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::handles::AuthHandle;
+    /// # use tss_esapi::interface_types::{
+    /// #     algorithm::HashingAlgorithm,
+    /// #     session_handles::AuthSession,
+    /// # };
+    /// # use tss_esapi::structures::CommandCodeList;
+    /// # let mut context =
+    /// #     Context::new(
+    /// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// #     ).expect("Failed to create Context");
+    /// context
+    ///     .execute_with_sessions((Some(AuthSession::Password), None, None), |ctx| {
+    ///         ctx.set_command_code_audit_status(
+    ///             AuthHandle::Owner,
+    ///             HashingAlgorithm::Sha256,
+    ///             CommandCodeList::new(),
+    ///             CommandCodeList::new(),
+    ///         )
+    ///     })
+    ///     .expect("Failed to set command code audit status");
+    /// ```
+    pub fn set_command_code_audit_status(
+        &mut self,
+        auth_handle: AuthHandle,
+        audit_algorithm: HashingAlgorithm,
+        set_list: CommandCodeList,
+        clear_list: CommandCodeList,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_SetCommandCodeAuditStatus(
+                    self.mut_context(),
+                    auth_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    audit_algorithm.into(),
+                    &set_list.into(),
+                    &clear_list.into(),
+                )
+            },
+            |ret| {
+                error!("Error setting command code audit status: {:#010X}", ret);
+            },
+        )
+    }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/command_audit_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/command_audit_tests.rs
@@ -1,2 +1,74 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_set_command_code_audit_status {
+    use crate::common::create_ctx_with_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        Context,
+        constants::{CapabilityType, CommandCode},
+        handles::AuthHandle,
+        interface_types::{algorithm::HashingAlgorithm, session_handles::AuthSession},
+        structures::{CapabilityData, CommandCodeList},
+    };
+
+    fn set_command_audit_status(
+        context: &mut Context,
+        set_list: CommandCodeList,
+        clear_list: CommandCodeList,
+    ) {
+        context
+            .execute_with_sessions((Some(AuthSession::Password), None, None), |ctx| {
+                ctx.set_command_code_audit_status(
+                    AuthHandle::Owner,
+                    HashingAlgorithm::Null,
+                    set_list,
+                    clear_list,
+                )
+            })
+            .expect("Failed to set command code audit status");
+    }
+
+    fn audit_commands(context: &mut Context) -> CommandCodeList {
+        let (capability_data, _more_data) = context
+            .execute_without_session(|ctx| {
+                ctx.get_capability(
+                    CapabilityType::AuditCommands,
+                    0,
+                    CommandCodeList::MAX_SIZE as u32,
+                )
+            })
+            .expect("Failed to get audit commands capability");
+
+        match capability_data {
+            CapabilityData::AuditCommands(command_codes) => command_codes,
+            _ => panic!("Unexpected capability data returned for audit commands"),
+        }
+    }
+
+    #[test]
+    fn test_set_command_code_audit_status() {
+        let mut context = create_ctx_with_session();
+        let command_code = CommandCode::GetRandom;
+
+        set_command_audit_status(
+            &mut context,
+            CommandCodeList::new(),
+            CommandCodeList::try_from(vec![command_code]).unwrap(),
+        );
+        assert!(!audit_commands(&mut context).contains(&command_code));
+
+        set_command_audit_status(
+            &mut context,
+            CommandCodeList::try_from(vec![command_code]).unwrap(),
+            CommandCodeList::new(),
+        );
+        assert!(audit_commands(&mut context).contains(&command_code));
+
+        set_command_audit_status(
+            &mut context,
+            CommandCodeList::new(),
+            CommandCodeList::try_from(vec![command_code]).unwrap(),
+        );
+        assert!(!audit_commands(&mut context).contains(&command_code));
+    }
+}


### PR DESCRIPTION
This pull request implements the following Esys wrapper function with its integration test:

- `set_command_code_audit_status` (ESAPI Spec 11.3.50)

Migrated from #625.