### PR TITLE
Pin tpm2-tss in Rawhide

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -66,11 +66,11 @@ paste = "1.0.14"
 getrandom = "0.2.11"
 
 [dev-dependencies]
-assert_fs = "1.1.3"
 env_logger = "0.11.5"
 serde_json = "^1.0.108"
 sha2 = { version = "0.10.8", features = ["oid"] }
 socket2 = "0.6.3"
+tempfile = "3.27.0"
 tss-esapi = { path = ".", features = [
     "integration-tests",
     "serde",

--- a/tss-esapi/src/lib.rs
+++ b/tss-esapi/src/lib.rs
@@ -5,7 +5,6 @@
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,
-    no_mangle_generic_items,
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,

--- a/tss-esapi/tests/Dockerfile-fedora-rawhide
+++ b/tss-esapi/tests/Dockerfile-fedora-rawhide
@@ -1,8 +1,37 @@
 FROM fedora:rawhide
 
+# TODO: revert when mainline is fixed
+# RUN dnf install -y \
+# 	tpm2-tss-devel tpm2-tools \
+# 	swtpm swtpm-tools swtpm-selinux\
+# 	rust clippy cargo \
+# 	llvm llvm-devel clang pkg-config \
+# 	dbus-daemon rust-gobject-sys-devel
+
 RUN dnf install -y \
-	tpm2-tss-devel tpm2-tools \
+	libtool automake autoconf autoconf-archive openssl-devel \
+	tpm2-tools git \
 	swtpm swtpm-tools swtpm-selinux\
 	rust clippy cargo \
 	llvm llvm-devel clang pkg-config \
-	dbus-daemon rust-gobject-sys-devel
+	dbus-daemon rust-gobject-sys-devel \
+	&& dnf builddep -y tpm2-tss \
+    && dnf clean all
+
+# Download and install the TSS library
+ENV TPM2_TSS_BINDINGS_VERSION=4.1.3
+ARG TPM2_TSS_VERSION=$TPM2_TSS_BINDINGS_VERSION
+ENV TPM2_TSS_VERSION=$TPM2_TSS_VERSION
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch $TPM2_TSS_VERSION
+RUN cd tpm2-tss \
+	&& ./bootstrap \
+	&& mkdir -p /usr/local/tpm2-tss \
+	&& ./configure --disable-fapi --with-pkgconfigdir=/usr/local/tpm2-tss \
+	&& make -j$(nproc) \
+	&& make install \
+	&& ldconfig \
+	&& rm -rf /tpm2-tss
+
+ENV PKG_CONFIG_PATH=/usr/local/tpm2-tss

--- a/tss-esapi/tests/all-fedora.sh
+++ b/tss-esapi/tests/all-fedora.sh
@@ -17,6 +17,8 @@ if [[ ! -z ${USE_FROZEN_LOCKFILE:+x} ]]; then
 	cp tests/Cargo.lock.frozen ../Cargo.lock
 fi
 
+export LD_LIBRARY_PATH="$(pkg-config --variable=libdir tss2-esys)${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
 ########################################
 # Run the TPM SWTPM server for doctest #
 ########################################

--- a/tss-esapi/tests/integration_tests/common/swtpm.rs
+++ b/tss-esapi/tests/integration_tests/common/swtpm.rs
@@ -7,12 +7,12 @@
 //! communicating over a Unix domain socket in a temporary directory. The session
 //! is cleaned up automatically on drop.
 
-use assert_fs::TempDir;
 use socket2::{Domain, SockAddr, Socket, Type};
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::process::{Child, Stdio};
 use std::time::Duration;
+use tempfile::TempDir;
 use tss_esapi::{
     Context, attributes::SessionAttributesBuilder, constants::SessionType,
     interface_types::algorithm::HashingAlgorithm, structures::SymmetricDefinition,


### PR DESCRIPTION
Pins the tpm2-tss libraries for Fedora rawhide. Removes the no_mangle_generic_items clippy rule.

Together with #663 this should turn the CI green.