### PR TITLE
feat(esapi): add missing TPM2 commands in dictionary_attack_functions

### DIFF
--- a/tss-esapi/src/context/tpm_commands/dictionary_attack_functions.rs
+++ b/tss-esapi/src/context/tpm_commands/dictionary_attack_functions.rs
@@ -1,8 +1,131 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use crate::Context;
+use crate::{
+    Context, Result, ReturnCode,
+    handles::AuthHandle,
+    tss2_esys::{Esys_DictionaryAttackLockReset, Esys_DictionaryAttackParameters},
+};
+use log::error;
 
 impl Context {
-    // Missing function: DictionaryAttackLockReset
-    // Missing function: DictionaryAttackParameters
+    /// Reset the dictionary attack lockout.
+    ///
+    /// # Arguments
+    ///
+    /// * `lock_handle` - An [AuthHandle] referencing the lockout authorization.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command cancels the effect of a TPM lockout due to a number of successive
+    /// > authorization failures. If this command is properly authorized, the lockout counter
+    /// > is set to zero.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// use tss_esapi::handles::AuthHandle;
+    /// # let mut context = Context::new(
+    /// #     TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// # )
+    /// # .expect("Failed to create Context");
+    ///
+    /// context
+    ///     .execute_with_nullauth_session(|ctx| {
+    ///         ctx.dictionary_attack_lock_reset(AuthHandle::Lockout)
+    ///     })
+    ///     .expect("Failed to reset dictionary attack lockout");
+    /// ```
+    pub fn dictionary_attack_lock_reset(&mut self, lock_handle: AuthHandle) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_DictionaryAttackLockReset(
+                    self.mut_context(),
+                    lock_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                )
+            },
+            |ret| {
+                error!("Error resetting dictionary attack lockout: {:#010X}", ret);
+            },
+        )
+    }
+
+    /// Set the dictionary attack parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `lock_handle` - An [AuthHandle] referencing the lockout authorization.
+    /// * `new_max_tries` - Count of authorization failures before the lockout is imposed.
+    /// * `new_recovery_time` - Time in seconds before the authorization failure count is
+    ///   automatically decremented. A value of zero disables dictionary attack protection.
+    /// * `lockout_recovery` - Time in seconds after a lockout authorization failure before use of
+    ///   the lockout authorization is allowed. A value of zero requires a reboot for recovery.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command changes the lockout parameters.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// use tss_esapi::{constants::PropertyTag, handles::AuthHandle};
+    /// # let mut context = Context::new(
+    /// #     TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// # )
+    /// # .expect("Failed to create Context");
+    /// # let new_max_tries = context
+    /// #     .get_tpm_property(PropertyTag::MaxAuthFail)
+    /// #     .expect("Failed to get maximum authorization failures")
+    /// #     .expect("TPM did not report maximum authorization failures");
+    /// # let new_recovery_time = context
+    /// #     .get_tpm_property(PropertyTag::LockoutInterval)
+    /// #     .expect("Failed to get lockout interval")
+    /// #     .expect("TPM did not report the lockout interval");
+    /// # let lockout_recovery = context
+    /// #     .get_tpm_property(PropertyTag::LockoutRecovery)
+    /// #     .expect("Failed to get lockout recovery time")
+    /// #     .expect("TPM did not report the lockout recovery time");
+    ///
+    /// context
+    ///     .execute_with_nullauth_session(|ctx| {
+    ///         ctx.dictionary_attack_parameters(
+    ///             AuthHandle::Lockout,
+    ///             new_max_tries,
+    ///             new_recovery_time,
+    ///             lockout_recovery,
+    ///         )
+    ///     })
+    ///     .expect("Failed to set dictionary attack parameters");
+    /// ```
+    pub fn dictionary_attack_parameters(
+        &mut self,
+        lock_handle: AuthHandle,
+        new_max_tries: u32,
+        new_recovery_time: u32,
+        lockout_recovery: u32,
+    ) -> Result<()> {
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_DictionaryAttackParameters(
+                    self.mut_context(),
+                    lock_handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    new_max_tries,
+                    new_recovery_time,
+                    lockout_recovery,
+                )
+            },
+            |ret| {
+                error!("Error setting dictionary attack parameters: {:#010X}", ret);
+            },
+        )
+    }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/dictionary_attack_functions_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/dictionary_attack_functions_tests.rs
@@ -1,2 +1,90 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+mod test_dictionary_attack_lock_reset {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{constants::PropertyTag, handles::AuthHandle};
+
+    #[test]
+    fn test_dictionary_attack_lock_reset() {
+        let mut context = create_ctx_with_session();
+        context
+            .dictionary_attack_lock_reset(AuthHandle::Lockout)
+            .expect("Failed to reset dictionary attack lockout");
+
+        let lockout_counter = context
+            .get_tpm_property(PropertyTag::LockoutCounter)
+            .expect("Failed to get dictionary attack lockout counter")
+            .expect("TPM did not report the dictionary attack lockout counter");
+        assert_eq!(0, lockout_counter);
+    }
+}
+
+mod test_dictionary_attack_parameters {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        Context,
+        constants::{CapabilityType, PropertyTag},
+        handles::AuthHandle,
+        structures::CapabilityData,
+    };
+
+    const NEW_MAX_TRIES: u32 = 10;
+    const NEW_RECOVERY_TIME: u32 = 300;
+    const NEW_LOCKOUT_RECOVERY: u32 = 300;
+
+    fn read_dictionary_attack_parameters(context: &mut Context) -> (u32, u32, u32) {
+        let (capability_data, _) = context
+            .execute_without_session(|ctx| {
+                ctx.get_capability(
+                    CapabilityType::TpmProperties,
+                    PropertyTag::MaxAuthFail.into(),
+                    3,
+                )
+            })
+            .expect("Failed to get dictionary attack parameters");
+        let CapabilityData::TpmProperties(properties) = capability_data else {
+            panic!("TPM returned an unexpected capability type");
+        };
+
+        let property_value = |property| {
+            properties
+                .find(property)
+                .unwrap_or_else(|| panic!("TPM did not report {property:?}"))
+                .value()
+        };
+
+        (
+            property_value(PropertyTag::MaxAuthFail),
+            property_value(PropertyTag::LockoutInterval),
+            property_value(PropertyTag::LockoutRecovery),
+        )
+    }
+
+    #[test]
+    fn test_dictionary_attack_parameters() {
+        let mut context = create_ctx_with_session();
+        let original_parameters = read_dictionary_attack_parameters(&mut context);
+
+        context
+            .dictionary_attack_parameters(
+                AuthHandle::Lockout,
+                NEW_MAX_TRIES,
+                NEW_RECOVERY_TIME,
+                NEW_LOCKOUT_RECOVERY,
+            )
+            .expect("Failed to set dictionary attack parameters");
+        assert_eq!(
+            (NEW_MAX_TRIES, NEW_RECOVERY_TIME, NEW_LOCKOUT_RECOVERY),
+            read_dictionary_attack_parameters(&mut context),
+        );
+
+        context
+            .dictionary_attack_parameters(
+                AuthHandle::Lockout,
+                original_parameters.0,
+                original_parameters.1,
+                original_parameters.2,
+            )
+            .expect("Failed to restore dictionary attack parameters");
+    }
+}


### PR DESCRIPTION
This pull request adds the following missing Esys wrappers with integration tests:

- `dictionary_attack_lock_reset` (ESAPI spec 11.3.86)
- `dictionary_attack_parameters` (11.3.87)

Migrated from #625.