### PR TITLE
feat(esapi): add missing TPM2 commands in enhanced authorization

### DIFF
--- a/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
+++ b/tss-esapi/src/context/tpm_commands/enhanced_authorization_ea_commands.rs
@@ -5,17 +5,20 @@ use crate::{
     attributes::LocalityAttributes,
     constants::CommandCode,
     handles::{AuthHandle, NvIndexHandle, ObjectHandle, SessionHandle},
-    interface_types::{YesNo, reserved_handles::NvAuth, session_handles::PolicySession},
+    interface_types::{
+        ArithmeticComparison, YesNo, reserved_handles::NvAuth, session_handles::PolicySession,
+    },
     structures::{
         AuthTicket, Digest, DigestList, Name, Nonce, PcrSelectionList, Signature, Timeout,
         VerifiedTicket,
     },
     tss2_esys::{
         Esys_PolicyAuthValue, Esys_PolicyAuthorize, Esys_PolicyAuthorizeNV, Esys_PolicyCommandCode,
-        Esys_PolicyCpHash, Esys_PolicyDuplicationSelect, Esys_PolicyGetDigest, Esys_PolicyLocality,
-        Esys_PolicyNameHash, Esys_PolicyNvWritten, Esys_PolicyOR, Esys_PolicyPCR,
-        Esys_PolicyPassword, Esys_PolicyPhysicalPresence, Esys_PolicySecret, Esys_PolicySigned,
-        Esys_PolicyTemplate,
+        Esys_PolicyCounterTimer, Esys_PolicyCpHash, Esys_PolicyDuplicationSelect,
+        Esys_PolicyGetDigest, Esys_PolicyLocality, Esys_PolicyNV, Esys_PolicyNameHash,
+        Esys_PolicyNvWritten, Esys_PolicyOR, Esys_PolicyPCR, Esys_PolicyPassword,
+        Esys_PolicyPhysicalPresence, Esys_PolicySecret, Esys_PolicySigned, Esys_PolicyTemplate,
+        Esys_PolicyTicket,
     },
 };
 use log::error;
@@ -111,7 +114,136 @@ impl Context {
         ))
     }
 
-    // Missing function: PolicyTicket
+    /// Include a policy ticket in the policy evaluation.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy_session` - The [PolicySession] being extended.
+    /// * `timeout` - The [Timeout] returned when `ticket` was produced.
+    /// * `cp_hash_a` - A [Digest] of the command parameters for the command being authorized.
+    /// * `policy_ref` - A [Nonce] associated with the policy.
+    /// * `auth_name` - The [Name] of the entity that provided the authorization.
+    /// * `ticket` - The [AuthTicket] produced by a previous policy command.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is similar to TPM2_PolicySigned() except that it takes a
+    /// > ticket instead of a signed authorization. The ticket represents a
+    /// > validated authorization that had an expiration time associated with it.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::convert::TryFrom;
+    /// use tss_esapi::{
+    ///     Context, TctiNameConf,
+    ///     constants::SessionType,
+    ///     handles::{AuthHandle, SessionHandle},
+    ///     interface_types::{algorithm::HashingAlgorithm, session_handles::PolicySession},
+    ///     structures::{Digest, Nonce, SymmetricDefinition},
+    /// };
+    ///
+    /// let mut context = Context::new(
+    ///     TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// )
+    /// .expect("Failed to create Context");
+    /// let trial_session = context
+    ///     .start_auth_session(
+    ///         None,
+    ///         None,
+    ///         None,
+    ///         SessionType::Trial,
+    ///         SymmetricDefinition::AES_256_CFB,
+    ///         HashingAlgorithm::Sha256,
+    ///     )
+    ///     .expect("Failed to create trial session")
+    ///     .expect("Received invalid handle");
+    /// let trial_policy_session =
+    ///     PolicySession::try_from(trial_session).expect("Failed to convert policy session");
+    /// let cp_hash_a = Digest::default();
+    /// let policy_ref = Nonce::default();
+    ///
+    /// // PolicySecret with no expiration returns a NULL ticket. PolicyTicket must
+    /// // reject it, which exercises the command without fabricating TPM-protected data.
+    /// let (timeout, null_ticket) = context
+    ///     .execute_with_nullauth_session(|ctx| {
+    ///         ctx.policy_secret(
+    ///             trial_policy_session,
+    ///             AuthHandle::Endorsement,
+    ///             Nonce::default(),
+    ///             cp_hash_a.clone(),
+    ///             policy_ref.clone(),
+    ///             None,
+    ///         )
+    ///     })
+    ///     .expect("Failed to call PolicySecret");
+    /// let auth_name = context
+    ///     .tr_get_name(AuthHandle::Endorsement.into())
+    ///     .expect("Failed to get endorsement Name");
+    /// let second_trial_session = context
+    ///     .start_auth_session(
+    ///         None,
+    ///         None,
+    ///         None,
+    ///         SessionType::Trial,
+    ///         SymmetricDefinition::AES_256_CFB,
+    ///         HashingAlgorithm::Sha256,
+    ///     )
+    ///     .expect("Failed to create second trial session")
+    ///     .expect("Received invalid handle");
+    /// let second_policy_session = PolicySession::try_from(second_trial_session)
+    ///     .expect("Failed to convert second policy session");
+    ///
+    /// assert!(
+    ///     context
+    ///         .policy_ticket(
+    ///             second_policy_session,
+    ///             timeout,
+    ///             cp_hash_a,
+    ///             policy_ref,
+    ///             auth_name,
+    ///             null_ticket,
+    ///         )
+    ///         .is_err(),
+    ///     "PolicyTicket unexpectedly accepted a NULL ticket",
+    /// );
+    /// context
+    ///     .flush_context(SessionHandle::from(trial_session).into())
+    ///     .expect("Failed to flush first trial session");
+    /// context
+    ///     .flush_context(SessionHandle::from(second_trial_session).into())
+    ///     .expect("Failed to flush second trial session");
+    /// ```
+    pub fn policy_ticket(
+        &mut self,
+        policy_session: PolicySession,
+        timeout: Timeout,
+        cp_hash_a: Digest,
+        policy_ref: Nonce,
+        auth_name: Name,
+        ticket: AuthTicket,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PolicyTicket(
+                    self.mut_context(),
+                    SessionHandle::from(policy_session).into(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &timeout.into(),
+                    &cp_hash_a.into(),
+                    &policy_ref.into(),
+                    &auth_name.into(),
+                    &ticket.try_into()?,
+                )
+            },
+            |ret| {
+                error!("Error when computing policy ticket: {:#010X}", ret);
+            },
+        )
+    }
 
     /// Cause conditional gating of a policy based on an OR'd condition.
     ///
@@ -216,8 +348,222 @@ impl Context {
         )
     }
 
-    // Missing function: PolicyNV
-    // Missing function: PolicyCounterTimer
+    /// Cause conditional gating of a policy based on the contents of an NV index.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy_session` - The [PolicySession] being extended.
+    /// * `auth_handle` - Handle indicating the source of authorization for the NV index.
+    /// * `nv_index_handle` - The [NvIndexHandle] of the NV index to check.
+    /// * `operand_b` - A [Digest] used as the second operand in the comparison.
+    /// * `offset` - The offset in the NV index at which the first operand begins.
+    /// * `operation` - The [ArithmeticComparison] operation.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to cause conditional gating of a policy based
+    /// > on the contents of an NV Index.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::convert::TryFrom;
+    /// use tss_esapi::{
+    ///     Context, TctiNameConf,
+    ///     attributes::NvIndexAttributesBuilder,
+    ///     constants::SessionType,
+    ///     handles::{NvIndexTpmHandle, SessionHandle},
+    ///     interface_types::{
+    ///         ArithmeticComparison,
+    ///         algorithm::HashingAlgorithm,
+    ///         reserved_handles::{NvAuth, Provision},
+    ///         session_handles::PolicySession,
+    ///     },
+    ///     structures::{Digest, MaxNvBuffer, NvPublicBuilder, SymmetricDefinition},
+    /// };
+    ///
+    /// let mut context = Context::new(
+    ///     TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// )
+    /// .expect("Failed to create Context");
+    /// let nv_index =
+    ///     NvIndexTpmHandle::new(0x01500041).expect("Failed to create NV index TPM handle");
+    /// let nv_attributes = NvIndexAttributesBuilder::new()
+    ///     .with_owner_write(true)
+    ///     .with_owner_read(true)
+    ///     .build()
+    ///     .expect("Failed to create NV index attributes");
+    /// let nv_public = NvPublicBuilder::new()
+    ///     .with_nv_index(nv_index)
+    ///     .with_index_name_algorithm(HashingAlgorithm::Sha256)
+    ///     .with_index_attributes(nv_attributes)
+    ///     .with_data_area_size(8)
+    ///     .build()
+    ///     .expect("Failed to build NvPublic");
+    /// let nv_index_handle = context
+    ///     .execute_with_nullauth_session(|ctx| {
+    ///         ctx.nv_define_space(Provision::Owner, None, nv_public)
+    ///     })
+    ///     .expect("Failed to define NV space");
+    /// context
+    ///     .execute_with_nullauth_session(|ctx| {
+    ///         ctx.nv_write(
+    ///             NvAuth::Owner,
+    ///             nv_index_handle,
+    ///             MaxNvBuffer::try_from(vec![0u8; 8]).expect("Failed to create NV data"),
+    ///             0,
+    ///         )
+    ///     })
+    ///     .expect("Failed to write NV data");
+    /// let trial_session = context
+    ///     .start_auth_session(
+    ///         None,
+    ///         None,
+    ///         None,
+    ///         SessionType::Trial,
+    ///         SymmetricDefinition::AES_256_CFB,
+    ///         HashingAlgorithm::Sha256,
+    ///     )
+    ///     .expect("Failed to create trial session")
+    ///     .expect("Received invalid handle");
+    /// let policy_session =
+    ///     PolicySession::try_from(trial_session).expect("Failed to convert policy session");
+    ///
+    /// let policy_result = context.execute_with_nullauth_session(|ctx| {
+    ///     ctx.policy_nv(
+    ///         policy_session,
+    ///         NvAuth::Owner,
+    ///         nv_index_handle,
+    ///         Digest::try_from(vec![0u8; 8]).expect("Failed to create operand"),
+    ///         0,
+    ///         ArithmeticComparison::Eq,
+    ///     )
+    /// });
+    /// context
+    ///     .execute_with_nullauth_session(|ctx| {
+    ///         ctx.nv_undefine_space(Provision::Owner, nv_index_handle)
+    ///     })
+    ///     .expect("Failed to undefine NV space");
+    /// context
+    ///     .flush_context(SessionHandle::from(trial_session).into())
+    ///     .expect("Failed to flush trial session");
+    /// policy_result.expect("Failed to call PolicyNV");
+    /// ```
+    pub fn policy_nv(
+        &mut self,
+        policy_session: PolicySession,
+        auth_handle: NvAuth,
+        nv_index_handle: NvIndexHandle,
+        operand_b: Digest,
+        offset: u16,
+        operation: ArithmeticComparison,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PolicyNV(
+                    self.mut_context(),
+                    AuthHandle::from(auth_handle).into(),
+                    nv_index_handle.into(),
+                    SessionHandle::from(policy_session).into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &operand_b.into(),
+                    offset,
+                    operation.into(),
+                )
+            },
+            |ret| {
+                error!("Error when computing policy NV: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Cause conditional gating of a policy based on the TPM's counter/timer.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy_session` - The [PolicySession] being extended.
+    /// * `operand_b` - A [Digest] used as the second operand in the comparison.
+    /// * `offset` - The offset in the `TPMS_TIME_INFO` structure at which the first operand begins.
+    /// * `operation` - The [ArithmeticComparison] operation.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command is used to cause conditional gating of a policy based
+    /// > on the contents of the TPMS_TIME_INFO structure.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::convert::TryFrom;
+    /// use tss_esapi::{
+    ///     Context, TctiNameConf,
+    ///     constants::SessionType,
+    ///     handles::SessionHandle,
+    ///     interface_types::{
+    ///         ArithmeticComparison, algorithm::HashingAlgorithm, session_handles::PolicySession,
+    ///     },
+    ///     structures::{Digest, SymmetricDefinition},
+    /// };
+    ///
+    /// let mut context = Context::new(
+    ///     TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// )
+    /// .expect("Failed to create Context");
+    /// let trial_session = context
+    ///     .start_auth_session(
+    ///         None,
+    ///         None,
+    ///         None,
+    ///         SessionType::Trial,
+    ///         SymmetricDefinition::AES_256_CFB,
+    ///         HashingAlgorithm::Sha256,
+    ///     )
+    ///     .expect("Failed to create trial session")
+    ///     .expect("Received invalid handle");
+    /// let policy_session =
+    ///     PolicySession::try_from(trial_session).expect("Failed to convert policy session");
+    ///
+    /// context
+    ///     .policy_counter_timer(
+    ///         policy_session,
+    ///         Digest::try_from(vec![0u8; 8]).expect("Failed to create operand"),
+    ///         0,
+    ///         ArithmeticComparison::UnsignedGe,
+    ///     )
+    ///     .expect("Failed to call PolicyCounterTimer");
+    /// context
+    ///     .flush_context(SessionHandle::from(trial_session).into())
+    ///     .expect("Failed to flush trial session");
+    /// ```
+    pub fn policy_counter_timer(
+        &mut self,
+        policy_session: PolicySession,
+        operand_b: Digest,
+        offset: u16,
+        operation: ArithmeticComparison,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_PolicyCounterTimer(
+                    self.mut_context(),
+                    SessionHandle::from(policy_session).into(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &operand_b.into(),
+                    offset,
+                    operation.into(),
+                )
+            },
+            |ret| {
+                error!("Error when computing policy counter timer: {:#010X}", ret);
+            },
+        )
+    }
 
     /// Cause conditional gating of a policy based on command code of authorized command.
     ///

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/enhanced_authorization_ea_commands_tests.rs
@@ -911,3 +911,198 @@ mod test_policy_authorize_nv {
         policy_result.unwrap();
     }
 }
+
+mod test_policy_ticket {
+    use crate::common::create_ctx_with_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        constants::SessionType,
+        handles::AuthHandle,
+        interface_types::{algorithm::HashingAlgorithm, session_handles::PolicySession},
+        structures::{Digest, Nonce, SymmetricDefinition},
+    };
+
+    #[test]
+    fn test_policy_ticket_rejects_null_ticket() {
+        let mut context = create_ctx_with_session();
+
+        let trial_session = context
+            .execute_without_session(|ctx| {
+                ctx.start_auth_session(
+                    None,
+                    None,
+                    None,
+                    SessionType::Trial,
+                    SymmetricDefinition::AES_256_CFB,
+                    HashingAlgorithm::Sha256,
+                )
+            })
+            .expect("Failed to create trial session")
+            .expect("Received invalid handle");
+        let trial_policy_session =
+            PolicySession::try_from(trial_session).expect("Failed to convert to policy session");
+        let cp_hash_a = Digest::default();
+        let policy_ref = Nonce::default();
+
+        // A non-negative expiration produces a NULL ticket. Keep that ticket so
+        // that PolicyTicket can be exercised without fabricating TPM-protected data.
+        let (timeout, null_ticket) = context
+            .policy_secret(
+                trial_policy_session,
+                AuthHandle::Endorsement,
+                Nonce::default(),
+                cp_hash_a.clone(),
+                policy_ref.clone(),
+                None,
+            )
+            .expect("Failed to call policy_secret");
+        let auth_name = context
+            .tr_get_name(AuthHandle::Endorsement.into())
+            .expect("Failed to get endorsement name");
+
+        let second_trial_session = context
+            .execute_without_session(|ctx| {
+                ctx.start_auth_session(
+                    None,
+                    None,
+                    None,
+                    SessionType::Trial,
+                    SymmetricDefinition::AES_256_CFB,
+                    HashingAlgorithm::Sha256,
+                )
+            })
+            .expect("Failed to create second trial session")
+            .expect("Received invalid handle");
+        let second_policy_session = PolicySession::try_from(second_trial_session)
+            .expect("Failed to convert second session to policy session");
+
+        assert!(
+            context
+                .policy_ticket(
+                    second_policy_session,
+                    timeout,
+                    cp_hash_a,
+                    policy_ref,
+                    auth_name,
+                    null_ticket,
+                )
+                .is_err(),
+            "PolicyTicket unexpectedly accepted a NULL ticket",
+        );
+    }
+}
+
+mod test_policy_nv {
+    use crate::common::create_ctx_with_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        attributes::NvIndexAttributesBuilder,
+        constants::SessionType,
+        handles::NvIndexTpmHandle,
+        interface_types::{
+            ArithmeticComparison,
+            algorithm::HashingAlgorithm,
+            reserved_handles::{NvAuth, Provision},
+            session_handles::PolicySession,
+        },
+        structures::{Digest, MaxNvBuffer, NvPublicBuilder, SymmetricDefinition},
+    };
+
+    #[test]
+    fn test_policy_nv() {
+        let mut context = create_ctx_with_session();
+        let nv_index =
+            NvIndexTpmHandle::new(0x01500040).expect("Failed to create NV index TPM handle");
+        let nv_index_attributes = NvIndexAttributesBuilder::new()
+            .with_owner_write(true)
+            .with_owner_read(true)
+            .build()
+            .expect("Failed to create NV index attributes");
+        let nv_public = NvPublicBuilder::new()
+            .with_nv_index(nv_index)
+            .with_index_name_algorithm(HashingAlgorithm::Sha256)
+            .with_index_attributes(nv_index_attributes)
+            .with_data_area_size(8)
+            .build()
+            .expect("Failed to build NvPublic");
+        let nv_index_handle = context
+            .nv_define_space(Provision::Owner, None, nv_public)
+            .expect("Failed to define NV space");
+
+        context
+            .nv_write(
+                NvAuth::Owner,
+                nv_index_handle,
+                MaxNvBuffer::try_from(vec![0u8; 8]).expect("Failed to create NV data"),
+                0,
+            )
+            .expect("Failed to write NV data");
+
+        let trial_session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Trial,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .expect("Failed to create trial session")
+            .expect("Received invalid handle");
+        let policy_session =
+            PolicySession::try_from(trial_session).expect("Failed to convert to policy session");
+
+        let policy_result = context.policy_nv(
+            policy_session,
+            NvAuth::Owner,
+            nv_index_handle,
+            Digest::try_from(vec![0u8; 8]).expect("Failed to create operand"),
+            0,
+            ArithmeticComparison::Eq,
+        );
+
+        context
+            .nv_undefine_space(Provision::Owner, nv_index_handle)
+            .expect("Failed to undefine NV space");
+        policy_result.expect("Failed to call policy_nv");
+    }
+}
+
+mod test_policy_counter_timer {
+    use crate::common::create_ctx_without_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        constants::SessionType,
+        interface_types::{
+            ArithmeticComparison, algorithm::HashingAlgorithm, session_handles::PolicySession,
+        },
+        structures::{Digest, SymmetricDefinition},
+    };
+
+    #[test]
+    fn test_policy_counter_timer() {
+        let mut context = create_ctx_without_session();
+        let trial_session = context
+            .start_auth_session(
+                None,
+                None,
+                None,
+                SessionType::Trial,
+                SymmetricDefinition::AES_256_CFB,
+                HashingAlgorithm::Sha256,
+            )
+            .expect("Failed to create trial session")
+            .expect("Received invalid handle");
+        let policy_session =
+            PolicySession::try_from(trial_session).expect("Failed to convert to policy session");
+
+        context
+            .policy_counter_timer(
+                policy_session,
+                Digest::try_from(vec![0u8; 8]).expect("Failed to create operand"),
+                0,
+                ArithmeticComparison::UnsignedGe,
+            )
+            .expect("Failed to call policy_counter_timer");
+    }
+}

--- a/tss-esapi/tests/integration_tests/interface_types_tests/arithmetic_comparison_tests.rs
+++ b/tss-esapi/tests/integration_tests/interface_types_tests/arithmetic_comparison_tests.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+use tss_esapi::{
+    Error, WrapperErrorKind,
+    constants::tss::{
+        TPM2_EO_BITCLEAR, TPM2_EO_BITSET, TPM2_EO_EQ, TPM2_EO_NEQ, TPM2_EO_SIGNED_GE,
+        TPM2_EO_SIGNED_GT, TPM2_EO_SIGNED_LE, TPM2_EO_SIGNED_LT, TPM2_EO_UNSIGNED_GE,
+        TPM2_EO_UNSIGNED_GT, TPM2_EO_UNSIGNED_LE, TPM2_EO_UNSIGNED_LT,
+    },
+    interface_types::ArithmeticComparison,
+    tss2_esys::TPM2_EO,
+};
+
+#[test]
+fn test_conversions() {
+    let expected_values = [
+        (ArithmeticComparison::Eq, TPM2_EO_EQ),
+        (ArithmeticComparison::Neq, TPM2_EO_NEQ),
+        (ArithmeticComparison::SignedGt, TPM2_EO_SIGNED_GT),
+        (ArithmeticComparison::UnsignedGt, TPM2_EO_UNSIGNED_GT),
+        (ArithmeticComparison::SignedLt, TPM2_EO_SIGNED_LT),
+        (ArithmeticComparison::UnsignedLt, TPM2_EO_UNSIGNED_LT),
+        (ArithmeticComparison::SignedGe, TPM2_EO_SIGNED_GE),
+        (ArithmeticComparison::UnsignedGe, TPM2_EO_UNSIGNED_GE),
+        (ArithmeticComparison::SignedLe, TPM2_EO_SIGNED_LE),
+        (ArithmeticComparison::UnsignedLe, TPM2_EO_UNSIGNED_LE),
+        (ArithmeticComparison::BitSet, TPM2_EO_BITSET),
+        (ArithmeticComparison::BitClear, TPM2_EO_BITCLEAR),
+    ];
+
+    for (comparison, raw_value) in expected_values {
+        assert_eq!(raw_value, TPM2_EO::from(comparison));
+        assert_eq!(
+            comparison,
+            ArithmeticComparison::try_from(raw_value).unwrap()
+        );
+    }
+}
+
+#[test]
+fn test_invalid_conversion() {
+    assert_eq!(
+        Err(Error::WrapperError(WrapperErrorKind::InvalidParam)),
+        ArithmeticComparison::try_from(TPM2_EO::MAX),
+    );
+}

--- a/tss-esapi/tests/integration_tests/interface_types_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/interface_types_tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod algorithms_tests;
+mod arithmetic_comparison_tests;
 mod data_handles_tests;
 mod key_bits_tests;
 mod reserved_handles_tests;


### PR DESCRIPTION
This pull request implements the following Esys wrappers with integration tests:

- `policy_ticket` (ESAPI spec 11.3.60)
- `policy_nv` (11.3.64)
- `policy_counter_timer` (11.3.65)

Migrated from #625.