### PR TITLE
abstraction: add conversion for ecc signature and ecc parameters

### DIFF
--- a/tss-esapi/src/abstraction/public.rs
+++ b/tss-esapi/src/abstraction/public.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::interface_types::ecc::EccCurve;
-use crate::structures::Public;
+use crate::structures::{EccParameter, EccPoint, Public};
 use crate::utils::PublicKey as TpmPublicKey;
 use crate::{Error, WrapperErrorKind};
 
@@ -73,6 +73,32 @@ where
             }
             _ => Err(Error::local_error(WrapperErrorKind::UnsupportedParam)),
         }
+    }
+}
+
+impl<C> TryFrom<&PublicKey<C>> for EccPoint
+where
+    C: CurveArithmetic + AssociatedTpmCurve,
+    FieldBytesSize<C>: ModulusSize,
+    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+{
+    type Error = Error;
+
+    fn try_from(value: &PublicKey<C>) -> Result<Self, Self::Error> {
+        let affine = value.to_encoded_point(false);
+        let x_bytes = affine
+            .x()
+            .ok_or_else(|| Error::local_error(WrapperErrorKind::InvalidParam))?;
+        let y_bytes = affine
+            .y()
+            .ok_or_else(|| Error::local_error(WrapperErrorKind::InvalidParam))?;
+
+        let x_param = EccParameter::from_bytes(x_bytes.as_slice())
+            .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;
+        let y_param = EccParameter::from_bytes(y_bytes.as_slice())
+            .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;
+
+        Ok(EccPoint::new(x_param, y_param))
     }
 }
 

--- a/tss-esapi/src/abstraction/signatures.rs
+++ b/tss-esapi/src/abstraction/signatures.rs
@@ -3,12 +3,13 @@
 
 use crate::{
     Error, Result, WrapperErrorKind,
-    structures::{EccSignature, Signature},
+    abstraction::AssociatedHashingAlgorithm,
+    structures::{EccParameter, EccSignature, Signature},
 };
 
 use std::convert::TryFrom;
 
-use ecdsa::SignatureSize;
+use ecdsa::{SignatureSize, hazmat::DigestPrimitive};
 use elliptic_curve::{
     FieldBytes, FieldBytesSize, PrimeCurve,
     generic_array::{ArrayLength, typenum::Unsigned},
@@ -85,5 +86,39 @@ impl TryFrom<&Signature> for rsa::pss::Signature {
 
         Self::try_from(signature.signature().as_bytes())
             .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))
+    }
+}
+
+impl<C> TryFrom<&ecdsa::Signature<C>> for EccSignature
+where
+    C: PrimeCurve + DigestPrimitive,
+    C::Digest: AssociatedHashingAlgorithm,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    type Error = Error;
+
+    fn try_from(signature: &ecdsa::Signature<C>) -> Result<Self> {
+        let (r, s) = signature.split_bytes();
+
+        let signature_r = EccParameter::from_bytes(r.as_slice())
+            .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;
+        let signature_s = EccParameter::from_bytes(s.as_slice())
+            .map_err(|_| Error::local_error(WrapperErrorKind::InvalidParam))?;
+
+        EccSignature::create(C::Digest::TPM_DIGEST, signature_r, signature_s)
+    }
+}
+
+impl<C> TryFrom<&ecdsa::Signature<C>> for Signature
+where
+    C: PrimeCurve + DigestPrimitive,
+    C::Digest: AssociatedHashingAlgorithm,
+    SignatureSize<C>: ArrayLength<u8>,
+{
+    type Error = Error;
+
+    fn try_from(signature: &ecdsa::Signature<C>) -> Result<Self> {
+        let ecc_signature = EccSignature::try_from(signature)?;
+        Ok(Signature::EcDsa(ecc_signature))
     }
 }


### PR DESCRIPTION
This helps converting a cryptographic objects from the non-TPM world.