### PR TITLE
HashAgile: expose the algorithm and the content

### DIFF
--- a/tss-esapi/src/abstraction/hashing.rs
+++ b/tss-esapi/src/abstraction/hashing.rs
@@ -3,6 +3,12 @@
 
 use crate::interface_types::algorithm::HashingAlgorithm;
 
+#[cfg(feature = "rustcrypto")]
+use {
+    crate::{Error, Result, WrapperErrorKind, structures::HashAgile},
+    digest::{Output, OutputSizeUser},
+};
+
 /// Provides the value of the digest used in this crate for the digest.
 pub trait AssociatedHashingAlgorithm {
     /// Value of the digest when interacting with the TPM.
@@ -47,4 +53,27 @@ impl AssociatedHashingAlgorithm for sha3::Sha3_384 {
 #[cfg(feature = "sha3")]
 impl AssociatedHashingAlgorithm for sha3::Sha3_512 {
     const TPM_DIGEST: HashingAlgorithm = HashingAlgorithm::Sha3_512;
+}
+
+impl HashAgile {
+    #[cfg(feature = "rustcrypto")]
+    #[expect(
+        clippy::unnecessary_fallible_conversions,
+        reason = "GenericArray::From<&[T]> will panic if the payload is not the same length"
+    )]
+    /// Return the hash content of the [`HashAgile`]
+    ///
+    /// # Errors
+    ///
+    /// Return an error if the specified [`AssociatedHashingAlgorithm`] is not the
+    /// one in the [`HashAgile`].
+    pub fn to_output<H: AssociatedHashingAlgorithm + OutputSizeUser>(&self) -> Result<Output<H>> {
+        if self.algorithm == H::TPM_DIGEST {
+            <&Output<H>>::try_from(self.digest.as_bytes())
+                .map_err(|_| Error::local_error(WrapperErrorKind::WrongValueFromTpm))
+                .cloned()
+        } else {
+            Err(Error::local_error(WrapperErrorKind::InvalidParam))
+        }
+    }
 }

--- a/tss-esapi/src/structures/hash/agile.rs
+++ b/tss-esapi/src/structures/hash/agile.rs
@@ -8,8 +8,8 @@ use std::convert::{TryFrom, TryInto};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HashAgile {
-    algorithm: HashingAlgorithm,
-    digest: Digest,
+    pub(crate) algorithm: HashingAlgorithm,
+    pub(crate) digest: Digest,
 }
 
 impl HashAgile {
@@ -63,5 +63,12 @@ impl TryFrom<TPMT_HA> for HashAgile {
                 _ => return Err(Error::local_error(WrapperErrorKind::WrongValueFromTpm)),
             },
         })
+    }
+}
+
+impl HashAgile {
+    /// Return the [`HashingAlgorithm`] of the [`HashAgile`]
+    pub fn hashing_algorithm(&self) -> HashingAlgorithm {
+        self.algorithm
     }
 }


### PR DESCRIPTION
This allows to verify an hmac signature emitted by a TPM.