### PR TITLE
fix: use salted sessions in load_ak/create_ak

### DIFF
--- a/tss-esapi/src/abstraction/ak.rs
+++ b/tss-esapi/src/abstraction/ak.rs
@@ -171,7 +171,7 @@ pub fn load_ak(
 
     let policy_auth_session = context
         .start_auth_session(
-            None,
+            Some(parent),
             None,
             None,
             SessionType::Policy,
@@ -244,7 +244,7 @@ pub fn create_ak<IKC: IntoKeyCustomization>(
 
     let policy_auth_session = context
         .start_auth_session(
-            None,
+            Some(parent),
             None,
             None,
             SessionType::Policy,


### PR DESCRIPTION
## Summary

- Switch `load_ak()` and `create_ak()` to use salted policy sessions by
  passing the parent EK handle as `tpmKey` to `start_auth_session`
- Fixes `TPM_RC_SIZE` (`0x000001d5`) errors with tpm2-tss >= 4.2.0, which
  introduced a regression in ESAPI parameter encryption for unsalted sessions
- Improves security: salted sessions derive encryption keys from a proper
  shared secret (RSA-encrypted salt or ECDH) rather than plaintext nonces
- Aligns with `tpm2-tools` behavior (e.g. `tpm2_createak` already uses salted
  sessions)

Fixes #681

## Test plan

- [x] All 7 AK integration tests pass against tpm2-tss 4.2.0 (RSA and ECC EKs)
- [x] Reproduced the failure without the fix against tpm2-tss 4.2.0
- [x] `cargo check` passes cleanly

*This PR was created with the help of AI (Claude Code by Anthropic).*