### PR TITLE
feat(esapi): add missing TPM2 commands in hash_hmac_event_sequences

### DIFF
--- a/tss-esapi/src/context/tpm_commands/hash_hmac_event_sequences.rs
+++ b/tss-esapi/src/context/tpm_commands/hash_hmac_event_sequences.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     Context, Result, ReturnCode,
-    handles::{ObjectHandle, TpmHandle},
-    interface_types::{algorithm::HashingAlgorithm, reserved_handles::Hierarchy},
-    structures::{Auth, Digest, HashcheckTicket, MaxBuffer},
+    handles::{ObjectHandle, PcrHandle, TpmHandle},
+    interface_types::{
+        algorithm::{HashingAlgorithm, MacSchemeAlgorithm},
+        reserved_handles::Hierarchy,
+    },
+    structures::{Auth, Digest, DigestValues, HashcheckTicket, MaxBuffer},
     tss2_esys::{
-        Esys_HMAC_Start, Esys_HashSequenceStart, Esys_SequenceComplete, Esys_SequenceUpdate,
+        Esys_EventSequenceComplete, Esys_HMAC_Start, Esys_HashSequenceStart, Esys_MAC_Start,
+        Esys_SequenceComplete, Esys_SequenceUpdate,
     },
 };
 use log::error;
@@ -142,7 +146,132 @@ impl Context {
         Ok(ObjectHandle::from(sequence_handle))
     }
 
-    // Missing function: MAC_Start
+    /// Starts a MAC sequence using the specified key and scheme.
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` - An [ObjectHandle] referencing an unrestricted keyed-hash or symmetric-cipher
+    ///   signing key.
+    /// * `scheme` - The [MacSchemeAlgorithm] to use. A hash algorithm selects HMAC and
+    ///   [MacSchemeAlgorithm::Cmac] selects a symmetric block-cipher MAC. If the key has a default
+    ///   scheme, [MacSchemeAlgorithm::Null] selects it.
+    /// * `auth` - Optional authorization value for subsequent use of the sequence.
+    ///
+    /// # Returns
+    ///
+    /// An [ObjectHandle] referencing the newly created MAC sequence.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command starts a MAC sequence. The TPM will create and initialize a MAC sequence
+    /// > structure, assign a handle to the sequence, and set the authValue of the sequence object
+    /// > to the value in auth.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// # use tss_esapi::attributes::ObjectAttributesBuilder;
+    /// # use tss_esapi::interface_types::{
+    /// #     algorithm::{HashingAlgorithm, PublicAlgorithm},
+    /// #     reserved_handles::Hierarchy,
+    /// # };
+    /// # use tss_esapi::structures::{
+    /// #     KeyedHashScheme, PublicBuilder, PublicKeyedHashParameters,
+    /// # };
+    /// use tss_esapi::{
+    ///     interface_types::algorithm::MacSchemeAlgorithm,
+    ///     structures::MaxBuffer,
+    /// };
+    /// # let mut context = Context::new(
+    /// #     TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// # )
+    /// # .expect("Failed to create Context");
+    /// # let object_attributes = ObjectAttributesBuilder::new()
+    /// #     .with_sign_encrypt(true)
+    /// #     .with_sensitive_data_origin(true)
+    /// #     .with_user_with_auth(true)
+    /// #     .build()
+    /// #     .expect("Failed to build object attributes");
+    /// # let key_public = PublicBuilder::new()
+    /// #     .with_public_algorithm(PublicAlgorithm::KeyedHash)
+    /// #     .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+    /// #     .with_object_attributes(object_attributes)
+    /// #     .with_keyed_hash_parameters(PublicKeyedHashParameters::new(
+    /// #         KeyedHashScheme::HMAC_SHA_256,
+    /// #     ))
+    /// #     .with_keyed_hash_unique_identifier(Default::default())
+    /// #     .build()
+    /// #     .expect("Failed to build keyed-hash public area");
+    /// # let key_handle = context
+    /// #     .execute_with_nullauth_session(|ctx| {
+    /// #         ctx.create_primary(Hierarchy::Owner, key_public, None, None, None, None)
+    /// #     })
+    /// #     .expect("Failed to create MAC key")
+    /// #     .key_handle;
+    ///
+    /// let sequence_handle = context
+    ///     .execute_with_nullauth_session(|ctx| {
+    ///         ctx.mac_sequence_start(
+    ///             key_handle.into(),
+    ///             MacSchemeAlgorithm::Sha256,
+    ///             None,
+    ///         )
+    ///     })
+    ///     .expect("Failed to start MAC sequence");
+    /// context
+    ///     .execute_with_nullauth_session(|ctx| {
+    ///         ctx.sequence_update(
+    ///             sequence_handle,
+    ///             MaxBuffer::from_bytes(b"data to authenticate")
+    ///                 .expect("Failed to create sequence buffer"),
+    ///         )
+    ///     })
+    ///     .expect("Failed to update MAC sequence");
+    /// let (mac, _ticket) = context
+    ///     .execute_with_nullauth_session(|ctx| {
+    ///         ctx.sequence_complete(
+    ///             sequence_handle,
+    ///             MaxBuffer::default(),
+    ///             Hierarchy::Null,
+    ///         )
+    ///     })
+    ///     .expect("Failed to complete MAC sequence");
+    /// assert_eq!(32, mac.len());
+    /// # context
+    /// #     .flush_context(key_handle.into())
+    /// #     .expect("Failed to flush MAC key");
+    /// ```
+    pub fn mac_sequence_start(
+        &mut self,
+        handle: ObjectHandle,
+        scheme: MacSchemeAlgorithm,
+        auth: Option<Auth>,
+    ) -> Result<ObjectHandle> {
+        let mut sequence_handle = ObjectHandle::None.into();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_MAC_Start(
+                    self.mut_context(),
+                    handle.into(),
+                    self.required_session_1()?,
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &auth.unwrap_or_default().into(),
+                    scheme.into(),
+                    &mut sequence_handle,
+                )
+            },
+            |ret| {
+                error!(
+                    "Error failed to perform MAC sequence start operation: {:#010X}",
+                    ret
+                );
+            },
+        )?;
+        Ok(ObjectHandle::from(sequence_handle))
+    }
 
     /// Starts hash sequence of large data (larger than [`MaxBuffer::MAX_SIZE`]) using the specified algorithm.
     ///
@@ -322,5 +451,115 @@ impl Context {
         ))
     }
 
-    // Missing function: EventSequenceComplete
+    /// Completes an Event Sequence and extends a PCR with the resulting digests.
+    ///
+    /// # Arguments
+    ///
+    /// * `pcr_handle` - A [PcrHandle] of the PCR to extend.
+    /// * `sequence_handle` - An [ObjectHandle] referencing the Event Sequence to complete.
+    /// * `buffer` - A [MaxBuffer] containing the final data to include in the event.
+    ///
+    /// # Returns
+    ///
+    /// A [DigestValues] containing one digest for each implemented hash algorithm.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command adds the last part of data, if any, to an Event Sequence and returns
+    /// > the result in a digest list. If pcrHandle references a PCR and not TPM_RH_NULL, then
+    /// > the returned digest list is processed in the same manner as the digest list input
+    /// > parameter to TPM2_PCR_Extend(). That is, if a bank contains a PCR associated with
+    /// > pcrHandle, it is extended with the associated digest value from the list.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use tss_esapi::{Context, TctiNameConf};
+    /// use tss_esapi::{
+    ///     handles::PcrHandle,
+    ///     interface_types::{
+    ///         algorithm::HashingAlgorithm,
+    ///         session_handles::AuthSession,
+    ///     },
+    ///     structures::MaxBuffer,
+    /// };
+    /// # let mut context = Context::new(
+    /// #     TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// # )
+    /// # .expect("Failed to create Context");
+    /// # context
+    /// #     .execute_with_nullauth_session(|ctx| ctx.pcr_reset(PcrHandle::Pcr16))
+    /// #     .expect("Failed to reset PCR 16 before the example");
+    /// let sequence_handle = context
+    ///     .hash_sequence_start(HashingAlgorithm::Null, None)
+    ///     .expect("Failed to start Event Sequence");
+    /// let digests = context
+    ///     .execute_with_sessions(
+    ///         (
+    ///             Some(AuthSession::Password),
+    ///             Some(AuthSession::Password),
+    ///             None,
+    ///         ),
+    ///         |ctx| {
+    ///             ctx.event_sequence_complete(
+    ///                 PcrHandle::Pcr16,
+    ///                 sequence_handle,
+    ///                 MaxBuffer::from_bytes(b"event data")
+    ///                     .expect("Failed to create event buffer"),
+    ///             )
+    ///         },
+    ///     )
+    ///     .expect("Failed to complete Event Sequence");
+    /// assert!(digests.value().contains_key(&HashingAlgorithm::Sha256));
+    /// # context
+    /// #     .execute_with_nullauth_session(|ctx| ctx.pcr_reset(PcrHandle::Pcr16))
+    /// #     .expect("Failed to reset PCR 16 after the example");
+    /// ```
+    pub fn event_sequence_complete(
+        &mut self,
+        pcr_handle: PcrHandle,
+        sequence_handle: ObjectHandle,
+        buffer: MaxBuffer,
+    ) -> Result<DigestValues> {
+        let mut results_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_EventSequenceComplete(
+                    self.mut_context(),
+                    pcr_handle.into(),
+                    sequence_handle.into(),
+                    self.required_session_1()?,
+                    self.required_session_2()?,
+                    self.optional_session_3(),
+                    &buffer.into(),
+                    &mut results_ptr,
+                )
+            },
+            |ret| {
+                error!("Error completing event sequence: {:#010X}", ret);
+            },
+        )?;
+
+        let results = Context::ffi_data_to_owned(results_ptr)?;
+        let mut digest_values = DigestValues::new();
+        for index in 0..results.count as usize {
+            let hash = results.digests[index];
+            let algorithm = HashingAlgorithm::try_from(hash.hashAlg)?;
+            let digest = match algorithm {
+                HashingAlgorithm::Sha1 => Digest::from(unsafe { hash.digest.sha1 }),
+                HashingAlgorithm::Sha256 => Digest::from(unsafe { hash.digest.sha256 }),
+                HashingAlgorithm::Sha384 => Digest::from(unsafe { hash.digest.sha384 }),
+                HashingAlgorithm::Sha512 => Digest::from(unsafe { hash.digest.sha512 }),
+                HashingAlgorithm::Sm3_256 => Digest::from(unsafe { hash.digest.sm3_256 }),
+                _ => {
+                    return Err(crate::Error::local_error(
+                        crate::WrapperErrorKind::WrongValueFromTpm,
+                    ));
+                }
+            };
+            digest_values.set(algorithm, digest);
+        }
+        Ok(digest_values)
+    }
 }

--- a/tss-esapi/src/interface_types/algorithm.rs
+++ b/tss-esapi/src/interface_types/algorithm.rs
@@ -5,8 +5,9 @@ use crate::{
     constants::AlgorithmIdentifier,
     tss2_esys::{
         TPMI_ALG_ASYM, TPMI_ALG_ECC_SCHEME, TPMI_ALG_HASH, TPMI_ALG_KDF, TPMI_ALG_KEYEDHASH_SCHEME,
-        TPMI_ALG_PUBLIC, TPMI_ALG_RSA_DECRYPT, TPMI_ALG_RSA_SCHEME, TPMI_ALG_SIG_SCHEME,
-        TPMI_ALG_SYM, TPMI_ALG_SYM_MODE, TPMI_ALG_SYM_OBJECT, TPMI_ECC_KEY_EXCHANGE,
+        TPMI_ALG_MAC_SCHEME, TPMI_ALG_PUBLIC, TPMI_ALG_RSA_DECRYPT, TPMI_ALG_RSA_SCHEME,
+        TPMI_ALG_SIG_SCHEME, TPMI_ALG_SYM, TPMI_ALG_SYM_MODE, TPMI_ALG_SYM_OBJECT,
+        TPMI_ECC_KEY_EXCHANGE,
     },
 };
 use log::error;
@@ -74,6 +75,88 @@ impl TryFrom<TPMI_ALG_HASH> for HashingAlgorithm {
 
     fn try_from(tpmi_alg_hash: TPMI_ALG_HASH) -> Result<Self> {
         HashingAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_alg_hash)?)
+    }
+}
+
+/// Enum containing the supported MAC schemes.
+///
+/// # Details
+/// This corresponds to the `TPMI_ALG_MAC_SCHEME` interface type. Hash algorithms select HMAC,
+/// while [Cmac][MacSchemeAlgorithm::Cmac] selects a symmetric block-cipher MAC.
+///
+/// # Example
+///
+/// ```rust
+/// use tss_esapi::{
+///     constants::AlgorithmIdentifier,
+///     interface_types::algorithm::MacSchemeAlgorithm,
+/// };
+///
+/// let scheme = MacSchemeAlgorithm::Sha256;
+/// assert_eq!(AlgorithmIdentifier::Sha256, scheme.into());
+/// ```
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum MacSchemeAlgorithm {
+    Sha1,
+    Sha256,
+    Sha384,
+    Sha512,
+    Sm3_256,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
+    Cmac,
+    Null,
+}
+
+impl From<MacSchemeAlgorithm> for AlgorithmIdentifier {
+    fn from(mac_scheme_algorithm: MacSchemeAlgorithm) -> Self {
+        match mac_scheme_algorithm {
+            MacSchemeAlgorithm::Sha1 => AlgorithmIdentifier::Sha1,
+            MacSchemeAlgorithm::Sha256 => AlgorithmIdentifier::Sha256,
+            MacSchemeAlgorithm::Sha384 => AlgorithmIdentifier::Sha384,
+            MacSchemeAlgorithm::Sha512 => AlgorithmIdentifier::Sha512,
+            MacSchemeAlgorithm::Sm3_256 => AlgorithmIdentifier::Sm3_256,
+            MacSchemeAlgorithm::Sha3_256 => AlgorithmIdentifier::Sha3_256,
+            MacSchemeAlgorithm::Sha3_384 => AlgorithmIdentifier::Sha3_384,
+            MacSchemeAlgorithm::Sha3_512 => AlgorithmIdentifier::Sha3_512,
+            MacSchemeAlgorithm::Cmac => AlgorithmIdentifier::Cmac,
+            MacSchemeAlgorithm::Null => AlgorithmIdentifier::Null,
+        }
+    }
+}
+
+impl TryFrom<AlgorithmIdentifier> for MacSchemeAlgorithm {
+    type Error = Error;
+
+    fn try_from(algorithm_identifier: AlgorithmIdentifier) -> Result<Self> {
+        match algorithm_identifier {
+            AlgorithmIdentifier::Sha1 => Ok(MacSchemeAlgorithm::Sha1),
+            AlgorithmIdentifier::Sha256 => Ok(MacSchemeAlgorithm::Sha256),
+            AlgorithmIdentifier::Sha384 => Ok(MacSchemeAlgorithm::Sha384),
+            AlgorithmIdentifier::Sha512 => Ok(MacSchemeAlgorithm::Sha512),
+            AlgorithmIdentifier::Sm3_256 => Ok(MacSchemeAlgorithm::Sm3_256),
+            AlgorithmIdentifier::Sha3_256 => Ok(MacSchemeAlgorithm::Sha3_256),
+            AlgorithmIdentifier::Sha3_384 => Ok(MacSchemeAlgorithm::Sha3_384),
+            AlgorithmIdentifier::Sha3_512 => Ok(MacSchemeAlgorithm::Sha3_512),
+            AlgorithmIdentifier::Cmac => Ok(MacSchemeAlgorithm::Cmac),
+            AlgorithmIdentifier::Null => Ok(MacSchemeAlgorithm::Null),
+            _ => Err(Error::local_error(WrapperErrorKind::InvalidParam)),
+        }
+    }
+}
+
+impl From<MacSchemeAlgorithm> for TPMI_ALG_MAC_SCHEME {
+    fn from(mac_scheme_algorithm: MacSchemeAlgorithm) -> Self {
+        AlgorithmIdentifier::from(mac_scheme_algorithm).into()
+    }
+}
+
+impl TryFrom<TPMI_ALG_MAC_SCHEME> for MacSchemeAlgorithm {
+    type Error = Error;
+
+    fn try_from(tpmi_alg_mac_scheme: TPMI_ALG_MAC_SCHEME) -> Result<Self> {
+        MacSchemeAlgorithm::try_from(AlgorithmIdentifier::try_from(tpmi_alg_mac_scheme)?)
     }
 }
 

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hash_hmac_event_sequences_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/hash_hmac_event_sequences_tests.rs
@@ -155,3 +155,127 @@ mod test_hmac_sequence {
         let _ticket = ticket.expect("HashcheckTicket should be returned");
     }
 }
+
+mod test_mac_sequence {
+    use crate::common::create_ctx_with_session;
+    use tss_esapi::{
+        attributes::ObjectAttributesBuilder,
+        interface_types::{
+            algorithm::{HashingAlgorithm, MacSchemeAlgorithm, PublicAlgorithm},
+            reserved_handles::Hierarchy,
+        },
+        structures::{KeyedHashScheme, MaxBuffer, PublicBuilder, PublicKeyedHashParameters},
+    };
+
+    #[test]
+    fn test_mac_sequence_matches_hmac_sequence() {
+        let mut context = create_ctx_with_session();
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_sign_encrypt(true)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .build()
+            .expect("Failed to build object attributes");
+        let key_public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::KeyedHash)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_keyed_hash_parameters(PublicKeyedHashParameters::new(
+                KeyedHashScheme::HMAC_SHA_256,
+            ))
+            .with_keyed_hash_unique_identifier(Default::default())
+            .build()
+            .expect("Failed to build public structure for key");
+        let key_handle = context
+            .create_primary(Hierarchy::Owner, key_public, None, None, None, None)
+            .expect("Failed to create primary MAC key")
+            .key_handle;
+        let data = MaxBuffer::from_bytes(b"data authenticated by both sequence commands")
+            .expect("Failed to create MAC input buffer");
+
+        let mac_sequence = context
+            .mac_sequence_start(key_handle.into(), MacSchemeAlgorithm::Sha256, None)
+            .expect("Failed to start MAC sequence");
+        context
+            .sequence_update(mac_sequence, data.clone())
+            .expect("Failed to update MAC sequence");
+        let (mac_result, _) = context
+            .sequence_complete(mac_sequence, MaxBuffer::default(), Hierarchy::Null)
+            .expect("Failed to complete MAC sequence");
+
+        let hmac_sequence = context
+            .hmac_sequence_start(key_handle.into(), HashingAlgorithm::Sha256, None)
+            .expect("Failed to start HMAC sequence");
+        context
+            .sequence_update(hmac_sequence, data)
+            .expect("Failed to update HMAC sequence");
+        let (hmac_result, _) = context
+            .sequence_complete(hmac_sequence, MaxBuffer::default(), Hierarchy::Null)
+            .expect("Failed to complete HMAC sequence");
+
+        assert_eq!(hmac_result, mac_result);
+        context
+            .flush_context(key_handle.into())
+            .expect("Failed to flush MAC key");
+    }
+}
+
+mod test_event_sequence_complete {
+    use crate::common::create_ctx_with_session;
+    use sha2::{Digest as _, Sha256};
+    use tss_esapi::{
+        handles::PcrHandle,
+        interface_types::{algorithm::HashingAlgorithm, session_handles::AuthSession},
+        structures::MaxBuffer,
+    };
+
+    #[test]
+    fn test_event_sequence_complete() {
+        let mut context = create_ctx_with_session();
+        let pcr_session = context.sessions().0;
+        context
+            .execute_with_session(pcr_session, |ctx| ctx.pcr_reset(PcrHandle::Pcr16))
+            .expect("Failed to reset PCR 16 before test");
+
+        let first_data = [0x01, 0x02, 0x03, 0x04];
+        let final_data = [0x05, 0x06];
+        let sequence_handle = context
+            .hash_sequence_start(HashingAlgorithm::Null, None)
+            .expect("Failed to start Event Sequence");
+        context
+            .sequence_update(
+                sequence_handle,
+                MaxBuffer::from_bytes(&first_data).expect("Failed to create first event buffer"),
+            )
+            .expect("Failed to update Event Sequence");
+        let digest_values = context
+            .execute_with_sessions(
+                (
+                    Some(AuthSession::Password),
+                    Some(AuthSession::Password),
+                    None,
+                ),
+                |ctx| {
+                    ctx.event_sequence_complete(
+                        PcrHandle::Pcr16,
+                        sequence_handle,
+                        MaxBuffer::from_bytes(&final_data)
+                            .expect("Failed to create final event buffer"),
+                    )
+                },
+            )
+            .expect("Failed to complete Event Sequence");
+
+        let expected_digest =
+            Sha256::digest([first_data.as_slice(), final_data.as_slice()].concat());
+        let actual_digest = digest_values
+            .value()
+            .get(&HashingAlgorithm::Sha256)
+            .expect("Event Sequence did not return a SHA-256 digest");
+        assert_eq!(&expected_digest[..], actual_digest.as_bytes());
+
+        context
+            .execute_with_session(pcr_session, |ctx| ctx.pcr_reset(PcrHandle::Pcr16))
+            .expect("Failed to reset PCR 16 after test");
+    }
+}

--- a/tss-esapi/tests/integration_tests/interface_types_tests/algorithms_tests.rs
+++ b/tss-esapi/tests/integration_tests/interface_types_tests/algorithms_tests.rs
@@ -106,6 +106,49 @@ mod hashing_algorithm_tests {
     }
 }
 
+mod mac_scheme_algorithm_tests {
+    use super::*;
+    use tss_esapi::{
+        constants::{
+            AlgorithmIdentifier,
+            tss::{
+                TPM2_ALG_CMAC, TPM2_ALG_NULL, TPM2_ALG_SHA1, TPM2_ALG_SHA3_256, TPM2_ALG_SHA3_384,
+                TPM2_ALG_SHA3_512, TPM2_ALG_SHA256, TPM2_ALG_SHA384, TPM2_ALG_SHA512,
+                TPM2_ALG_SM3_256,
+            },
+        },
+        interface_types::algorithm::MacSchemeAlgorithm,
+    };
+
+    #[test]
+    fn test_mac_scheme_algorithm_conversion() {
+        test_conversion!(TPM2_ALG_SHA1, MacSchemeAlgorithm::Sha1);
+        test_conversion!(TPM2_ALG_SHA256, MacSchemeAlgorithm::Sha256);
+        test_conversion!(TPM2_ALG_SHA384, MacSchemeAlgorithm::Sha384);
+        test_conversion!(TPM2_ALG_SHA512, MacSchemeAlgorithm::Sha512);
+        test_conversion!(TPM2_ALG_SM3_256, MacSchemeAlgorithm::Sm3_256);
+        test_conversion!(TPM2_ALG_SHA3_256, MacSchemeAlgorithm::Sha3_256);
+        test_conversion!(TPM2_ALG_SHA3_384, MacSchemeAlgorithm::Sha3_384);
+        test_conversion!(TPM2_ALG_SHA3_512, MacSchemeAlgorithm::Sha3_512);
+        test_conversion!(TPM2_ALG_CMAC, MacSchemeAlgorithm::Cmac);
+        test_conversion!(TPM2_ALG_NULL, MacSchemeAlgorithm::Null);
+    }
+
+    #[test]
+    fn test_conversion_of_incorrect_algorithm() {
+        test_invalid_tpm_alg_conversion!(
+            TPM2_ALG_RSA,
+            MacSchemeAlgorithm,
+            WrapperErrorKind::InvalidParam
+        );
+        test_invalid_algorithm_conversion!(
+            AlgorithmIdentifier::Ecc,
+            MacSchemeAlgorithm,
+            WrapperErrorKind::InvalidParam
+        )
+    }
+}
+
 mod keyed_hash_scheme_tests {
     use super::*;
     use tss_esapi::{


### PR DESCRIPTION
Adds the following Esys wrappers and their integration tests:

- `mac_sequence_start` for TPM2_MAC_Start (ESAPI spec 11.3.34)
- `event_sequence_complete` (11.3.38)

To implement the latter, the Rust wrapper type for `TPMI_ALG_MAC_SCHEME` and its integration tests are added.