### PR TITLE
feat(esapi): add TPM2B_TEMPLATE wrapper type

### DIFF
--- a/tss-esapi/src/ffi/data_zeroize.rs
+++ b/tss-esapi/src/ffi/data_zeroize.rs
@@ -10,7 +10,7 @@ use crate::{
         TPM2B_ID_OBJECT, TPM2B_IV, TPM2B_MAX_BUFFER, TPM2B_MAX_NV_BUFFER, TPM2B_NAME,
         TPM2B_PRIVATE, TPM2B_PRIVATE_KEY_RSA, TPM2B_PRIVATE_VENDOR_SPECIFIC, TPM2B_PUBLIC,
         TPM2B_PUBLIC_KEY_RSA, TPM2B_SENSITIVE_CREATE, TPM2B_SENSITIVE_DATA, TPM2B_SYM_KEY,
-        TPML_PCR_SELECTION, TPMS_CREATION_DATA, TPMS_ECC_PARMS, TPMS_ECC_POINT,
+        TPM2B_TEMPLATE, TPML_PCR_SELECTION, TPMS_CREATION_DATA, TPMS_ECC_PARMS, TPMS_ECC_POINT,
         TPMS_KEYEDHASH_PARMS, TPMS_PCR_SELECTION, TPMS_RSA_PARMS, TPMS_SCHEME_ECDAA,
         TPMS_SCHEME_HASH, TPMS_SCHEME_XOR, TPMS_SENSITIVE_CREATE, TPMS_SYMCIPHER_PARMS,
         TPMT_ECC_SCHEME, TPMT_KDF_SCHEME, TPMT_KEYEDHASH_SCHEME, TPMT_PUBLIC, TPMT_RSA_SCHEME,
@@ -121,6 +121,7 @@ implement_ffi_data_zeroizer_trait_for_buffer_type!(TPM2B_PRIVATE_VENDOR_SPECIFIC
 implement_ffi_data_zeroizer_trait_for_buffer_type!(TPM2B_PUBLIC_KEY_RSA);
 implement_ffi_data_zeroizer_trait_for_buffer_type!(TPM2B_SENSITIVE_DATA);
 implement_ffi_data_zeroizer_trait_for_buffer_type!(TPM2B_SYM_KEY);
+implement_ffi_data_zeroizer_trait_for_buffer_type!(TPM2B_TEMPLATE);
 implement_ffi_data_zeroizer_trait_for_named_field_structured_buffer_type!(
     TPM2B_CREATION_DATA,
     creationData
@@ -454,6 +455,7 @@ implement_zeroize_test_buffer_type!(
     test_tpm2b_sensitive_data_ffi_data_zeroize
 );
 implement_zeroize_test_buffer_type!(TPM2B_SYM_KEY, test_tpm2b_sym_key_ffi_data_zeroize);
+implement_zeroize_test_buffer_type!(TPM2B_TEMPLATE, test_tpm2b_template_ffi_data_zeroize);
 
 implement_zeroize_test_for_named_field_structured_buffer_type!(
     TPM2B_NAME,

--- a/tss-esapi/src/structures/buffers.rs
+++ b/tss-esapi/src/structures/buffers.rs
@@ -99,6 +99,7 @@ macro_rules! buffer_type {
 pub mod attest;
 pub mod private;
 pub mod public;
+pub mod public_template;
 pub mod sensitive;
 pub mod sensitive_create;
 

--- a/tss-esapi/src/structures/buffers/public_template.rs
+++ b/tss-esapi/src/structures/buffers/public_template.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    Error, Result, WrapperErrorKind,
+    structures::Public,
+    traits::{Marshall, UnMarshall, impl_mu_standard},
+    tss2_esys::{TPM2B_TEMPLATE, UINT16},
+};
+use log::error;
+use std::{convert::TryFrom, mem::size_of, ops::Deref};
+use zeroize::{Zeroize, Zeroizing};
+
+/// A public template used when creating and loading an object in one operation.
+///
+/// This type corresponds to `TPM2B_TEMPLATE`. It stores either a marshalled [Public] structure or
+/// a raw derivation template. Use the byte conversions when constructing a derivation template.
+///
+/// # Example
+///
+/// ```rust
+/// use std::convert::TryFrom;
+/// use tss_esapi::{
+///     interface_types::{
+///         algorithm::{HashingAlgorithm, RsaSchemeAlgorithm},
+///         key_bits::RsaKeyBits,
+///     },
+///     structures::{Public, PublicTemplate, RsaExponent, RsaScheme},
+///     utils::create_unrestricted_signing_rsa_public,
+/// };
+///
+/// let public = create_unrestricted_signing_rsa_public(
+///     RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
+///         .expect("Failed to create RSA scheme"),
+///     RsaKeyBits::Rsa2048,
+///     RsaExponent::default(),
+/// )
+/// .expect("Failed to create public area");
+/// let template = PublicTemplate::try_from(public.clone())
+///     .expect("Failed to create public template");
+///
+/// assert_eq!(
+///     public,
+///     Public::try_from(template).expect("Failed to decode public template")
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
+pub struct PublicTemplate(Zeroizing<Vec<u8>>);
+
+impl Default for PublicTemplate {
+    fn default() -> Self {
+        Self(Vec::new().into())
+    }
+}
+
+impl PublicTemplate {
+    /// Maximum size of a public template in bytes.
+    pub const MAX_SIZE: usize = size_of::<TPM2B_TEMPLATE>() - size_of::<UINT16>();
+
+    /// Creates a public template containing the supplied bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Self::ensure_valid_buffer_size(bytes.len(), "bytes(&[u8])")?;
+        Ok(Self(bytes.to_vec().into()))
+    }
+
+    /// Returns the raw template bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    fn ensure_valid_buffer_size(buffer_size: usize, container_name: &str) -> Result<()> {
+        if buffer_size > Self::MAX_SIZE {
+            error!(
+                "Invalid {} size for PublicTemplate (> {})",
+                container_name,
+                Self::MAX_SIZE
+            );
+            return Err(Error::local_error(WrapperErrorKind::WrongParamSize));
+        }
+        Ok(())
+    }
+}
+
+impl AsRef<[u8]> for PublicTemplate {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Deref for PublicTemplate {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TryFrom<Vec<u8>> for PublicTemplate {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self> {
+        Self::ensure_valid_buffer_size(bytes.len(), "Vec<u8>")?;
+        Ok(Self(bytes.into()))
+    }
+}
+
+impl TryFrom<&[u8]> for PublicTemplate {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::from_bytes(bytes)
+    }
+}
+
+impl TryFrom<TPM2B_TEMPLATE> for PublicTemplate {
+    type Error = Error;
+
+    fn try_from(template: TPM2B_TEMPLATE) -> Result<Self> {
+        let size = template.size as usize;
+        Self::ensure_valid_buffer_size(size, "TPM2B_TEMPLATE buffer")?;
+        Ok(Self(template.buffer[..size].to_vec().into()))
+    }
+}
+
+impl From<PublicTemplate> for TPM2B_TEMPLATE {
+    fn from(template: PublicTemplate) -> Self {
+        let mut ffi_template = TPM2B_TEMPLATE {
+            size: template.0.len() as u16,
+            ..Default::default()
+        };
+        ffi_template.buffer[..template.0.len()].copy_from_slice(&template.0);
+        ffi_template
+    }
+}
+
+impl TryFrom<Public> for PublicTemplate {
+    type Error = Error;
+
+    fn try_from(public: Public) -> Result<Self> {
+        Self::try_from(public.marshall()?)
+    }
+}
+
+impl TryFrom<PublicTemplate> for Public {
+    type Error = Error;
+
+    fn try_from(template: PublicTemplate) -> Result<Self> {
+        Self::unmarshall(template.as_bytes())
+    }
+}
+
+impl_mu_standard!(PublicTemplate, TPM2B_TEMPLATE);

--- a/tss-esapi/src/structures/mod.rs
+++ b/tss-esapi/src/structures/mod.rs
@@ -40,7 +40,7 @@ pub use self::buffers::{
     initial_value::InitialValue, max_buffer::MaxBuffer, max_nv_buffer::MaxNvBuffer, nonce::Nonce,
     private::Private, private_key_rsa::PrivateKeyRsa,
     private_vendor_specific::PrivateVendorSpecific, public::PublicBuffer,
-    public_key_rsa::PublicKeyRsa, sensitive::SensitiveBuffer,
+    public_key_rsa::PublicKeyRsa, public_template::PublicTemplate, sensitive::SensitiveBuffer,
     sensitive_create::SensitiveCreateBuffer, sensitive_data::SensitiveData,
     symmetric_key::SymmetricKey, timeout::Timeout, tpm_context_data::TpmContextData,
 };

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/mod.rs
@@ -11,5 +11,6 @@ mod max_buffer_tests;
 mod nonce_tests;
 mod private;
 mod public;
+mod public_template_tests;
 mod sensitive;
 mod sensitive_create_buffer_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/public_template_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/buffers_tests/public_template_tests.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+use tss_esapi::{
+    Error, WrapperErrorKind,
+    structures::{Public, PublicTemplate},
+    tss2_esys::TPM2B_TEMPLATE,
+};
+
+#[test]
+fn test_byte_conversions() {
+    let expected = vec![0xA5; PublicTemplate::MAX_SIZE];
+    let from_slice = PublicTemplate::try_from(expected.as_slice()).unwrap();
+    let from_vec = PublicTemplate::try_from(expected.clone()).unwrap();
+
+    assert_eq!(expected.as_slice(), from_slice.as_bytes());
+    assert_eq!(from_slice, from_vec);
+}
+
+#[test]
+fn test_rejects_oversized_data() {
+    assert_eq!(
+        Error::WrapperError(WrapperErrorKind::WrongParamSize),
+        PublicTemplate::try_from(vec![0u8; PublicTemplate::MAX_SIZE + 1]).unwrap_err()
+    );
+}
+
+#[test]
+fn test_tpm2b_template_conversion() {
+    let expected = vec![0x5A; PublicTemplate::MAX_SIZE];
+    let template = PublicTemplate::try_from(expected.clone()).unwrap();
+    let ffi_template = TPM2B_TEMPLATE::from(template.clone());
+
+    assert_eq!(expected.len(), ffi_template.size as usize);
+    assert_eq!(expected.as_slice(), &ffi_template.buffer[..expected.len()]);
+    assert_eq!(template, PublicTemplate::try_from(ffi_template).unwrap());
+}
+
+#[test]
+fn test_public_conversion_and_marshalling() {
+    crate::common::publics().iter().for_each(|public| {
+        let template = PublicTemplate::try_from(public.clone()).unwrap();
+        crate::common::check_marshall_unmarshall(&template);
+        assert_eq!(
+            public,
+            &Public::try_from(template).expect("Failed to decode PublicTemplate")
+        );
+    });
+}


### PR DESCRIPTION
This PR adds a Rust wrapper type for the `TPM2B_TEMPLATE` structure (specified in Section 12.2.6, [TPM2 2.0 Library Specification - Part 2: Structures](https://trustedcomputinggroup.org/wp-content/uploads/Trusted-Platform-Module-2.0-Library-Part-2-Structures_Version-185_pub.pdf)).

Currently, this structure is used only with the deprecated `TPM2_CreateLoaded` command. This command was deprecated in version 184 of the TPM2 2.0 Library Specification - Part 3: Commands. So, its Esys wrapper is currently not implemented. Since there is a working branch in my fork that already implements it, I can add it to this PR if necessary.