### PR TITLE
feat(esapi): fully support NV digest attestations

### DIFF
--- a/tss-esapi-sys/src/bindings/aarch64-unknown-linux-gnu.rs
+++ b/tss-esapi-sys/src/bindings/aarch64-unknown-linux-gnu.rs
@@ -1815,6 +1815,7 @@ pub union TPMU_ATTEST {
     pub sessionAudit: TPMS_SESSION_AUDIT_INFO,
     pub time: TPMS_TIME_ATTEST_INFO,
     pub nv: TPMS_NV_CERTIFY_INFO,
+    pub nvDigest: TPMS_NV_DIGEST_CERTIFY_INFO,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -1831,6 +1832,8 @@ const _: () = {
         [::std::mem::offset_of!(TPMU_ATTEST, sessionAudit) - 0usize];
     ["Offset of field: TPMU_ATTEST::time"][::std::mem::offset_of!(TPMU_ATTEST, time) - 0usize];
     ["Offset of field: TPMU_ATTEST::nv"][::std::mem::offset_of!(TPMU_ATTEST, nv) - 0usize];
+    ["Offset of field: TPMU_ATTEST::nvDigest"]
+        [::std::mem::offset_of!(TPMU_ATTEST, nvDigest) - 0usize];
 };
 impl Default for TPMU_ATTEST {
     fn default() -> Self {

--- a/tss-esapi-sys/src/bindings/arm-unknown-linux-gnueabi.rs
+++ b/tss-esapi-sys/src/bindings/arm-unknown-linux-gnueabi.rs
@@ -1784,6 +1784,7 @@ pub union TPMU_ATTEST {
     pub sessionAudit: TPMS_SESSION_AUDIT_INFO,
     pub time: TPMS_TIME_ATTEST_INFO,
     pub nv: TPMS_NV_CERTIFY_INFO,
+    pub nvDigest: TPMS_NV_DIGEST_CERTIFY_INFO,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -1800,6 +1801,8 @@ const _: () = {
         [::std::mem::offset_of!(TPMU_ATTEST, sessionAudit) - 0usize];
     ["Offset of field: TPMU_ATTEST::time"][::std::mem::offset_of!(TPMU_ATTEST, time) - 0usize];
     ["Offset of field: TPMU_ATTEST::nv"][::std::mem::offset_of!(TPMU_ATTEST, nv) - 0usize];
+    ["Offset of field: TPMU_ATTEST::nvDigest"]
+        [::std::mem::offset_of!(TPMU_ATTEST, nvDigest) - 0usize];
 };
 impl Default for TPMU_ATTEST {
     fn default() -> Self {

--- a/tss-esapi-sys/src/bindings/x86_64-unknown-darwin.rs
+++ b/tss-esapi-sys/src/bindings/x86_64-unknown-darwin.rs
@@ -4007,6 +4007,7 @@ pub union TPMU_ATTEST {
     pub sessionAudit: TPMS_SESSION_AUDIT_INFO,
     pub time: TPMS_TIME_ATTEST_INFO,
     pub nv: TPMS_NV_CERTIFY_INFO,
+    pub nvDigest: TPMS_NV_DIGEST_CERTIFY_INFO,
 }
 #[test]
 fn bindgen_test_layout_TPMU_ATTEST() {
@@ -4090,6 +4091,16 @@ fn bindgen_test_layout_TPMU_ATTEST() {
             stringify!(TPMU_ATTEST),
             "::",
             stringify!(nv)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).nvDigest) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(TPMU_ATTEST),
+            "::",
+            stringify!(nvDigest)
         )
     );
 }

--- a/tss-esapi-sys/src/bindings/x86_64-unknown-linux-gnu.rs
+++ b/tss-esapi-sys/src/bindings/x86_64-unknown-linux-gnu.rs
@@ -1817,6 +1817,7 @@ pub union TPMU_ATTEST {
     pub sessionAudit: TPMS_SESSION_AUDIT_INFO,
     pub time: TPMS_TIME_ATTEST_INFO,
     pub nv: TPMS_NV_CERTIFY_INFO,
+    pub nvDigest: TPMS_NV_DIGEST_CERTIFY_INFO,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -1833,6 +1834,8 @@ const _: () = {
         [::std::mem::offset_of!(TPMU_ATTEST, sessionAudit) - 0usize];
     ["Offset of field: TPMU_ATTEST::time"][::std::mem::offset_of!(TPMU_ATTEST, time) - 0usize];
     ["Offset of field: TPMU_ATTEST::nv"][::std::mem::offset_of!(TPMU_ATTEST, nv) - 0usize];
+    ["Offset of field: TPMU_ATTEST::nvDigest"]
+        [::std::mem::offset_of!(TPMU_ATTEST, nvDigest) - 0usize];
 };
 impl Default for TPMU_ATTEST {
     fn default() -> Self {

--- a/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
+++ b/tss-esapi/src/context/tpm_commands/non_volatile_storage.rs
@@ -1473,7 +1473,8 @@ impl Context {
     /// * `nv_index_handle` - The [NvIndexHandle] of the NV index to be certified.
     /// * `qualifying_data` - [Data] to qualify the signing.
     /// * `signing_scheme` - The [SignatureScheme] to use for signing.
-    /// * `size` - Number of octets to certify.
+    /// * `size` - Number of octets to certify. When both `size` and `offset` are zero, the TPM
+    ///   certifies a digest of the complete NV index.
     /// * `offset` - Octet offset into the NV area.
     ///
     /// # Details
@@ -1484,7 +1485,10 @@ impl Context {
     ///
     /// # Returns
     ///
-    /// A tuple of `(Attest, Signature)`.
+    /// A tuple of `(Attest, Signature)`. The returned [Attest] contains
+    /// [AttestInfo::NvDigest](crate::structures::AttestInfo::NvDigest) when both `size` and
+    /// `offset` are zero; otherwise it contains
+    /// [AttestInfo::Nv](crate::structures::AttestInfo::Nv).
     ///
     /// # Example
     /// ```rust
@@ -1502,7 +1506,7 @@ impl Context {
     ///         reserved_handles::{Hierarchy, NvAuth, Provision},
     ///         session_handles::AuthSession,
     ///     },
-    ///     structures::{Data, SignatureScheme},
+    ///     structures::{AttestInfo, Data, SignatureScheme},
     /// };
     ///
     /// # // Create context
@@ -1558,7 +1562,7 @@ impl Context {
     ///     })
     ///     .expect("Call to nv_write failed");
     ///
-    /// // Certify the NV index contents.
+    /// // Certify a digest of the complete NV index contents.
     /// let nv_certify_result = context.execute_with_sessions(
     ///     (
     ///         Some(AuthSession::Password),
@@ -1572,7 +1576,7 @@ impl Context {
     ///             nv_index_handle,
     ///             Data::try_from(vec![0xff; 16]).unwrap(),
     ///             SignatureScheme::Null,
-    ///             8,
+    ///             0,
     ///             0,
     ///         )
     ///     },
@@ -1586,7 +1590,8 @@ impl Context {
     ///     .expect("Call to nv_undefine_space failed");
     ///
     /// // Process result
-    /// let (_attest, _signature) = nv_certify_result.expect("Call to nv_certify failed");
+    /// let (attest, _signature) = nv_certify_result.expect("Call to nv_certify failed");
+    /// assert!(matches!(attest.attested(), AttestInfo::NvDigest { .. }));
     /// ```
     #[allow(clippy::too_many_arguments)]
     pub fn nv_certify(

--- a/tss-esapi/src/structures/attestation/attest.rs
+++ b/tss-esapi/src/structures/attestation/attest.rs
@@ -9,7 +9,6 @@ use crate::{
     traits::impl_mu_standard,
     tss2_esys::TPMS_ATTEST,
 };
-use log::error;
 use std::convert::{TryFrom, TryInto};
 
 /// Type for holding attestation data
@@ -109,10 +108,9 @@ impl TryFrom<TPMS_ATTEST> for Attest {
                 AttestationType::Nv => AttestInfo::Nv {
                     info: unsafe { tpms_attest.attested.nv }.try_into()?,
                 },
-                AttestationType::NvDigest => {
-                    error!("NvDigest attestation type is currently not supported");
-                    return Err(Error::local_error(WrapperErrorKind::UnsupportedParam));
-                }
+                AttestationType::NvDigest => AttestInfo::NvDigest {
+                    info: unsafe { tpms_attest.attested.nvDigest }.try_into()?,
+                },
             },
         })
     }

--- a/tss-esapi/src/structures/attestation/attest_info.rs
+++ b/tss-esapi/src/structures/attestation/attest_info.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     structures::{
-        CertifyInfo, CommandAuditInfo, CreationInfo, NvCertifyInfo, QuoteInfo, SessionAuditInfo,
-        TimeAttestInfo,
+        CertifyInfo, CommandAuditInfo, CreationInfo, NvCertifyInfo, NvDigestCertifyInfo, QuoteInfo,
+        SessionAuditInfo, TimeAttestInfo,
     },
     tss2_esys::TPMU_ATTEST,
 };
@@ -25,8 +25,7 @@ pub enum AttestInfo {
     Time { info: TimeAttestInfo },
     Creation { info: CreationInfo },
     Nv { info: NvCertifyInfo },
-    // NvDigest, the TPMS_NV_DIGEST_CERTIFY_INFO,
-    // was first added in the 3.1.0 version of the tpm2-tss
+    NvDigest { info: NvDigestCertifyInfo },
 }
 
 impl From<AttestInfo> for TPMU_ATTEST {
@@ -47,6 +46,9 @@ impl From<AttestInfo> for TPMU_ATTEST {
                 creation: info.into(),
             },
             AttestInfo::Nv { info } => TPMU_ATTEST { nv: info.into() },
+            AttestInfo::NvDigest { info } => TPMU_ATTEST {
+                nvDigest: info.into(),
+            },
         }
     }
 }

--- a/tss-esapi/src/structures/attestation/nv_digest_certify_info.rs
+++ b/tss-esapi/src/structures/attestation/nv_digest_certify_info.rs
@@ -1,7 +1,12 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::structures::{Digest, Name};
+use crate::{
+    Error, Result,
+    structures::{Digest, Name},
+    tss2_esys::TPMS_NV_DIGEST_CERTIFY_INFO,
+};
+use std::convert::{TryFrom, TryInto};
 
 /// This structure contains the Name and hash of the
 /// contents of the selected NV Index that is certified by
@@ -9,6 +14,28 @@ use crate::structures::{Digest, Name};
 ///
 /// # Details
 /// This corresponds to  TPMS_NV_DIGEST_CERTIFY_INFO.
+///
+/// # Example
+///
+/// ```rust
+/// use std::convert::{TryFrom, TryInto};
+/// use tss_esapi::{
+///     structures::{Digest, Name, NvDigestCertifyInfo},
+///     tss2_esys::TPMS_NV_DIGEST_CERTIFY_INFO,
+/// };
+///
+/// let index_name = Name::try_from(vec![0xAA; 34])?;
+/// let nv_digest = Digest::try_from(vec![0xBB; 32])?;
+/// let info: NvDigestCertifyInfo = TPMS_NV_DIGEST_CERTIFY_INFO {
+///     indexName: index_name.clone().into(),
+///     nvDigest: nv_digest.clone().into(),
+/// }
+/// .try_into()?;
+///
+/// assert_eq!(info.index_name(), &index_name);
+/// assert_eq!(info.nv_digest(), &nv_digest);
+/// # Ok::<(), tss_esapi::Error>(())
+/// ```
 #[derive(Debug, Clone)]
 pub struct NvDigestCertifyInfo {
     index_name: Name,
@@ -24,5 +51,25 @@ impl NvDigestCertifyInfo {
     /// Returns the NV digest.
     pub const fn nv_digest(&self) -> &Digest {
         &self.nv_digest
+    }
+}
+
+impl From<NvDigestCertifyInfo> for TPMS_NV_DIGEST_CERTIFY_INFO {
+    fn from(nv_digest_certify_info: NvDigestCertifyInfo) -> Self {
+        TPMS_NV_DIGEST_CERTIFY_INFO {
+            indexName: nv_digest_certify_info.index_name.into(),
+            nvDigest: nv_digest_certify_info.nv_digest.into(),
+        }
+    }
+}
+
+impl TryFrom<TPMS_NV_DIGEST_CERTIFY_INFO> for NvDigestCertifyInfo {
+    type Error = Error;
+
+    fn try_from(tpms_nv_digest_certify_info: TPMS_NV_DIGEST_CERTIFY_INFO) -> Result<Self> {
+        Ok(Self {
+            index_name: tpms_nv_digest_certify_info.indexName.try_into()?,
+            nv_digest: tpms_nv_digest_certify_info.nvDigest.try_into()?,
+        })
     }
 }

--- a/tss-esapi/tests/integration_tests/common/tpms_types_equality_checks.rs
+++ b/tss-esapi/tests/integration_tests/common/tpms_types_equality_checks.rs
@@ -3,15 +3,17 @@
 use tss_esapi::{
     constants::tss::{
         TPM2_ST_ATTEST_CERTIFY, TPM2_ST_ATTEST_COMMAND_AUDIT, TPM2_ST_ATTEST_CREATION,
-        TPM2_ST_ATTEST_NV, TPM2_ST_ATTEST_QUOTE, TPM2_ST_ATTEST_SESSION_AUDIT, TPM2_ST_ATTEST_TIME,
+        TPM2_ST_ATTEST_NV, TPM2_ST_ATTEST_NV_DIGEST, TPM2_ST_ATTEST_QUOTE,
+        TPM2_ST_ATTEST_SESSION_AUDIT, TPM2_ST_ATTEST_TIME,
     },
     tss2_esys::{
         TPMS_ALG_PROPERTY, TPMS_ATTEST, TPMS_CERTIFY_INFO, TPMS_CLOCK_INFO,
         TPMS_COMMAND_AUDIT_INFO, TPMS_CONTEXT, TPMS_CREATION_INFO, TPMS_ECC_PARMS, TPMS_EMPTY,
-        TPMS_KEYEDHASH_PARMS, TPMS_NV_CERTIFY_INFO, TPMS_PCR_SELECTION, TPMS_QUOTE_INFO,
-        TPMS_RSA_PARMS, TPMS_SCHEME_ECDAA, TPMS_SCHEME_HASH, TPMS_SCHEME_HMAC, TPMS_SCHEME_XOR,
-        TPMS_SENSITIVE_CREATE, TPMS_SESSION_AUDIT_INFO, TPMS_SYMCIPHER_PARMS,
-        TPMS_TAGGED_PCR_SELECT, TPMS_TAGGED_PROPERTY, TPMS_TIME_ATTEST_INFO, TPMS_TIME_INFO,
+        TPMS_KEYEDHASH_PARMS, TPMS_NV_CERTIFY_INFO, TPMS_NV_DIGEST_CERTIFY_INFO,
+        TPMS_PCR_SELECTION, TPMS_QUOTE_INFO, TPMS_RSA_PARMS, TPMS_SCHEME_ECDAA, TPMS_SCHEME_HASH,
+        TPMS_SCHEME_HMAC, TPMS_SCHEME_XOR, TPMS_SENSITIVE_CREATE, TPMS_SESSION_AUDIT_INFO,
+        TPMS_SYMCIPHER_PARMS, TPMS_TAGGED_PCR_SELECT, TPMS_TAGGED_PROPERTY, TPMS_TIME_ATTEST_INFO,
+        TPMS_TIME_INFO,
     },
 };
 
@@ -128,6 +130,14 @@ pub fn ensure_tpms_nv_certify_info_equality(
     crate::common::ensure_tpm2b_max_nv_buffer_equality(&expected.nvContents, &actual.nvContents);
 }
 
+pub fn ensure_tpms_nv_digest_certify_info_equality(
+    expected: &TPMS_NV_DIGEST_CERTIFY_INFO,
+    actual: &TPMS_NV_DIGEST_CERTIFY_INFO,
+) {
+    crate::common::ensure_tpm2b_name_equality(&expected.indexName, &actual.indexName);
+    crate::common::ensure_tpm2b_digest_equality(&expected.nvDigest, &actual.nvDigest);
+}
+
 pub fn ensure_tpms_attest_equality(expected: &TPMS_ATTEST, actual: &TPMS_ATTEST) {
     assert_eq!(
         expected.magic, actual.magic,
@@ -178,6 +188,10 @@ pub fn ensure_tpms_attest_equality(expected: &TPMS_ATTEST, actual: &TPMS_ATTEST)
                 &actual.attested.nv
             })
         }
+        TPM2_ST_ATTEST_NV_DIGEST => ensure_tpms_nv_digest_certify_info_equality(
+            unsafe { &expected.attested.nvDigest },
+            unsafe { &actual.attested.nvDigest },
+        ),
         _ => panic!("'type_' value in TPMS_ATTEST contained invalid or unsupported value"),
     }
 }

--- a/tss-esapi/tests/integration_tests/context_tests/tpm_commands/non_volatile_storage_tests.rs
+++ b/tss-esapi/tests/integration_tests/context_tests/tpm_commands/non_volatile_storage_tests.rs
@@ -795,17 +795,24 @@ mod test_nv_global_write_lock {
 
 mod test_nv_certify {
     use crate::common::create_ctx_with_session;
+    use sha2::{Digest as _, Sha256};
     use std::convert::TryFrom;
     use tss_esapi::{
         attributes::NvIndexAttributesBuilder,
+        constants::StructureTag,
         handles::NvIndexTpmHandle,
         interface_types::{
             algorithm::{HashingAlgorithm, RsaSchemeAlgorithm},
             key_bits::RsaKeyBits,
             reserved_handles::{Hierarchy, NvAuth, Provision},
             session_handles::AuthSession,
+            structure_tags::AttestationType,
         },
-        structures::{Data, MaxNvBuffer, NvPublicBuilder, RsaExponent, RsaScheme, SignatureScheme},
+        structures::{
+            AttestInfo, Data, Digest, MaxNvBuffer, NvPublicBuilder, RsaExponent, RsaScheme,
+            SignatureScheme, Ticket,
+        },
+        traits::Marshall,
         utils::create_unrestricted_signing_rsa_public,
     };
 
@@ -847,13 +854,14 @@ mod test_nv_certify {
             .nv_define_space(Provision::Owner, None, nv_public)
             .expect("Failed to define NV space");
 
-        let data = MaxNvBuffer::try_from(vec![1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+        let written_data = (1u8..=32).collect::<Vec<_>>();
+        let data = MaxNvBuffer::try_from(written_data.clone()).unwrap();
         context
             .nv_write(NvAuth::Owner, nv_index_handle, data, 0)
             .expect("Failed to write NV");
 
-        // Certify the NV index
-        let (_attest, _signature) = context
+        // Certify part of the NV index contents.
+        let (attest, _signature) = context
             .execute_with_sessions(
                 (
                     Some(AuthSession::Password),
@@ -873,6 +881,63 @@ mod test_nv_certify {
                 },
             )
             .expect("Failed to certify NV");
+        assert_eq!(attest.attestation_type(), AttestationType::Nv);
+        assert!(matches!(attest.attested(), AttestInfo::Nv { .. }));
+
+        // A zero size and offset requests an attestation containing a digest of
+        // the complete NV index instead of exposing the contents.
+        let qualifying_data = Data::try_from(vec![0xaau8; 16]).unwrap();
+        let (digest_attest, signature) = context
+            .execute_with_sessions(
+                (
+                    Some(AuthSession::Password),
+                    Some(AuthSession::Password),
+                    None,
+                ),
+                |ctx| {
+                    ctx.nv_certify(
+                        sign_key_handle,
+                        NvAuth::Owner,
+                        nv_index_handle,
+                        qualifying_data.clone(),
+                        SignatureScheme::Null,
+                        0,
+                        0,
+                    )
+                },
+            )
+            .expect("Failed to certify the NV digest");
+
+        assert_eq!(digest_attest.attestation_type(), AttestationType::NvDigest,);
+        assert_eq!(digest_attest.extra_data(), &qualifying_data);
+
+        let (_, expected_index_name) = context
+            .nv_read_public(nv_index_handle)
+            .expect("Failed to read NV public data");
+        let expected_nv_digest = Sha256::digest(&written_data);
+
+        if let AttestInfo::NvDigest { info } = digest_attest.attested() {
+            assert_eq!(info.index_name(), &expected_index_name);
+            assert_eq!(info.nv_digest().as_bytes(), &expected_nv_digest[..]);
+        } else {
+            panic!("NV digest certification did not return NvDigest attestation info");
+        }
+
+        let signed_digest = Digest::try_from(
+            Sha256::digest(
+                digest_attest
+                    .marshall()
+                    .expect("Failed to marshall NV digest attestation"),
+            )
+            .to_vec(),
+        )
+        .expect("Failed to create attestation digest");
+        let ticket = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.verify_signature(sign_key_handle, signed_digest, signature)
+            })
+            .expect("Failed to verify NV digest attestation signature");
+        assert_eq!(ticket.tag(), StructureTag::Verified);
 
         // Cleanup
         context

--- a/tss-esapi/tests/integration_tests/structures_tests/attest_info_test.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/attest_info_test.rs
@@ -6,8 +6,8 @@ use tss_esapi::{
     structures::{AttestInfo, Digest, MaxNvBuffer, Name, PcrSelectionListBuilder, PcrSlot},
     tss2_esys::{
         TPMS_CERTIFY_INFO, TPMS_CLOCK_INFO, TPMS_COMMAND_AUDIT_INFO, TPMS_CREATION_INFO,
-        TPMS_NV_CERTIFY_INFO, TPMS_QUOTE_INFO, TPMS_SESSION_AUDIT_INFO, TPMS_TIME_ATTEST_INFO,
-        TPMS_TIME_INFO, TPMU_ATTEST,
+        TPMS_NV_CERTIFY_INFO, TPMS_NV_DIGEST_CERTIFY_INFO, TPMS_QUOTE_INFO,
+        TPMS_SESSION_AUDIT_INFO, TPMS_TIME_ATTEST_INFO, TPMS_TIME_INFO, TPMU_ATTEST,
     },
 };
 
@@ -207,5 +207,31 @@ fn test_nv_into_tpm_type_conversions() {
     crate::common::ensure_tpms_nv_certify_info_equality(
         &expected_tpms_nv_certify_info,
         actual_tpms_nv_certify_info,
+    );
+}
+
+#[test]
+fn test_nv_digest_into_tpm_type_conversions() {
+    let expected_tpms_nv_digest_certify_info = TPMS_NV_DIGEST_CERTIFY_INFO {
+        indexName: Name::try_from(vec![0xf0u8; 34])
+            .expect("Failed to create index name")
+            .into(),
+        nvDigest: Digest::try_from(vec![0xfcu8; 32])
+            .expect("Failed to create NV digest")
+            .into(),
+    };
+
+    let tpmu_attest: TPMU_ATTEST = AttestInfo::NvDigest {
+        info: expected_tpms_nv_digest_certify_info
+            .try_into()
+            .expect("Failed to convert TPMS_NV_DIGEST_CERTIFY_INFO into NvDigestCertifyInfo"),
+    }
+    .into();
+
+    let actual_tpms_nv_digest_certify_info = unsafe { &tpmu_attest.nvDigest };
+
+    crate::common::ensure_tpms_nv_digest_certify_info_equality(
+        &expected_tpms_nv_digest_certify_info,
+        actual_tpms_nv_digest_certify_info,
     );
 }

--- a/tss-esapi/tests/integration_tests/structures_tests/attest_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/attest_tests.rs
@@ -10,8 +10,8 @@ use tss_esapi::{
     traits::{Marshall, UnMarshall},
     tss2_esys::{
         TPMS_ATTEST, TPMS_CERTIFY_INFO, TPMS_CLOCK_INFO, TPMS_COMMAND_AUDIT_INFO,
-        TPMS_CREATION_INFO, TPMS_NV_CERTIFY_INFO, TPMS_QUOTE_INFO, TPMS_SESSION_AUDIT_INFO,
-        TPMS_TIME_ATTEST_INFO, TPMS_TIME_INFO,
+        TPMS_CREATION_INFO, TPMS_NV_CERTIFY_INFO, TPMS_NV_DIGEST_CERTIFY_INFO, TPMS_QUOTE_INFO,
+        TPMS_SESSION_AUDIT_INFO, TPMS_TIME_ATTEST_INFO, TPMS_TIME_INFO,
     },
 };
 
@@ -311,6 +311,77 @@ fn test_attest_with_nv_creation_info_into_tpm_type_conversions() {
     let actual_tpms_attest: TPMS_ATTEST = attest.into();
 
     crate::common::ensure_tpms_attest_equality(&expected_tpms_attest, &actual_tpms_attest);
+}
+
+#[test]
+fn test_attest_with_nv_digest_info_into_tpm_type_conversions() {
+    let expected_index_name =
+        Name::try_from(vec![0xf0u8; 34]).expect("Failed to create index name");
+    let expected_nv_digest =
+        Digest::try_from(vec![0xfcu8; 32]).expect("Failed to create NV digest");
+    let expected_attest_info = AttestInfo::NvDigest {
+        info: TPMS_NV_DIGEST_CERTIFY_INFO {
+            indexName: expected_index_name.clone().into(),
+            nvDigest: expected_nv_digest.clone().into(),
+        }
+        .try_into()
+        .expect("Failed to convert TPMS_NV_DIGEST_CERTIFY_INFO into NvDigestCertifyInfo"),
+    };
+
+    let (attest, expected_tpms_attest) =
+        create_validated_test_parameters(expected_attest_info, AttestationType::NvDigest);
+
+    if let AttestInfo::NvDigest { info } = attest.attested() {
+        assert_eq!(
+            &expected_index_name,
+            info.index_name(),
+            "NvDigestCertifyInfo did not contain the expected index name",
+        );
+        assert_eq!(
+            &expected_nv_digest,
+            info.nv_digest(),
+            "NvDigestCertifyInfo did not contain the expected NV digest",
+        );
+    } else {
+        panic!("Converted Attest did not contain expected value for 'attest info'");
+    }
+
+    let actual_tpms_attest: TPMS_ATTEST = attest.into();
+
+    crate::common::ensure_tpms_attest_equality(&expected_tpms_attest, &actual_tpms_attest);
+}
+
+#[test]
+fn test_nv_digest_marshall_and_unmarshall() {
+    let expected_index_name =
+        Name::try_from(vec![0xf0u8; 34]).expect("Failed to create index name");
+    let expected_nv_digest =
+        Digest::try_from(vec![0xfcu8; 32]).expect("Failed to create NV digest");
+    let expected_attest_info = AttestInfo::NvDigest {
+        info: TPMS_NV_DIGEST_CERTIFY_INFO {
+            indexName: expected_index_name.clone().into(),
+            nvDigest: expected_nv_digest.clone().into(),
+        }
+        .try_into()
+        .expect("Failed to convert TPMS_NV_DIGEST_CERTIFY_INFO into NvDigestCertifyInfo"),
+    };
+
+    let (attest, _) =
+        create_validated_test_parameters(expected_attest_info, AttestationType::NvDigest);
+    let marshalled_attest = attest.marshall().expect("Failed to marshall Attest");
+    let unmarshalled_attest =
+        Attest::unmarshall(&marshalled_attest).expect("Failed to unmarshall Attest");
+
+    assert_eq!(
+        AttestationType::NvDigest,
+        unmarshalled_attest.attestation_type(),
+    );
+    if let AttestInfo::NvDigest { info } = unmarshalled_attest.attested() {
+        assert_eq!(&expected_index_name, info.index_name());
+        assert_eq!(&expected_nv_digest, info.nv_digest());
+    } else {
+        panic!("Unmarshalled Attest did not contain NvDigest attestation info");
+    }
 }
 
 #[test]

--- a/tss-esapi/tests/integration_tests/structures_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/mod.rs
@@ -13,6 +13,7 @@ mod creation_data_tests;
 mod creation_info_tests;
 mod lists_tests;
 mod nv_certify_info_tests;
+mod nv_digest_certify_info_tests;
 mod pcr_tests;
 mod quote_info_tests;
 mod session_audit_info_tests;

--- a/tss-esapi/tests/integration_tests/structures_tests/nv_digest_certify_info_tests.rs
+++ b/tss-esapi/tests/integration_tests/structures_tests/nv_digest_certify_info_tests.rs
@@ -1,0 +1,42 @@
+// Copyright 2026 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::{TryFrom, TryInto};
+use tss_esapi::{
+    structures::{Digest, Name, NvDigestCertifyInfo},
+    tss2_esys::TPMS_NV_DIGEST_CERTIFY_INFO,
+};
+
+#[test]
+fn test_conversion() {
+    let expected_index_name =
+        Name::try_from(vec![0xf0u8; 34]).expect("Failed to create index name");
+    let expected_nv_digest =
+        Digest::try_from(vec![0xfcu8; 32]).expect("Failed to create NV digest");
+    let expected_tpms_nv_digest_certify_info = TPMS_NV_DIGEST_CERTIFY_INFO {
+        indexName: expected_index_name.clone().into(),
+        nvDigest: expected_nv_digest.clone().into(),
+    };
+
+    let nv_digest_certify_info: NvDigestCertifyInfo = expected_tpms_nv_digest_certify_info
+        .try_into()
+        .expect("Failed to convert TPMS_NV_DIGEST_CERTIFY_INFO into NvDigestCertifyInfo");
+    assert_eq!(
+        &expected_index_name,
+        nv_digest_certify_info.index_name(),
+        "NvDigestCertifyInfo did not contain the expected index name",
+    );
+    assert_eq!(
+        &expected_nv_digest,
+        nv_digest_certify_info.nv_digest(),
+        "NvDigestCertifyInfo did not contain the expected NV digest",
+    );
+
+    let actual_tpms_nv_digest_certify_info: TPMS_NV_DIGEST_CERTIFY_INFO =
+        nv_digest_certify_info.into();
+
+    crate::common::ensure_tpms_nv_digest_certify_info_equality(
+        &expected_tpms_nv_digest_certify_info,
+        &actual_tpms_nv_digest_certify_info,
+    );
+}


### PR DESCRIPTION
- Add `TPM2_ST_ATTEST_NV_DIGEST` bindings for all archs.
- Add NV digest wrapper type
- Add full support for NV digest attestation in `nv_certify` command

Supersedes #625.

### Note

This PR depends on the upstream tpm2-tss 4.2.x support for `TPM2_ST_ATTEST_NV_DIGEST`. It must remain a draft until tpm2-tss 4.2.1 is released with the fix from tpm2-software/tpm2-tss#3123.

### Testing

The test environment used the `.devcontainer` image. The TPM-backed `NvDigest` test passed against upstream tpm2-tss main commit `be602a5c2d23e385b009d865798c3e85b3b2fa3b`. The complete test suite and rustdoc tests were run against tpm2-tss PR 3123 head `1a02ac3395c028cccf176d47e95a0bcb30d0987a`, which contains the prospective 4.2.1 fix.
