### PR TITLE
feat(esapi): add the incremental_self_test command

### DIFF
--- a/tss-esapi/src/context/tpm_commands/testing.rs
+++ b/tss-esapi/src/context/tpm_commands/testing.rs
@@ -1,10 +1,11 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    Context, Result, ReturnCode,
+    Context, Error, Result, ReturnCode, WrapperErrorKind,
+    constants::AlgorithmIdentifier,
     interface_types::YesNo,
     structures::MaxBuffer,
-    tss2_esys::{Esys_GetTestResult, Esys_SelfTest},
+    tss2_esys::{Esys_GetTestResult, Esys_IncrementalSelfTest, Esys_SelfTest, TPML_ALG},
 };
 use log::error;
 use std::convert::TryFrom;
@@ -29,7 +30,105 @@ impl Context {
         )
     }
 
-    // Missing function: incremental_self_test
+    /// Performs incremental self-tests for selected algorithms.
+    ///
+    /// Algorithms that have already been tested are not tested again. Passing an empty slice does
+    /// not start any tests and can be used to query which algorithms remain untested.
+    ///
+    /// # Arguments
+    ///
+    /// * `to_test` - Algorithms that the TPM should test in anticipation of future use.
+    ///
+    /// # Returns
+    ///
+    /// The algorithms or functions for which some testing remains incomplete. This is not a list
+    /// of only the tests scheduled by this call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [WrapperErrorKind::WrongParamSize] if `to_test` exceeds the TPM algorithm-list
+    /// capacity. Invalid data returned by the TPM is also reported as an error.
+    ///
+    /// # Details
+    ///
+    /// *From the specification*
+    /// > This command causes the TPM to perform a test of the selected algorithms.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tss_esapi::{Context, TctiNameConf};
+    ///
+    /// let mut context = Context::new(
+    ///     TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+    /// )
+    /// .expect("Failed to create Context");
+    ///
+    /// let to_do_list = context
+    ///     .incremental_self_test(&[])
+    ///     .expect("Failed to query pending self-tests");
+    /// println!("{} algorithms still require testing", to_do_list.len());
+    /// ```
+    pub fn incremental_self_test(
+        &mut self,
+        to_test: &[AlgorithmIdentifier],
+    ) -> Result<Vec<AlgorithmIdentifier>> {
+        let mut to_test_list = TPML_ALG::default();
+        if to_test.len() > to_test_list.algorithms.len() {
+            error!(
+                "Too many algorithms requested for incremental self-test ({} > {})",
+                to_test.len(),
+                to_test_list.algorithms.len()
+            );
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+
+        to_test_list.count = u32::try_from(to_test.len())
+            .map_err(|_| Error::local_error(WrapperErrorKind::WrongParamSize))?;
+        for (&algorithm, destination) in to_test.iter().zip(to_test_list.algorithms.iter_mut()) {
+            *destination = algorithm.into();
+        }
+
+        let mut to_do_list_ptr = null_mut();
+        ReturnCode::ensure_success(
+            unsafe {
+                Esys_IncrementalSelfTest(
+                    self.mut_context(),
+                    self.optional_session_1(),
+                    self.optional_session_2(),
+                    self.optional_session_3(),
+                    &to_test_list,
+                    &mut to_do_list_ptr,
+                )
+            },
+            |ret| {
+                error!("Error performing incremental self-test: {:#010X}", ret);
+            },
+        )?;
+
+        let to_do_list = Context::ffi_data_to_owned(to_do_list_ptr)?;
+        let to_do_count = usize::try_from(to_do_list.count).map_err(|_| {
+            error!(
+                "Invalid algorithm count returned by incremental self-test: {}",
+                to_do_list.count
+            );
+            Error::local_error(WrapperErrorKind::WrongValueFromTpm)
+        })?;
+        if to_do_count > to_do_list.algorithms.len() {
+            error!(
+                "Invalid algorithm count returned by incremental self-test ({} > {})",
+                to_do_count,
+                to_do_list.algorithms.len()
+            );
+            return Err(Error::local_error(WrapperErrorKind::WrongValueFromTpm));
+        }
+
+        to_do_list.algorithms[..to_do_count]
+            .iter()
+            .copied()
+            .map(AlgorithmIdentifier::try_from)
+            .collect()
+    }
 
     /// Get the TPM self test result
     ///
@@ -40,7 +139,7 @@ impl Context {
     /// test went in the form a [Result].
     ///
     /// If testing of all functions is complete without functional failures then Ok(())
-    /// or else a `TssError` (see [Error](crate::Error)) is returned.
+    /// or else a `TssError` (see [Error]) is returned.
     ///
     /// - A [TpmFormatZeroWarningResponseCode](crate::error::TpmFormatZeroWarningResponseCode) with a `Testing`
     ///   [TpmFormatZeroWarning](crate::constants::return_code::TpmFormatZeroWarning) indicates that the test

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/testing_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/testing_tests.rs
@@ -20,3 +20,25 @@ mod test_get_test_result {
         rc.unwrap();
     }
 }
+
+mod test_incremental_self_test {
+    use crate::common::create_ctx_without_session;
+    use tss_esapi::constants::AlgorithmIdentifier;
+
+    #[test]
+    fn test_incremental_self_test() {
+        let mut context = create_ctx_without_session();
+
+        let _to_do_list = context
+            .incremental_self_test(&[AlgorithmIdentifier::Sha256])
+            .expect("Failed to perform incremental self-test");
+    }
+
+    #[test]
+    fn test_incremental_self_test_rejects_too_many_algorithms() {
+        let mut context = create_ctx_without_session();
+
+        let too_many_algorithms = vec![AlgorithmIdentifier::Sha256; 129];
+        assert!(context.incremental_self_test(&too_many_algorithms).is_err());
+    }
+}


### PR DESCRIPTION
Adds the `incremental_self_test` command (from ESAPI spec 11.3.4) to `testing.rs` and its integration tests. Migrated from #625.